### PR TITLE
fix: amd platform donot register torch implement

### DIFF
--- a/mojo_opset/core/function.py
+++ b/mojo_opset/core/function.py
@@ -8,7 +8,7 @@ logger = get_logger(__name__)
 
 
 class MojoFunction(Function):
-    supported_platforms_list = ["npu", "mlu"]
+    supported_platforms_list = ["npu", "mlu", "meta_device"]
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)


### PR DESCRIPTION
Bug🐛: Amd platform raise this error.
```plaintext
>>> from mojo_opset import MojoTopPFilter
[WARNING] 03/03/2026 08:49:56 /code/mojo_opset/mojo_opset/utils/platform.py:34 >> No accelerator detected
[WARNING] 03/03/2026 08:49:56 /code/mojo_opset/mojo_opset/coree/backend_registry.py:74 >> Operator TorchSiluFunction is notsupported on meta_device platform.
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "/code/mojo_opset/mojo_opset/__init__.py", line 5, in <module>
from mojo_opset.core import *
File "<frozen importlib._bootstrap>", line 1027, in _find_and_lopad
File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
File "/usr/local/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
exec(co, module.__dict__)
File "/code/mojo_opset/mojo_opset/core/__init__.py", line 88,in <module>
from .functions.activation import MojoSiluFunction
File "<frozen importlib._bootstrap>", line 1027, in _find_and_Load
File "<frozen importlib._bootstrap>", line 1006, in _find_andi_load_unlocked
File "<frozen importlib._bootstrap>", line 688,in _load_unlocked
File "/usr/local/lib/python3.10/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
exec(co, module.__dict__)
File "/code/mojo_opset/mojo_opset/core/functions/activation.py", line 6, in <module>
class MojoSiluFunction(MojoFunction):
File "/code/mojo_opset/mojo_opset/core/function.py", line 24, in _init_subclass_
type (
File "/code/mojo_opset/mojo_opset/core/function.py", line 40, in __init_subclass_
core_op_cls.forward = cls._registry.get(target_backend).forward
File "/code/mojo_opset/mojo_opset/core/backend_registry.py", line 82, in get
assert len(self._registry) > 0, f"{self._operator_name} does not iimplement any backend.
AssertionError: SiluFunction does not implement any backend
assert 0 > 0
where 0 = len({})
where {} = <mojo_opset.core.backend_registry.MojoBackendRegistry object at 0x7f0cd438f0a0>._registry
```

fix: function base class support `meta_device`