### PR TITLE
feat: add MojoDebugger debug suite for LLM operator-level debugging

### DIFF
--- a/docs/debug_suite.md
+++ b/docs/debug_suite.md
@@ -196,6 +196,8 @@ model(input_ids_2)
 
 ### Dump 输出
 
+> **性能提示**：Dump 通过 `torch.save` 在 forward hook 中同步写入磁盘。对少量算子做偶尔 dump 是可接受的，但如果同时对大量算子启用 dump，同步 I/O 会显著阻塞执行流水线。建议配合 `max_steps` 限制写入次数，或一次只 dump 少量目标算子。
+
 Dump 将输入和输出张量保存为 `.pt` 文件，路径格式为 `{dump_dir}/rank{LOCAL_RANK}/`：
 
 ```

--- a/docs/debug_suite.md
+++ b/docs/debug_suite.md
@@ -1,0 +1,302 @@
+# MojoDebugger — mojo_opset 调试套件
+
+## 概述
+
+`MojoDebugger` 是一个轻量级、非侵入式的 LLM 模型调试工具，专为 `mojo_opset` 构建的模型设计。它提供两项核心能力：
+
+- **Dump** — 将指定层、指定算子的输入/输出张量保存到磁盘，供离线分析。
+- **Compare** — 将加速后端（如 TTX）的算子输出与 `torch` 参考实现进行逐元素对比，实时打印绝对误差、相对误差和余弦相似度。
+
+两项功能均支持**运行时动态切换规则**——无需重建模型，即可在不同 forward 之间更换要观测的算子。
+
+---
+
+## 设计方案
+
+### 整体架构
+
+```
+MojoDebugger.enable()          ← 补丁 MojoOperator.__new__，捕获构造参数
+        │
+   模型构建                      ← 每个 MojoOperator 自动记录 (core_cls, init_args)
+        │
+dbg = MojoDebugger()
+dbg.attach(model)              ← 遍历模型树，传播 layer_idx，
+        │                        在每个 MojoOperator 上注册 forward hook
+        │
+dbg.set_dump("2:input_layernorm")
+dbg.set_compare("*:mlp.act_fn")
+        │
+   model(input_ids)            ← 每个 MojoOperator.forward() 执行时：
+        │                        1. Hook 读取当前活跃规则（API / 环境变量）
+        │                        2. 匹配命中 → 执行 dump 和/或 compare
+        │                        3. Compare: 惰性构建 torch 影子实例 → 运行参考 forward → 输出差异
+        │
+dbg.detach()                   ← 移除 hook，释放影子实例
+```
+
+### 核心设计决策
+
+**1. Dual-Build 影子实例机制**
+
+调试模式会补丁 `MojoOperator.__new__`，在每个算子构造时记录其构造参数。当 compare 规则被触发时，系统**惰性创建**一个 torch 影子实例——使用相同的构造参数，但强制走 `torch` 后端。权重通过 `load_state_dict` 从主实例同步。这样可以安全地对比加速后端和 torch 参考的输出，避免因后端 `__init__` 中的权重变换（如转置、量化）导致的不一致。
+
+**内存优化**：如果后端类没有重写 `__init__`（仅重写 `forward`），则不创建影子实例，直接调用核心类的 `forward` 方法，节省显存。
+
+**2. 语义化 `layer_idx` 传播**
+
+调试器不通过解析 module path 字符串来识别层号，而是查找具有 `layer_idx` 属性的模块（如 `DecoderLayer.layer_idx`），并将其传播给所有子 `MojoOperator`。由此产生稳定、可读的标识符，如 `layer5.input_layernorm`。
+
+对于不在任何 DecoderLayer 内的算子（如全局 RMSNorm、LM Head），`layer_idx` 为 `None`，在规则中用 `none` 表示。
+
+**3. 动态规则引擎**
+
+规则来源有两个优先级：
+1. **Python API**（`set_compare`、`set_dump`）—— 优先级最高
+2. **环境变量**（`MOJO_DEBUG_COMPARE`、`MOJO_DEBUG_DUMP`）—— 作为兜底
+
+Hook 在每次 forward 时重新读取活跃规则，因此支持在迭代之间动态切换观测目标。环境变量的变更也会被即时感知（带缓存优化）。
+
+**4. 健壮性保障**
+
+- 所有调试逻辑的异常均被捕获并以 warning 输出——**永远不会中断推理**。
+- 不匹配任何算子的规则会产生警告，并列出可用目标。
+- Dump 文件按 `rank{LOCAL_RANK}/` 子目录组织，适配分布式训练。
+- 步数计数器（`max_steps`）限制每个算子的 dump/compare 次数，防止磁盘和日志爆炸。
+
+---
+
+## 规则格式
+
+规则格式为 `layer_idx:op_name`，多个规则用 `;` 分隔：
+
+| 规则示例 | 含义 |
+|---|---|
+| `5:input_layernorm` | 第 5 层的 `input_layernorm` |
+| `*:mlp.act_fn` | **所有层**的 `mlp.act_fn` |
+| `none:norm` | 全局算子 `norm`（不在任何 DecoderLayer 内） |
+| `*:MojoRMSNorm` | 所有 `MojoRMSNorm` 实例（按类名匹配） |
+| `0:input_layernorm;0:mlp.down_proj` | 第 0 层的两个算子 |
+
+`attach()` 后，调试器会打印所有已发现的算子及其层号归属，帮助你编写规则：
+
+```
+[MojoDebug] Attached. 58 MojoOperator instances discovered:
+  layer 0-4: input_layernorm (MojoRMSNorm), mlp.act_fn (MojoSwiGLU), ...
+  global: embed (MojoEmbedding), lm_head (MojoLinear), norm (MojoRMSNorm)
+[MojoDebug] Rule format: "layer_idx:op_name", e.g. "5:input_layernorm" or "*:self_attn.rope"
+```
+
+---
+
+## 使用方式
+
+### 方式一：Python API（推荐）
+
+```python
+from mojo_opset.utils.debugger import MojoDebugger
+
+# 第 1 步：在模型构建之前启用调试模式
+MojoDebugger.enable()
+
+# 第 2 步：正常构建和加载模型
+model = build_llama_model(config)
+model.load_state_dict(checkpoint)
+
+# 第 3 步：创建调试器并挂载到模型
+dbg = MojoDebugger(dump_dir="./debug_output", max_steps=5)
+dbg.attach(model)
+
+# 第 4 步：设置规则 — dump 第 0 层的 input_layernorm
+dbg.set_dump("0:input_layernorm")
+
+# 第 5 步：执行推理
+output = model(input_ids)
+
+# 第 6 步：切换到 compare 模式，观测下一次 forward
+dbg.set_compare("*:mlp.act_fn")
+output = model(input_ids)
+
+# 第 7 步：清理
+dbg.detach()
+```
+
+### 方式二：环境变量
+
+通过环境变量启用调试，无需修改模型构建代码：
+
+```bash
+# 启用调试模式（import mojo_opset 时自动补丁 MojoOperator.__new__）
+export MOJO_DEBUG=1
+
+# 设置 compare / dump 规则
+export MOJO_DEBUG_COMPARE="5:input_layernorm;5:mlp.act_fn"
+export MOJO_DEBUG_DUMP="0:self_attn.q_proj"
+
+# 可选：自定义 dump 目录和最大步数
+export MOJO_DEBUG_DUMP_DIR="./my_debug_dumps"
+export MOJO_DEBUG_MAX_STEPS=3
+
+python run_inference.py
+```
+
+> **注意**：`MOJO_DEBUG=1` 仅自动完成 `enable()` 步骤。你仍需在脚本中创建 `MojoDebugger` 实例并调用 `attach(model)`。
+
+```python
+# run_inference.py
+from mojo_opset.utils.debugger import MojoDebugger
+
+model = build_model(config)
+model.load_state_dict(checkpoint)
+
+dbg = MojoDebugger()
+dbg.attach(model)
+
+# 规则从环境变量 MOJO_DEBUG_COMPARE / MOJO_DEBUG_DUMP 读取
+output = model(input_ids)
+
+dbg.detach()
+```
+
+### 动态规则切换
+
+规则可以在 forward 之间随时更换——适用于逐层排查精度问题的场景：
+
+```python
+dbg.attach(model)
+
+# 第 1 次推理：对比第 0 层
+dbg.set_compare("0:input_layernorm")
+model(input_ids_1)
+
+# 第 2 次推理：切换到第 4 层
+dbg.set_compare("4:mlp.down_proj")
+model(input_ids_2)
+
+# 第 3 次推理：同时 dump 和 compare
+dbg.set_dump("2:post_attention_layernorm")
+dbg.set_compare("2:post_attention_layernorm")
+model(input_ids_3)
+
+# 清除所有规则（后续 forward 无调试开销）
+dbg.clear_rules()
+model(input_ids_4)
+```
+
+环境变量同样支持运行时切换：
+
+```python
+import os
+os.environ["MOJO_DEBUG_COMPARE"] = "0:self_attn.q_proj"
+model(input_ids_1)
+
+os.environ["MOJO_DEBUG_COMPARE"] = "0:self_attn.k_proj"
+model(input_ids_2)
+```
+
+### Dump 输出
+
+Dump 将输入和输出张量保存为 `.pt` 文件，路径格式为 `{dump_dir}/rank{LOCAL_RANK}/`：
+
+```
+./mojo_debug_dump/
+  rank0/
+    layer2.input_layernorm_step0_input.pt
+    layer2.input_layernorm_step0_output.pt
+    layer2.input_layernorm_step1_input.pt
+    layer2.input_layernorm_step1_output.pt
+```
+
+加载并分析：
+
+```python
+import torch
+output = torch.load("./mojo_debug_dump/rank0/layer2.input_layernorm_step0_output.pt")
+print(output.shape, output.dtype, output.mean(), output.std())
+```
+
+同时，每次 dump 还会在日志中打印张量统计信息：
+
+```
+[MojoDebug] layer2.input_layernorm step=0 | output shape=(2, 16, 128) dtype=torch.float32 mean=0.0123 std=0.9876 min=-2.345 max=3.456
+```
+
+### Compare 输出
+
+Compare 在日志中逐算子打印精度指标：
+
+```
+[MojoDebug] layer5.input_layernorm step=0 | max_abs_diff=1.526e-05 max_rel_diff=3.814e-04 cos_sim=0.999998
+[MojoDebug] layer5.mlp.act_fn step=0      | max_abs_diff=7.629e-06 max_rel_diff=1.907e-04 cos_sim=1.000000
+```
+
+| 指标 | 说明 |
+|---|---|
+| `max_abs_diff` | 后端输出与 torch 参考之间的最大绝对误差 |
+| `max_rel_diff` | 最大相对误差（分母 clamp 到 1e-12 以避免除零） |
+| `cos_sim` | 展平后的输出向量之间的余弦相似度 |
+
+> **注意**：Compare 仅报告数值差异，不做 pass/fail 判定。开发者可根据自身精度要求自行判断。
+
+---
+
+## API 参考
+
+### 类方法
+
+| 方法 | 说明 |
+|---|---|
+| `MojoDebugger.enable()` | 补丁 `MojoOperator.__new__`，捕获构造参数。**必须在模型构建之前调用。** |
+| `MojoDebugger.disable()` | 恢复原始 `MojoOperator.__new__`。 |
+
+### 实例方法
+
+| 方法 | 说明 |
+|---|---|
+| `__init__(dump_dir=None, max_steps=None)` | 创建调试器。`dump_dir` 依次取：参数 → `MOJO_DEBUG_DUMP_DIR` → `./mojo_debug_dump`。 |
+| `attach(model)` | 遍历模型，传播 `layer_idx`，在所有 `MojoOperator` 上注册 hook。 |
+| `detach()` | 移除 hook，释放影子实例，清理调试属性。 |
+| `set_compare(rules)` | 设置 compare 规则，如 `"5:input_layernorm;*:mlp.act_fn"`。传入空字符串清除。 |
+| `set_dump(rules)` | 设置 dump 规则。传入空字符串清除。 |
+| `clear_rules()` | 清除所有通过 API 设置的规则。 |
+| `set_dump_dir(path)` | 运行时更改 dump 目录。 |
+| `set_max_steps(n)` | 设置每个算子的最大 dump/compare 步数。 |
+| `reset_step_counters()` | 重置所有步数计数器（配合 `max_steps` 实现"再 dump 一轮"）。 |
+
+### 环境变量
+
+| 变量 | 说明 | 默认值 |
+|---|---|---|
+| `MOJO_DEBUG` | 设为 `1` 时，`import mojo_opset` 自动调用 `enable()` | — |
+| `MOJO_DEBUG_COMPARE` | Compare 规则字符串（格式同 `set_compare`） | — |
+| `MOJO_DEBUG_DUMP` | Dump 规则字符串（格式同 `set_dump`） | — |
+| `MOJO_DEBUG_DUMP_DIR` | Dump 输出目录 | `./mojo_debug_dump` |
+| `MOJO_DEBUG_MAX_STEPS` | 每个算子的最大 dump/compare 步数 | 无限制 |
+
+---
+
+## 常见问题
+
+**Q：忘记在模型构建前调用 `enable()` 会怎样？**
+
+对于后端没有重写 `__init__` 的算子（大多数情况），compare 仍可正常工作。对于后端有自定义 `__init__` 的算子，会打印 warning 并退化为直接调用核心类 `forward`，如果后端在 `__init__` 中对权重做了变换，则对比结果可能不准确。
+
+**Q：调试器会影响推理输出吗？**
+
+不会。Hook 仅读取输入/输出。Compare 在传入参考 forward 前会深拷贝输入。原始计算不受任何影响。
+
+**Q：分布式训练如何使用？**
+
+Dump 文件按 `rank{LOCAL_RANK}/` 子目录保存。日志使用 rank-0-only 打印，避免重复输出。
+
+**Q：能否对同一个算子同时 dump 和 compare？**
+
+可以。两种规则在每次 forward 中独立检查和执行。
+
+**Q：规则没有匹配到任何算子怎么办？**
+
+会打印 warning，提示检查 `attach()` 输出中列出的可用目标。推理正常继续，不受影响。
+
+**Q：`max_steps` 到达上限后还想再 dump 怎么办？**
+
+调用 `dbg.reset_step_counters()` 重置计数器，后续 forward 会重新从 step 0 开始。

--- a/docs/debug_suite.md
+++ b/docs/debug_suite.md
@@ -240,6 +240,33 @@ Compare 在日志中逐算子打印精度指标：
 
 > **注意**：Compare 仅报告数值差异，不做 pass/fail 判定。开发者可根据自身精度要求自行判断。
 
+### Compare 模式：observe vs replace
+
+Compare 支持两种模式，通过 `compare_mode` 参数或 `MOJO_DEBUG_COMPARE_MODE` 环境变量指定：
+
+| 模式 | 行为 | 适用场景 |
+|---|---|---|
+| `observe`（默认） | 对比后不修改输出，加速后端结果原样传给下游 | 观察每个算子的累积误差 |
+| `replace` | 对比后将加速后端输出**替换**为 torch 参考输出 | 逐层隔离误差，定位误差来源 |
+
+**observe 模式**下，如果 Layer 0 引入了误差 `e0`，Layer 1 的 compare 看到的输入已经包含 `e0`，其报告的是累积误差。
+
+**replace 模式**下，每个 compare 命中的算子的输出都被 torch 参考结果替换，后续算子的输入是"干净"的。每个算子的 compare 报告仅反映该算子自身引入的误差。
+
+```python
+# 逐层误差隔离
+dbg = MojoDebugger(compare_mode="replace")
+dbg.attach(model)
+dbg.set_compare("*:input_layernorm;*:mlp.act_fn")
+model(input_ids)  # 每个算子的 diff 仅反映自身误差
+
+# 运行时切换
+dbg.set_compare_mode("observe")   # 切回观察模式
+model(input_ids)
+```
+
+> **提示**：建议先用 `observe` 模式粗略定位误差较大的层，再用 `replace` 模式逐层隔离，确认误差的具体来源。
+
 ---
 
 ## API 参考
@@ -255,11 +282,12 @@ Compare 在日志中逐算子打印精度指标：
 
 | 方法 | 说明 |
 |---|---|
-| `__init__(dump_dir=None, max_steps=None)` | 创建调试器。`dump_dir` 依次取：参数 → `MOJO_DEBUG_DUMP_DIR` → `./mojo_debug_dump`。 |
+| `__init__(dump_dir=None, max_steps=None, compare_mode=None)` | 创建调试器。`dump_dir` 依次取：参数 → `MOJO_DEBUG_DUMP_DIR` → `./mojo_debug_dump`。`compare_mode` 默认 `"observe"`。 |
 | `attach(model)` | 遍历模型，传播 `layer_idx`，在所有 `MojoOperator` 上注册 hook。 |
 | `detach()` | 移除 hook，释放影子实例，清理调试属性。 |
 | `set_compare(rules)` | 设置 compare 规则，如 `"5:input_layernorm;*:mlp.act_fn"`。传入空字符串清除。 |
 | `set_dump(rules)` | 设置 dump 规则。传入空字符串清除。 |
+| `set_compare_mode(mode)` | 切换 compare 模式：`"observe"` 或 `"replace"`。 |
 | `clear_rules()` | 清除所有通过 API 设置的规则。 |
 | `set_dump_dir(path)` | 运行时更改 dump 目录。 |
 | `set_max_steps(n)` | 设置每个算子的最大 dump/compare 步数。 |
@@ -274,6 +302,7 @@ Compare 在日志中逐算子打印精度指标：
 | `MOJO_DEBUG_DUMP` | Dump 规则字符串（格式同 `set_dump`） | — |
 | `MOJO_DEBUG_DUMP_DIR` | Dump 输出目录 | `./mojo_debug_dump` |
 | `MOJO_DEBUG_MAX_STEPS` | 每个算子的最大 dump/compare 步数 | 无限制 |
+| `MOJO_DEBUG_COMPARE_MODE` | Compare 模式：`observe` 或 `replace` | `observe` |
 
 ---
 
@@ -285,7 +314,7 @@ Compare 在日志中逐算子打印精度指标：
 
 **Q：调试器会影响推理输出吗？**
 
-不会。Hook 仅读取输入/输出。Compare 在传入参考 forward 前会深拷贝输入。原始计算不受任何影响。
+在默认的 `observe` 模式下不会。Hook 仅读取输入/输出，Compare 在传入参考 forward 前会深拷贝输入，原始计算不受任何影响。在 `replace` 模式下，compare 命中的算子的输出会被 torch 参考结果替换——这是有意为之的行为，用于逐层隔离误差。
 
 **Q：分布式训练如何使用？**
 

--- a/mojo_opset/__init__.py
+++ b/mojo_opset/__init__.py
@@ -1,3 +1,10 @@
+import os
+
+if os.environ.get("MOJO_DEBUG") == "1":
+    from mojo_opset.utils.debugger import MojoDebugger
+
+    MojoDebugger.enable()
+
 from mojo_opset.utils.patching import rewrite_assertion
 
 with rewrite_assertion(__name__):

--- a/mojo_opset/utils/debugger.py
+++ b/mojo_opset/utils/debugger.py
@@ -44,6 +44,8 @@ def _deep_clone(value):
         return value.detach().clone()
     if isinstance(value, (tuple, list)):
         cloned = [_deep_clone(v) for v in value]
+        if hasattr(type(value), "_fields"):  # namedtuple
+            return type(value)(*cloned)
         return type(value)(cloned)
     if isinstance(value, dict):
         return {k: _deep_clone(v) for k, v in value.items()}
@@ -55,7 +57,10 @@ def _to_cpu(value):
     if isinstance(value, torch.Tensor):
         return value.detach().cpu()
     if isinstance(value, (tuple, list)):
-        return type(value)(_to_cpu(v) for v in value)
+        converted = [_to_cpu(v) for v in value]
+        if hasattr(type(value), "_fields"):  # namedtuple
+            return type(value)(*converted)
+        return type(value)(converted)
     if isinstance(value, dict):
         return {k: _to_cpu(v) for k, v in value.items()}
     return value

--- a/mojo_opset/utils/debugger.py
+++ b/mojo_opset/utils/debugger.py
@@ -1,0 +1,722 @@
+import functools
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+from mojo_opset.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_PREFIX = "[MojoDebug]"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Rule:
+    layer_idx: str  # int-string, "*", or "none"
+    op_name: str
+    raw: str
+
+
+# ---------------------------------------------------------------------------
+# Utility helpers
+# ---------------------------------------------------------------------------
+
+
+def _restore_env(key: str, old_value: Optional[str]):
+    if old_value is None:
+        os.environ.pop(key, None)
+    else:
+        os.environ[key] = old_value
+
+
+def _deep_clone(value):
+    """Recursively clone tensors; pass through non-tensors unchanged."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().clone()
+    if isinstance(value, (tuple, list)):
+        cloned = [_deep_clone(v) for v in value]
+        return type(value)(cloned)
+    if isinstance(value, dict):
+        return {k: _deep_clone(v) for k, v in value.items()}
+    return value
+
+
+def _to_cpu(value):
+    """Recursively move tensors to CPU for serialisation."""
+    if isinstance(value, torch.Tensor):
+        return value.detach().cpu()
+    if isinstance(value, (tuple, list)):
+        return type(value)(_to_cpu(v) for v in value)
+    if isinstance(value, dict):
+        return {k: _to_cpu(v) for k, v in value.items()}
+    return value
+
+
+def _infer_core_cls_from_mro(module):
+    """Walk MRO to find the class whose direct parent is MojoOperator."""
+    from mojo_opset.core.operator import MojoOperator
+
+    for cls in type(module).__mro__:
+        if MojoOperator in cls.__bases__:
+            return cls
+    return None
+
+
+def _parse_rules(rule_str: str) -> List[_Rule]:
+    """Parse ``'layer_idx:op_name;...'`` into a list of :class:`_Rule`.
+
+    Invalid segments are skipped with a warning.
+    """
+    if not rule_str or not rule_str.strip():
+        return []
+
+    rules: List[_Rule] = []
+    for segment in rule_str.split(";"):
+        segment = segment.strip()
+        if not segment:
+            continue
+        parts = segment.split(":", 1)
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            logger.warning(
+                f"{_PREFIX} Ignoring malformed rule: '{segment}'. "
+                f"Expected format 'layer_idx:op_name'."
+            )
+            continue
+        rules.append(
+            _Rule(
+                layer_idx=parts[0].strip(),
+                op_name=parts[1].strip(),
+                raw=segment,
+            )
+        )
+    return rules
+
+
+def _match_single(
+    layer_idx: Optional[int],
+    op_name: str,
+    module,
+    rule: _Rule,
+) -> bool:
+    # --- layer_idx ---
+    if rule.layer_idx == "*":
+        pass
+    elif rule.layer_idx == "none":
+        if layer_idx is not None:
+            return False
+    else:
+        try:
+            if layer_idx != int(rule.layer_idx):
+                return False
+        except (ValueError, TypeError):
+            return False
+
+    # --- op_name ---
+    if rule.op_name.startswith("Mojo"):
+        core_cls = getattr(module, "_debug_core_cls", None) or _infer_core_cls_from_mro(module)
+        if core_cls is None or core_cls.__name__ != rule.op_name:
+            return False
+    else:
+        if op_name != rule.op_name and not op_name.endswith("." + rule.op_name):
+            return False
+
+    return True
+
+
+def _match(
+    layer_idx: Optional[int],
+    op_name: str,
+    module,
+    rules: List[_Rule],
+) -> Optional[_Rule]:
+    for rule in rules:
+        if _match_single(layer_idx, op_name, module, rule):
+            return rule
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MojoDebugger
+# ---------------------------------------------------------------------------
+
+
+class MojoDebugger:
+    """Lightweight debug controller for mojo_opset operators.
+
+    Typical usage::
+
+        MojoDebugger.enable()            # before model construction
+        model = build_model(config)
+        model.load_state_dict(ckpt)
+
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("5:input_layernorm")
+        output = model(input_ids)
+        dbg.detach()
+    """
+
+    _enabled: bool = False
+    _original_new = None
+
+    # ------------------------------------------------------------------
+    # Class-level: enable / disable
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def enable(cls):
+        """Patch ``MojoOperator.__new__`` to capture construction args.
+
+        Must be called **before** model construction.  Idempotent.
+        """
+        if cls._enabled:
+            return
+
+        from mojo_opset.core.operator import MojoOperator
+
+        original_new = MojoOperator.__new__
+
+        @functools.wraps(original_new)
+        def _debug_new(klass, *args, **kwargs):
+            instance = original_new(klass, *args, **kwargs)
+            if MojoOperator in klass.__bases__:
+                instance._debug_core_cls = klass
+                instance._debug_init_args = (args, kwargs)
+            return instance
+
+        MojoOperator.__new__ = _debug_new
+        cls._original_new = original_new
+        cls._enabled = True
+        logger.info_rank0(f"{_PREFIX} Debug mode enabled. MojoOperator.__new__ patched.")
+
+    @classmethod
+    def disable(cls):
+        """Restore original ``MojoOperator.__new__``."""
+        if not cls._enabled:
+            return
+        from mojo_opset.core.operator import MojoOperator
+
+        if cls._original_new is not None:
+            MojoOperator.__new__ = cls._original_new
+        cls._enabled = False
+        cls._original_new = None
+
+    # ------------------------------------------------------------------
+    # Instance-level
+    # ------------------------------------------------------------------
+
+    def __init__(
+        self,
+        dump_dir: Optional[str] = None,
+        max_steps: Optional[int] = None,
+    ):
+        self._dump_dir = (
+            dump_dir
+            or os.environ.get("MOJO_DEBUG_DUMP_DIR")
+            or "./mojo_debug_dump"
+        )
+
+        self._max_steps = max_steps
+        if self._max_steps is None:
+            env_max = os.environ.get("MOJO_DEBUG_MAX_STEPS")
+            if env_max is not None:
+                try:
+                    self._max_steps = int(env_max)
+                except ValueError:
+                    logger.warning(f"{_PREFIX} Invalid MOJO_DEBUG_MAX_STEPS='{env_max}', ignored.")
+
+        self._model: Optional[torch.nn.Module] = None
+        self._hook_handles: List = []
+        self._attached = False
+
+        # Rule caches (env-var driven)
+        self._env_cache: Dict[str, str] = {}
+        self._parsed_cache: Dict[str, List[_Rule]] = {}
+
+        # API-set rules take precedence over env vars
+        self._api_rules: Dict[str, Optional[List[_Rule]]] = {
+            "compare": None,
+            "dump": None,
+        }
+
+        self._step_counters: Dict[Tuple, int] = defaultdict(int)
+
+        # (layer_idx, op_name) -> module  — built during attach
+        self._op_map: Dict[Tuple[Optional[int], str], Any] = {}
+
+    # ------------------------------------------------------------------
+    # attach / detach
+    # ------------------------------------------------------------------
+
+    def attach(self, model: torch.nn.Module):
+        """Register debug hooks on all ``MojoOperator`` modules."""
+        from mojo_opset.core.operator import MojoOperator
+
+        if self._attached:
+            self.detach()
+            logger.warning(f"{_PREFIX} Previous debug session detached before re-attach.")
+
+        self._model = model
+        self._hook_handles = []
+        self._step_counters.clear()
+        self._op_map.clear()
+
+        if not self._enabled:
+            logger.warning(
+                f"{_PREFIX} MojoDebugger.enable() was not called before model construction. "
+                f"Compare may be limited for ops whose backend overrides __init__."
+            )
+
+        self._propagate_layer_info(model)
+
+        for name, module in model.named_modules():
+            if isinstance(module, MojoOperator):
+                handle = module.register_forward_hook(self._make_hook())
+                self._hook_handles.append(handle)
+                layer_idx = getattr(module, "_debug_layer_idx", None)
+                op_name = getattr(module, "_debug_op_name", name)
+                self._op_map[(layer_idx, op_name)] = module
+
+        self._attached = True
+        self._print_op_map()
+
+    def detach(self):
+        """Remove hooks, release shadows, clean up debug attributes."""
+        from mojo_opset.core.operator import MojoOperator
+
+        for handle in self._hook_handles:
+            handle.remove()
+        self._hook_handles.clear()
+
+        if self._model is not None:
+            for _, module in self._model.named_modules():
+                if isinstance(module, MojoOperator):
+                    for attr in (
+                        "_debug_layer_idx",
+                        "_debug_op_name",
+                        "_debug_torch_ref",
+                        "_debug_ref_forward",
+                        "_debug_torch_ref_ready",
+                    ):
+                        try:
+                            delattr(module, attr)
+                        except AttributeError:
+                            pass
+
+        self._model = None
+        self._attached = False
+        self._op_map.clear()
+        self._step_counters.clear()
+        self._env_cache.clear()
+        self._parsed_cache.clear()
+        self._api_rules = {"compare": None, "dump": None}
+
+    # ------------------------------------------------------------------
+    # Dynamic rule setters
+    # ------------------------------------------------------------------
+
+    def set_compare(self, rules: str):
+        """Set compare rules dynamically.  ``""`` clears."""
+        parsed = _parse_rules(rules)
+        self._api_rules["compare"] = parsed
+        if self._attached and parsed:
+            self._validate_rules(parsed, "compare")
+
+    def set_dump(self, rules: str):
+        """Set dump rules dynamically.  ``""`` clears."""
+        parsed = _parse_rules(rules)
+        self._api_rules["dump"] = parsed
+        if self._attached and parsed:
+            self._validate_rules(parsed, "dump")
+
+    def clear_rules(self):
+        self._api_rules = {"compare": None, "dump": None}
+
+    def set_dump_dir(self, path: str):
+        self._dump_dir = path
+
+    def set_max_steps(self, n: int):
+        self._max_steps = n
+
+    def reset_step_counters(self):
+        self._step_counters.clear()
+
+    # ------------------------------------------------------------------
+    # Layer-info propagation
+    # ------------------------------------------------------------------
+
+    def _propagate_layer_info(self, model: torch.nn.Module):
+        from mojo_opset.core.operator import MojoOperator
+
+        found_any_layer_idx = False
+
+        def _walk(module, layer_idx=None, layer_path="", current_path=""):
+            nonlocal found_any_layer_idx
+            if hasattr(module, "layer_idx"):
+                layer_idx = module.layer_idx
+                layer_path = current_path
+                found_any_layer_idx = True
+
+            if isinstance(module, MojoOperator):
+                module._debug_layer_idx = layer_idx
+                if layer_path and current_path.startswith(layer_path + "."):
+                    module._debug_op_name = current_path[len(layer_path) + 1 :]
+                else:
+                    module._debug_op_name = (
+                        current_path.split(".")[-1] if current_path else ""
+                    )
+
+            for name, child in module.named_children():
+                child_path = f"{current_path}.{name}" if current_path else name
+                _walk(child, layer_idx, layer_path, child_path)
+
+        _walk(model)
+
+        if not found_any_layer_idx:
+            logger.warning(
+                f"{_PREFIX} No module with 'layer_idx' attribute found. "
+                f"All ops have _debug_layer_idx=None. Use 'none:op_name' rules."
+            )
+
+    # ------------------------------------------------------------------
+    # Op-map printing
+    # ------------------------------------------------------------------
+
+    def _print_op_map(self):
+        if not self._op_map:
+            return
+
+        layer_ops: Dict[Optional[int], Dict[str, str]] = defaultdict(dict)
+        for (layer_idx, op_name), module in self._op_map.items():
+            core_cls = getattr(module, "_debug_core_cls", None) or _infer_core_cls_from_mro(module)
+            cls_name = core_cls.__name__ if core_cls else type(module).__name__
+            layer_ops[layer_idx][op_name] = cls_name
+
+        lines = [f"{_PREFIX} Attached. {len(self._op_map)} MojoOperator instances discovered:"]
+
+        layer_indices = sorted(k for k in layer_ops if k is not None)
+        if layer_indices:
+            # Group contiguous layers with identical op-name sets
+            groups: List[Tuple[int, int, Dict[str, str]]] = []
+            grp_start = layer_indices[0]
+            grp_ops = layer_ops[layer_indices[0]]
+            for idx in layer_indices[1:]:
+                if layer_ops[idx] == grp_ops:
+                    continue
+                groups.append((grp_start, idx - 1, grp_ops))
+                grp_start = idx
+                grp_ops = layer_ops[idx]
+            groups.append((grp_start, layer_indices[-1], grp_ops))
+
+            for start, end, ops in groups:
+                rng = str(start) if start == end else f"{start}-{end}"
+                op_strs = [f"{n} ({c})" for n, c in sorted(ops.items())]
+                lines.append(f"  layer {rng}: {', '.join(op_strs)}")
+
+        if None in layer_ops:
+            op_strs = [f"{n} ({c})" for n, c in sorted(layer_ops[None].items())]
+            lines.append(f"  global: {', '.join(op_strs)}")
+
+        lines.append(
+            f'{_PREFIX} Rule format: "layer_idx:op_name", '
+            f'e.g. "5:input_layernorm" or "*:self_attn.rope"'
+        )
+        logger.info_rank0("\n".join(lines))
+
+    # ------------------------------------------------------------------
+    # Rule engine
+    # ------------------------------------------------------------------
+
+    def _get_active_rules(self, rule_type: str) -> List[_Rule]:
+        api = self._api_rules.get(rule_type)
+        if api is not None:
+            return api
+
+        env_key = f"MOJO_DEBUG_{rule_type.upper()}"
+        current_val = os.environ.get(env_key, "")
+        cached_val = self._env_cache.get(env_key)
+
+        if current_val != cached_val:
+            self._env_cache[env_key] = current_val
+            parsed = _parse_rules(current_val)
+            self._parsed_cache[env_key] = parsed
+            if parsed and self._attached:
+                self._validate_rules(parsed, rule_type)
+
+        return self._parsed_cache.get(env_key, [])
+
+    def _validate_rules(self, rules: List[_Rule], rule_type: str):
+        for rule in rules:
+            matched_any = False
+            for (layer_idx, op_name), module in self._op_map.items():
+                if _match_single(layer_idx, op_name, module, rule):
+                    matched_any = True
+                    break
+            if not matched_any:
+                logger.warning(
+                    f"{_PREFIX} {rule_type} rule '{rule.raw}' did not match any "
+                    f"MojoOperator. Check attach() output for available targets."
+                )
+
+    # ------------------------------------------------------------------
+    # Hook factory
+    # ------------------------------------------------------------------
+
+    def _make_hook(self):
+        debugger = self
+
+        def hook(module, inputs, output):
+            try:
+                compare_rules = debugger._get_active_rules("compare")
+                dump_rules = debugger._get_active_rules("dump")
+
+                if not compare_rules and not dump_rules:
+                    return
+
+                layer_idx = getattr(module, "_debug_layer_idx", None)
+                op_name = getattr(module, "_debug_op_name", "")
+
+                matched_dump = _match(layer_idx, op_name, module, dump_rules)
+                matched_compare = _match(layer_idx, op_name, module, compare_rules)
+
+                if matched_dump is None and matched_compare is None:
+                    return
+
+                if matched_dump is not None:
+                    debugger._do_dump(layer_idx, op_name, module, inputs, output)
+
+                if matched_compare is not None:
+                    debugger._do_compare(layer_idx, op_name, module, inputs, output)
+
+            except Exception as e:
+                logger.warning_once(
+                    f"{_PREFIX} Unexpected error in hook for '{op_name}': {e}. "
+                    f"Debug skipped, inference unaffected."
+                )
+
+        return hook
+
+    # ------------------------------------------------------------------
+    # Tag helper
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_tag(layer_idx: Optional[int], op_name: str) -> str:
+        if layer_idx is not None:
+            return f"layer{layer_idx}.{op_name}"
+        return f"global.{op_name}"
+
+    # ------------------------------------------------------------------
+    # Dump
+    # ------------------------------------------------------------------
+
+    def _do_dump(self, layer_idx, op_name, module, inputs, output):
+        counter_key = ("dump", layer_idx, op_name)
+        step = self._step_counters[counter_key]
+        if self._max_steps is not None and step >= self._max_steps:
+            return
+        self._step_counters[counter_key] = step + 1
+
+        tag = self._make_tag(layer_idx, op_name)
+        self._log_tensor_stats(tag, step, output, "output")
+
+        dump_dir = self._get_dump_dir()
+        if dump_dir is not None:
+            try:
+                out_path = os.path.join(dump_dir, f"{tag}_step{step}_output.pt")
+                torch.save(_to_cpu(output), out_path)
+                in_path = os.path.join(dump_dir, f"{tag}_step{step}_input.pt")
+                torch.save(_to_cpu(inputs), in_path)
+                logger.info_rank0(f"{_PREFIX} {tag} step={step} | saved to {dump_dir}")
+            except (OSError, IOError) as e:
+                logger.warning_once(f"{_PREFIX} Failed to save dump for {tag}: {e}")
+
+    def _get_dump_dir(self) -> Optional[str]:
+        rank = int(os.environ.get("LOCAL_RANK", "0"))
+        dump_dir = os.path.join(self._dump_dir, f"rank{rank}")
+        try:
+            os.makedirs(dump_dir, exist_ok=True)
+            return dump_dir
+        except OSError as e:
+            logger.warning_once(f"{_PREFIX} Cannot create dump directory '{dump_dir}': {e}")
+            return None
+
+    def _log_tensor_stats(self, tag: str, step: int, value, prefix: str = "output"):
+        if isinstance(value, torch.Tensor):
+            t = value.detach().float()
+            nan_flag = " HAS_NAN" if torch.isnan(t).any() else ""
+            inf_flag = " HAS_INF" if torch.isinf(t).any() else ""
+            logger.info_rank0(
+                f"{_PREFIX} {tag} step={step} | {prefix} "
+                f"shape={tuple(value.shape)} dtype={value.dtype} "
+                f"mean={t.mean().item():.4g} std={t.std().item():.4g} "
+                f"min={t.min().item():.4g} max={t.max().item():.4g}"
+                f"{nan_flag}{inf_flag}"
+            )
+        elif isinstance(value, (tuple, list)):
+            for i, v in enumerate(value):
+                self._log_tensor_stats(tag, step, v, prefix=f"{prefix}[{i}]")
+        else:
+            logger.debug_rank0(
+                f"{_PREFIX} {tag} step={step} | {prefix} "
+                f"type={type(value).__name__} (non-tensor, skipped)"
+            )
+
+    # ------------------------------------------------------------------
+    # Compare
+    # ------------------------------------------------------------------
+
+    def _do_compare(self, layer_idx, op_name, module, inputs, output):
+        counter_key = ("cmp", layer_idx, op_name)
+        step = self._step_counters[counter_key]
+        if self._max_steps is not None and step >= self._max_steps:
+            return
+        self._step_counters[counter_key] = step + 1
+
+        tag = self._make_tag(layer_idx, op_name)
+
+        try:
+            self._ensure_torch_ref(module)
+        except Exception as e:
+            logger.warning_once(
+                f"{_PREFIX} Cannot build torch ref for {tag}: {e}. Compare skipped."
+            )
+            return
+
+        ref_inputs = _deep_clone(inputs)
+
+        try:
+            with torch.no_grad():
+                if module._debug_torch_ref is not None:
+                    ref_output = module._debug_torch_ref(*ref_inputs)
+                else:
+                    ref_output = module._debug_ref_forward(module, *ref_inputs)
+        except Exception as e:
+            logger.warning_once(
+                f"{_PREFIX} Torch ref forward failed for {tag}: {e}. Compare skipped."
+            )
+            return
+
+        self._compare_and_report(tag, step, output, ref_output)
+
+    def _compare_and_report(
+        self,
+        tag: str,
+        step: int,
+        output,
+        ref_output,
+        prefix: str = "",
+    ):
+        if isinstance(output, torch.Tensor) and isinstance(ref_output, torch.Tensor):
+            if output.shape != ref_output.shape:
+                logger.warning_rank0(
+                    f"{_PREFIX} {tag} step={step} | {prefix}SHAPE_MISMATCH "
+                    f"got {tuple(output.shape)} vs ref {tuple(ref_output.shape)}"
+                )
+                return
+
+            out_f = output.detach().float()
+            ref_f = ref_output.detach().float()
+            abs_diff = (out_f - ref_f).abs()
+            max_abs_diff = abs_diff.max().item()
+            max_rel_diff = (abs_diff / ref_f.abs().clamp(min=1e-12)).max().item()
+            cos_sim = F.cosine_similarity(
+                out_f.flatten().unsqueeze(0),
+                ref_f.flatten().unsqueeze(0),
+            ).item()
+
+            logger.info_rank0(
+                f"{_PREFIX} {tag} step={step} | {prefix}"
+                f"max_abs_diff={max_abs_diff:.4g} "
+                f"max_rel_diff={max_rel_diff:.4g} "
+                f"cos_sim={cos_sim:.6f}"
+            )
+
+        elif isinstance(output, (tuple, list)) and isinstance(ref_output, (tuple, list)):
+            if len(output) != len(ref_output):
+                logger.warning_rank0(
+                    f"{_PREFIX} {tag} step={step} | {prefix}LENGTH_MISMATCH "
+                    f"got {len(output)} vs ref {len(ref_output)}"
+                )
+                return
+            for i, (o, r) in enumerate(zip(output, ref_output)):
+                self._compare_and_report(tag, step, o, r, prefix=f"[{i}] ")
+
+        else:
+            logger.debug_rank0(
+                f"{_PREFIX} {tag} step={step} | {prefix}non-tensor output, skipped"
+            )
+
+    # ------------------------------------------------------------------
+    # Lazy shadow construction
+    # ------------------------------------------------------------------
+
+    def _ensure_torch_ref(self, module):
+        if getattr(module, "_debug_torch_ref_ready", False):
+            return
+
+        from mojo_opset.core.operator import MojoOperator  # noqa: F811
+
+        core_cls = getattr(module, "_debug_core_cls", None)
+        backend_cls = type(module)
+
+        if core_cls is None:
+            core_cls = _infer_core_cls_from_mro(module)
+            if core_cls is None:
+                raise RuntimeError(
+                    f"Cannot determine core op class for {backend_cls.__name__}."
+                )
+
+        if "__init__" not in backend_cls.__dict__:
+            # Backend shares __init__ with core — weights are in standard format.
+            module._debug_torch_ref = None
+            module._debug_ref_forward = core_cls.forward
+        else:
+            init_args = getattr(module, "_debug_init_args", None)
+            if init_args is None:
+                logger.warning_once(
+                    f"{_PREFIX} No init args recorded for {backend_cls.__name__}. "
+                    f"Falling back to direct core forward "
+                    f"(may be inaccurate if backend transforms weights)."
+                )
+                module._debug_torch_ref = None
+                module._debug_ref_forward = core_cls.forward
+            else:
+                args, kwargs = init_args
+                old_backend = os.environ.get("MOJO_BACKEND")
+                os.environ["MOJO_BACKEND"] = "torch"
+                try:
+                    shadow = core_cls(*args, **kwargs)
+                finally:
+                    _restore_env("MOJO_BACKEND", old_backend)
+
+                result = shadow.load_state_dict(module.state_dict(), strict=False)
+                if result.missing_keys:
+                    logger.warning(
+                        f"{_PREFIX} Shadow missing keys: {result.missing_keys}"
+                    )
+                if result.unexpected_keys:
+                    logger.warning(
+                        f"{_PREFIX} Shadow unexpected keys: {result.unexpected_keys}"
+                    )
+
+                try:
+                    device = next(module.parameters()).device
+                except StopIteration:
+                    device = torch.device("cpu")
+                shadow = shadow.to(device)
+                shadow.eval()
+
+                object.__setattr__(module, "_debug_torch_ref", shadow)
+                module._debug_ref_forward = None
+
+        module._debug_torch_ref_ready = True

--- a/mojo_opset/utils/debugger.py
+++ b/mojo_opset/utils/debugger.py
@@ -236,10 +236,13 @@ class MojoDebugger:
     # Instance-level
     # ------------------------------------------------------------------
 
+    _VALID_COMPARE_MODES = ("observe", "replace")
+
     def __init__(
         self,
         dump_dir: Optional[str] = None,
         max_steps: Optional[int] = None,
+        compare_mode: Optional[str] = None,
     ):
         self._dump_dir = (
             dump_dir
@@ -255,6 +258,15 @@ class MojoDebugger:
                     self._max_steps = int(env_max)
                 except ValueError:
                     logger.warning(f"{_PREFIX} Invalid MOJO_DEBUG_MAX_STEPS='{env_max}', ignored.")
+
+        if compare_mode is None:
+            compare_mode = os.environ.get("MOJO_DEBUG_COMPARE_MODE", "observe")
+        if compare_mode not in self._VALID_COMPARE_MODES:
+            logger.warning(
+                f"{_PREFIX} Invalid compare_mode='{compare_mode}', falling back to 'observe'."
+            )
+            compare_mode = "observe"
+        self._compare_mode = compare_mode
 
         self._model: Optional[torch.nn.Module] = None
         self._hook_handles: List = []
@@ -361,6 +373,14 @@ class MojoDebugger:
         self._api_rules["dump"] = parsed
         if self._attached and parsed:
             self._validate_rules(parsed, "dump")
+
+    def set_compare_mode(self, mode: str):
+        """Switch compare mode at runtime.  ``"observe"`` or ``"replace"``."""
+        if mode not in self._VALID_COMPARE_MODES:
+            raise ValueError(
+                f"Unknown compare_mode '{mode}'. Must be one of {self._VALID_COMPARE_MODES}."
+            )
+        self._compare_mode = mode
 
     def clear_rules(self):
         self._api_rules = {"compare": None, "dump": None}
@@ -546,7 +566,11 @@ class MojoDebugger:
                     debugger._do_dump(layer_idx, op_name, module, safe_inputs, output)
 
                 if matched_compare is not None:
-                    debugger._do_compare(layer_idx, op_name, module, safe_inputs, output)
+                    ref_output = debugger._do_compare(
+                        layer_idx, op_name, module, safe_inputs, output,
+                    )
+                    if debugger._compare_mode == "replace" and ref_output is not None:
+                        return ref_output
 
             except Exception as e:
                 logger.warning_once(
@@ -629,10 +653,16 @@ class MojoDebugger:
     # ------------------------------------------------------------------
 
     def _do_compare(self, layer_idx, op_name, module, inputs, output):
+        """Run torch reference forward and report diff.
+
+        Returns the reference output so the caller can decide whether to
+        replace the accelerator output (``replace`` mode).  Returns ``None``
+        on any failure or when the step limit has been reached.
+        """
         counter_key = ("cmp", layer_idx, op_name)
         step = self._step_counters[counter_key]
         if self._max_steps is not None and step >= self._max_steps:
-            return
+            return None
         self._step_counters[counter_key] = step + 1
 
         tag = self._make_tag(layer_idx, op_name)
@@ -643,7 +673,7 @@ class MojoDebugger:
             logger.warning_once(
                 f"{_PREFIX} Cannot build torch ref for {tag}: {e}. Compare skipped."
             )
-            return
+            return None
 
         ref_inputs = _deep_clone(inputs)
 
@@ -657,9 +687,10 @@ class MojoDebugger:
             logger.warning_once(
                 f"{_PREFIX} Torch ref forward failed for {tag}: {e}. Compare skipped."
             )
-            return
+            return None
 
         self._compare_and_report(tag, step, output, ref_output)
+        return ref_output
 
     def _compare_and_report(
         self,

--- a/mojo_opset/utils/debugger.py
+++ b/mojo_opset/utils/debugger.py
@@ -71,6 +71,28 @@ def _infer_core_cls_from_mro(module):
     return None
 
 
+def _infer_device(module) -> torch.device:
+    """Determine the device of a module from its parameters or buffers.
+
+    For stateless modules (no parameters/buffers), fall back to the device
+    recorded from pre-hook inputs, then to CPU.
+    """
+    try:
+        return next(module.parameters()).device
+    except StopIteration:
+        pass
+    try:
+        return next(module.buffers()).device
+    except StopIteration:
+        pass
+    pre_inputs = getattr(module, "_debug_pre_inputs", None)
+    if pre_inputs is not None:
+        for inp in pre_inputs:
+            if isinstance(inp, torch.Tensor):
+                return inp.device
+    return torch.device("cpu")
+
+
 def _parse_rules(rule_str: str) -> List[_Rule]:
     """Parse ``'layer_idx:op_name;...'`` into a list of :class:`_Rule`.
 
@@ -280,8 +302,9 @@ class MojoDebugger:
 
         for name, module in model.named_modules():
             if isinstance(module, MojoOperator):
-                handle = module.register_forward_hook(self._make_hook())
-                self._hook_handles.append(handle)
+                pre_h = module.register_forward_pre_hook(self._make_pre_hook())
+                post_h = module.register_forward_hook(self._make_hook())
+                self._hook_handles.extend([pre_h, post_h])
                 layer_idx = getattr(module, "_debug_layer_idx", None)
                 op_name = getattr(module, "_debug_op_name", name)
                 self._op_map[(layer_idx, op_name)] = module
@@ -306,6 +329,7 @@ class MojoDebugger:
                         "_debug_torch_ref",
                         "_debug_ref_forward",
                         "_debug_torch_ref_ready",
+                        "_debug_pre_inputs",
                     ):
                         try:
                             delattr(module, attr)
@@ -471,6 +495,31 @@ class MojoDebugger:
     # Hook factory
     # ------------------------------------------------------------------
 
+    def _make_pre_hook(self):
+        """Capture a snapshot of inputs *before* forward to handle in-place ops."""
+        debugger = self
+
+        def pre_hook(module, inputs):
+            try:
+                compare_rules = debugger._get_active_rules("compare")
+                dump_rules = debugger._get_active_rules("dump")
+                if not compare_rules and not dump_rules:
+                    return
+
+                layer_idx = getattr(module, "_debug_layer_idx", None)
+                op_name = getattr(module, "_debug_op_name", "")
+
+                need_snapshot = (
+                    _match(layer_idx, op_name, module, dump_rules) is not None
+                    or _match(layer_idx, op_name, module, compare_rules) is not None
+                )
+                if need_snapshot:
+                    module._debug_pre_inputs = _deep_clone(inputs)
+            except Exception:
+                pass
+
+        return pre_hook
+
     def _make_hook(self):
         debugger = self
 
@@ -491,17 +540,21 @@ class MojoDebugger:
                 if matched_dump is None and matched_compare is None:
                     return
 
+                safe_inputs = getattr(module, "_debug_pre_inputs", inputs)
+
                 if matched_dump is not None:
-                    debugger._do_dump(layer_idx, op_name, module, inputs, output)
+                    debugger._do_dump(layer_idx, op_name, module, safe_inputs, output)
 
                 if matched_compare is not None:
-                    debugger._do_compare(layer_idx, op_name, module, inputs, output)
+                    debugger._do_compare(layer_idx, op_name, module, safe_inputs, output)
 
             except Exception as e:
                 logger.warning_once(
                     f"{_PREFIX} Unexpected error in hook for '{op_name}': {e}. "
                     f"Debug skipped, inference unaffected."
                 )
+            finally:
+                module._debug_pre_inputs = None
 
         return hook
 
@@ -709,10 +762,7 @@ class MojoDebugger:
                         f"{_PREFIX} Shadow unexpected keys: {result.unexpected_keys}"
                     )
 
-                try:
-                    device = next(module.parameters()).device
-                except StopIteration:
-                    device = torch.device("cpu")
+                device = _infer_device(module)
                 shadow = shadow.to(device)
                 shadow.eval()
 

--- a/tests/base/test_debug_utils.py
+++ b/tests/base/test_debug_utils.py
@@ -1,0 +1,663 @@
+"""Integration test — validate MojoDebugger dump & compare on a 5-layer mini-transformer.
+
+The model intentionally mirrors a real LLM structure:
+
+    Embedding -> DecoderLayer x 5 -> final RMSNorm -> LM head (Linear)
+
+Each DecoderLayer contains:
+    input_layernorm  (MojoRMSNorm)
+    self_attn.q_proj (MojoLinear)
+    self_attn.k_proj (MojoLinear)
+    self_attn.v_proj (MojoLinear)
+    self_attn.o_proj (MojoLinear)
+    post_attention_layernorm (MojoRMSNorm)
+    mlp.gate_proj    (MojoLinear)
+    mlp.up_proj      (MojoLinear)
+    mlp.act_fn       (MojoSwiGLU)
+    mlp.down_proj    (MojoLinear)
+
+Tests are platform-aware:
+    - On accelerator platforms (NPU/MLU/ILU), the default backend (e.g. TTX)
+      is used, and compare produces real non-zero diffs against the torch ref.
+    - On CPU-only machines (meta_device fallback), the torch backend is used;
+      a dedicated test validates compare by perturbing shadow weights.
+"""
+import os
+import shutil
+import tempfile
+
+import pytest
+import torch
+
+from mojo_opset.utils.debugger import MojoDebugger
+from mojo_opset.utils.platform import get_platform, get_torch_device
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+NUM_LAYERS = 5
+HIDDEN = 128
+NUM_HEADS = 2
+HEAD_DIM = HIDDEN // NUM_HEADS  # 64, compatible with TTX SDPA kernel
+VOCAB_SIZE = 256
+SEQ_LEN = 16
+BATCH = 2
+
+
+# ---------------------------------------------------------------------------
+# Platform helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_test_device() -> str:
+    """Return a torch device string suitable for real computation.
+
+    ``get_torch_device()`` may return ``"meta"`` when no accelerator is
+    present, which cannot execute kernels.  Fall back to ``"cpu"`` in that
+    case.
+    """
+    dev = get_torch_device()
+    return "cpu" if dev == "meta" else dev
+
+
+def _is_torch_only_backend() -> bool:
+    """True when the default MojoOperator dispatch resolves to the torch fallback."""
+    return get_platform() == "meta_device"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_debug_env():
+    """Save / restore debug-related env vars and reset MojoDebugger state.
+
+    Does NOT force ``MOJO_BACKEND`` — lets the platform dispatch work
+    naturally so that tests exercise the real backend on accelerator CI.
+    """
+    keys = [
+        "MOJO_DEBUG", "MOJO_DEBUG_COMPARE",
+        "MOJO_DEBUG_DUMP", "MOJO_DEBUG_DUMP_DIR", "MOJO_DEBUG_MAX_STEPS",
+    ]
+    saved = {k: os.environ.get(k) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+    MojoDebugger.disable()
+
+
+@pytest.fixture
+def dump_dir():
+    d = tempfile.mkdtemp(prefix="mojo_debug_integ_")
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Model definition
+# ---------------------------------------------------------------------------
+
+
+def _build_mini_transformer(device: str = "cpu"):
+    from mojo_opset import (
+        MojoEmbedding,
+        MojoLinear,
+        MojoRMSNorm,
+        MojoSwiGLU,
+    )
+
+    class Attention(torch.nn.Module):
+        def __init__(self, hidden, num_heads):
+            super().__init__()
+            self.num_heads = num_heads
+            self.head_dim = hidden // num_heads
+            self.q_proj = MojoLinear(hidden, hidden, bias=False)
+            self.k_proj = MojoLinear(hidden, hidden, bias=False)
+            self.v_proj = MojoLinear(hidden, hidden, bias=False)
+            self.o_proj = MojoLinear(hidden, hidden, bias=False)
+
+        def forward(self, x):
+            B, T, _ = x.shape
+            q = self.q_proj(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+            k = self.k_proj(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+            v = self.v_proj(x).view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+            attn_out = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, is_causal=True, scale=self.head_dim ** -0.5,
+            )
+            attn_out = attn_out.transpose(1, 2).contiguous().view(B, T, -1)
+            return self.o_proj(attn_out)
+
+    class MLP(torch.nn.Module):
+        def __init__(self, hidden):
+            super().__init__()
+            intermediate = hidden * 4
+            self.gate_proj = MojoLinear(hidden, intermediate, bias=False)
+            self.up_proj = MojoLinear(hidden, intermediate, bias=False)
+            self.act_fn = MojoSwiGLU()
+            self.down_proj = MojoLinear(intermediate, hidden, bias=False)
+
+        def forward(self, x):
+            gate = self.gate_proj(x)
+            up = self.up_proj(x)
+            return self.down_proj(self.act_fn(gate, up))
+
+    class DecoderLayer(torch.nn.Module):
+        def __init__(self, layer_idx, hidden, num_heads):
+            super().__init__()
+            self.layer_idx = layer_idx
+            self.input_layernorm = MojoRMSNorm(norm_size=hidden)
+            self.self_attn = Attention(hidden, num_heads)
+            self.post_attention_layernorm = MojoRMSNorm(norm_size=hidden)
+            self.mlp = MLP(hidden)
+
+        def forward(self, x):
+            x = x + self.self_attn(self.input_layernorm(x))
+            x = x + self.mlp(self.post_attention_layernorm(x))
+            return x
+
+    class MiniTransformer(torch.nn.Module):
+        def __init__(self, vocab, hidden, num_heads, n_layers):
+            super().__init__()
+            self.embed = MojoEmbedding(vocab, hidden)
+            self.layers = torch.nn.ModuleList(
+                [DecoderLayer(i, hidden, num_heads) for i in range(n_layers)]
+            )
+            self.norm = MojoRMSNorm(norm_size=hidden)
+            self.lm_head = MojoLinear(hidden, vocab, bias=False)
+
+        def forward(self, input_ids):
+            x = self.embed(input_ids)
+            for layer in self.layers:
+                x = layer(x)
+            x = self.norm(x)
+            return self.lm_head(x)
+
+    model = MiniTransformer(VOCAB_SIZE, HIDDEN, NUM_HEADS, NUM_LAYERS)
+    # Small init to prevent NaN explosion across 5 layers
+    for m in model.modules():
+        if hasattr(m, "weight") and isinstance(m.weight, torch.nn.Parameter):
+            torch.nn.init.normal_(m.weight, std=0.02)
+    return model.to(device)
+
+
+def _random_input(device: str = "cpu"):
+    return torch.randint(0, VOCAB_SIZE, (BATCH, SEQ_LEN), device=device)
+
+
+# ---------------------------------------------------------------------------
+# 1. Attach / op-map verification
+# ---------------------------------------------------------------------------
+
+
+class TestAttachOpMap:
+
+    def test_opmap_structure(self):
+        """After attach, op_map should contain all per-layer ops and global ops."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+
+        per_layer_ops = {
+            "input_layernorm", "self_attn.q_proj", "self_attn.k_proj",
+            "self_attn.v_proj", "self_attn.o_proj",
+            "post_attention_layernorm",
+            "mlp.gate_proj", "mlp.up_proj", "mlp.act_fn", "mlp.down_proj",
+        }
+
+        for layer_idx in range(NUM_LAYERS):
+            for op_name in per_layer_ops:
+                assert (layer_idx, op_name) in dbg._op_map, (
+                    f"Missing ({layer_idx}, {op_name}) in op_map"
+                )
+
+        assert (None, "norm") in dbg._op_map
+        assert (None, "lm_head") in dbg._op_map
+        assert (None, "embed") in dbg._op_map
+
+        expected_total = NUM_LAYERS * len(per_layer_ops) + 3
+        assert len(dbg._op_map) == expected_total
+
+        dbg.detach()
+
+
+# ---------------------------------------------------------------------------
+# 2. Dump
+# ---------------------------------------------------------------------------
+
+
+class TestDumpIntegration:
+
+    def test_dump_single_op(self, dump_dir):
+        """Dump layer2's input_layernorm; verify output files exist and are loadable."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir)
+        dbg.attach(model)
+        dbg.set_dump("2:input_layernorm")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        rank_dir = os.path.join(dump_dir, "rank0")
+        files = os.listdir(rank_dir)
+        out_files = [f for f in files if f.endswith("_output.pt")]
+        in_files = [f for f in files if f.endswith("_input.pt")]
+        assert len(out_files) == 1
+        assert len(in_files) == 1
+        assert "layer2.input_layernorm" in out_files[0]
+
+        output_tensor = torch.load(
+            os.path.join(rank_dir, out_files[0]), weights_only=True,
+            map_location="cpu",
+        )
+        assert output_tensor.shape == (BATCH, SEQ_LEN, HIDDEN)
+
+        dbg.detach()
+
+
+    def test_dump_wildcard_all_layers(self, dump_dir):
+        """Dump mlp.act_fn across all layers; expect 5 output files."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir)
+        dbg.attach(model)
+        dbg.set_dump("*:mlp.act_fn")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        rank_dir = os.path.join(dump_dir, "rank0")
+        out_files = [f for f in os.listdir(rank_dir) if "output" in f]
+        assert len(out_files) == NUM_LAYERS
+        for i in range(NUM_LAYERS):
+            assert any(f"layer{i}.mlp.act_fn" in f for f in out_files)
+
+        dbg.detach()
+
+
+    def test_dump_global_op(self, dump_dir):
+        """Dump the global norm op (outside any DecoderLayer)."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir)
+        dbg.attach(model)
+        dbg.set_dump("none:norm")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        rank_dir = os.path.join(dump_dir, "rank0")
+        out_files = [f for f in os.listdir(rank_dir) if "output" in f]
+        assert len(out_files) == 1
+        assert "global.norm" in out_files[0]
+
+        dbg.detach()
+
+
+    def test_dump_multiple_ops_same_forward(self, dump_dir):
+        """Dump multiple ops (semicolon-separated) in a single forward pass."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir)
+        dbg.attach(model)
+        dbg.set_dump("0:input_layernorm;0:self_attn.o_proj;4:mlp.down_proj")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        rank_dir = os.path.join(dump_dir, "rank0")
+        out_files = [f for f in os.listdir(rank_dir) if "output" in f]
+        assert any("layer0.input_layernorm" in f for f in out_files)
+        assert any("layer0.self_attn.o_proj" in f for f in out_files)
+        assert any("layer4.mlp.down_proj" in f for f in out_files)
+        assert len(out_files) == 3
+
+        dbg.detach()
+
+
+    def test_dump_max_steps_across_forwards(self, dump_dir):
+        """With max_steps=2, only the first 2 of 3 forward passes are dumped."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir, max_steps=2)
+        dbg.attach(model)
+        dbg.set_dump("0:input_layernorm")
+
+        inp = _random_input(device)
+        with torch.no_grad():
+            for _ in range(3):
+                model(inp)
+
+        rank_dir = os.path.join(dump_dir, "rank0")
+        out_files = [f for f in os.listdir(rank_dir) if "output" in f]
+        assert len(out_files) == 2
+
+        dbg.detach()
+
+
+# ---------------------------------------------------------------------------
+# 3. Compare
+# ---------------------------------------------------------------------------
+
+
+class TestCompareIntegration:
+
+    def test_compare_single_op(self):
+        """Compare runs end-to-end; step counter increments correctly."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("3:input_layernorm")
+
+        with torch.no_grad():
+            out = model(_random_input(device))
+
+        assert out is not None
+        assert dbg._step_counters[("cmp", 3, "input_layernorm")] == 1
+        dbg.detach()
+
+
+    def test_compare_stateless_op(self):
+        """Compare a stateless, weight-free op (MojoSwiGLU)."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("0:mlp.act_fn")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        assert dbg._step_counters[("cmp", 0, "mlp.act_fn")] == 1
+        dbg.detach()
+
+
+    def test_compare_wildcard_all_norms(self):
+        """Compare all MojoRMSNorm instances (class-name match), including global norm."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("*:MojoRMSNorm")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        norm_keys = [k for k in dbg._step_counters if k[0] == "cmp"]
+        # 5 layers x 2 norms + 1 global norm = 11
+        assert len(norm_keys) == NUM_LAYERS * 2 + 1
+        for k in norm_keys:
+            assert dbg._step_counters[k] == 1
+
+        dbg.detach()
+
+
+    def test_compare_mlp_chain(self):
+        """Compare all ops in the MLP chain of a single layer."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare(
+            "1:mlp.gate_proj;1:mlp.up_proj;1:mlp.act_fn;1:mlp.down_proj"
+        )
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        for op in ["mlp.gate_proj", "mlp.up_proj", "mlp.act_fn", "mlp.down_proj"]:
+            assert dbg._step_counters[("cmp", 1, op)] == 1
+
+        dbg.detach()
+
+
+    def test_compare_does_not_alter_output(self):
+        """Enabling compare must not alter the model inference output."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+
+        inp = _random_input(device)
+        with torch.no_grad():
+            baseline = model(inp).clone()
+
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("*:input_layernorm;*:mlp.act_fn")
+
+        with torch.no_grad():
+            with_debug = model(inp)
+
+        assert torch.equal(baseline, with_debug), "compare must not alter inference output"
+        dbg.detach()
+
+
+    def test_compare_detects_perturbation(self):
+        """Verify compare exercises the full diff-computation path.
+
+        On accelerator platforms where TTX is used for RMSNorm, the compare
+        between TTX kernel output and torch reference naturally produces a
+        non-zero diff, validating the mechanism with real numerical difference.
+
+        On torch-only platforms where a shadow instance exists, we manually
+        perturb the shadow weights to guarantee a non-zero diff.
+
+        In all cases the step counter must increment (proving the compare
+        code path was fully executed) and the model must not crash.
+        """
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("0:input_layernorm")
+
+        # First forward — triggers lazy shadow construction and compare
+        with torch.no_grad():
+            model(_random_input(device))
+        assert dbg._step_counters[("cmp", 0, "input_layernorm")] == 1
+
+        # If a shadow instance exists (torch-only platform), perturb it
+        # to produce a guaranteed non-zero diff on the second forward.
+        target = dbg._op_map[(0, "input_layernorm")]
+        ref = getattr(target, "_debug_torch_ref", None)
+        if ref is not None:
+            with torch.no_grad():
+                for p in ref.parameters():
+                    p.add_(torch.randn_like(p) * 0.5)
+        # When ref is None the compare uses ref_forward (core forward on the
+        # same module).  On TTX platforms this naturally produces a non-zero
+        # diff because the kernel implementation differs from torch reference.
+
+        # Second forward — compare runs again; must not crash
+        with torch.no_grad():
+            out = model(_random_input(device))
+
+        assert out is not None
+        assert dbg._step_counters[("cmp", 0, "input_layernorm")] == 2
+        dbg.detach()
+
+
+# ---------------------------------------------------------------------------
+# 4. Dynamic rule switching
+# ---------------------------------------------------------------------------
+
+
+class TestDynamicSwitching:
+
+    def test_switch_compare_between_forwards(self):
+        """Switch compare target between two forward passes."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        inp = _random_input(device)
+
+        dbg.set_compare("0:input_layernorm")
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("cmp", 0, "input_layernorm")] == 1
+
+        dbg.set_compare("4:mlp.down_proj")
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("cmp", 4, "mlp.down_proj")] == 1
+        assert dbg._step_counters[("cmp", 0, "input_layernorm")] == 1
+
+        dbg.detach()
+
+
+    def test_dump_and_compare_simultaneously(self, dump_dir):
+        """Dump and compare the same op in a single forward pass."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir)
+        dbg.attach(model)
+        dbg.set_dump("2:post_attention_layernorm")
+        dbg.set_compare("2:post_attention_layernorm")
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        assert dbg._step_counters[("dump", 2, "post_attention_layernorm")] == 1
+        assert dbg._step_counters[("cmp", 2, "post_attention_layernorm")] == 1
+
+        rank_dir = os.path.join(dump_dir, "rank0")
+        assert any("post_attention_layernorm" in f for f in os.listdir(rank_dir))
+
+        dbg.detach()
+
+
+    def test_env_var_runtime_switch(self):
+        """Switch rules via env var between forward passes at runtime."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        inp = _random_input(device)
+
+        os.environ["MOJO_DEBUG_COMPARE"] = "0:self_attn.q_proj"
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("cmp", 0, "self_attn.q_proj")] == 1
+
+        os.environ["MOJO_DEBUG_COMPARE"] = "0:self_attn.k_proj"
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("cmp", 0, "self_attn.k_proj")] == 1
+        assert dbg._step_counters[("cmp", 0, "self_attn.q_proj")] == 1
+
+        os.environ.pop("MOJO_DEBUG_COMPARE", None)
+        dbg.detach()
+
+
+    def test_reset_counters_allows_re_dump(self, dump_dir):
+        """After reset_step_counters, dump resumes (max_steps re-counted)."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger(dump_dir=dump_dir, max_steps=1)
+        dbg.attach(model)
+        dbg.set_dump("0:input_layernorm")
+        inp = _random_input(device)
+
+        # 1st forward: step=0 -> dump succeeds -> counter=1
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("dump", 0, "input_layernorm")] == 1
+
+        # 2nd forward: counter=1 >= max_steps=1 -> skipped
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("dump", 0, "input_layernorm")] == 1
+
+        # After reset, counter goes back to 0; 3rd forward can dump again
+        dbg.reset_step_counters()
+        with torch.no_grad():
+            model(inp)
+        assert dbg._step_counters[("dump", 0, "input_layernorm")] == 1
+
+        # Both dumps write step0 -> same filename -> overwritten, only 1 file
+        rank_dir = os.path.join(dump_dir, "rank0")
+        out_files = [f for f in os.listdir(rank_dir) if f.endswith("_output.pt")]
+        assert len(out_files) == 1
+
+        dbg.detach()
+
+
+# ---------------------------------------------------------------------------
+# 5. Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCasesIntegration:
+
+    def test_unmatched_rule_warns_but_runs(self):
+        """Rule targeting a non-existent layer/op warns but inference is unaffected."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("99:nonexistent_op")
+
+        with torch.no_grad():
+            out = model(_random_input(device))
+        assert out is not None
+        assert all(v == 0 for v in dbg._step_counters.values())
+
+        dbg.detach()
+
+
+    def test_no_rules_no_overhead_counters(self):
+        """With no rules set, forward should not increment any step_counter."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+
+        with torch.no_grad():
+            model(_random_input(device))
+
+        assert len(dbg._step_counters) == 0
+        dbg.detach()
+
+
+    def test_multiple_forwards_accumulate_steps(self):
+        """Multiple forward passes correctly accumulate step_counter."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("1:self_attn.o_proj")
+        inp = _random_input(device)
+
+        with torch.no_grad():
+            for _ in range(5):
+                model(inp)
+
+        assert dbg._step_counters[("cmp", 1, "self_attn.o_proj")] == 5
+        dbg.detach()

--- a/tests/base/test_debug_utils.py
+++ b/tests/base/test_debug_utils.py
@@ -607,7 +607,91 @@ class TestDynamicSwitching:
 
 
 # ---------------------------------------------------------------------------
-# 5. Edge cases
+# 5. Compare replace mode
+# ---------------------------------------------------------------------------
+
+
+class TestCompareReplaceMode:
+
+    def test_compare_replace_mode_changes_output(self):
+        """In replace mode, matched ops' outputs are replaced with torch ref.
+
+        Verify that:
+        1. The model runs without error in replace mode.
+        2. The compare step counters are incremented (proving the code path
+           was exercised).
+        3. Running replace mode twice with the same input produces the same
+           output (deterministic replacement).
+        """
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        inp = _random_input(device)
+
+        dbg = MojoDebugger(compare_mode="replace")
+        dbg.attach(model)
+        dbg.set_compare("*:MojoRMSNorm")
+
+        with torch.no_grad():
+            out1 = model(inp).clone()
+        with torch.no_grad():
+            out2 = model(inp).clone()
+
+        # Step counters should have been incremented twice
+        cmp_keys = [k for k in dbg._step_counters if k[0] == "cmp"]
+        assert len(cmp_keys) == NUM_LAYERS * 2 + 1  # 5 layers * 2 norms + 1 global
+        for k in cmp_keys:
+            assert dbg._step_counters[k] == 2
+
+        assert torch.equal(out1, out2), (
+            "replace mode should produce deterministic output"
+        )
+        dbg.detach()
+
+    def test_compare_replace_mode_switchable(self):
+        """set_compare_mode switches behaviour between forward passes."""
+        device = _get_test_device()
+        MojoDebugger.enable()
+        model = _build_mini_transformer(device)
+        inp = _random_input(device)
+
+        dbg = MojoDebugger()
+        dbg.attach(model)
+        dbg.set_compare("*:MojoRMSNorm")
+
+        # Forward 1: observe (default)
+        assert dbg._compare_mode == "observe"
+        with torch.no_grad():
+            out_obs = model(inp).clone()
+
+        # Forward 2: switch to replace
+        dbg.set_compare_mode("replace")
+        assert dbg._compare_mode == "replace"
+        with torch.no_grad():
+            out_rep = model(inp).clone()
+
+        # Forward 3: switch back to observe
+        dbg.set_compare_mode("observe")
+        assert dbg._compare_mode == "observe"
+        with torch.no_grad():
+            out_obs2 = model(inp).clone()
+
+        # Observe mode should always produce the same output
+        assert torch.equal(out_obs, out_obs2), (
+            "observe mode should produce consistent output"
+        )
+
+        # Replace mode must complete without error and increment counters
+        cmp_keys = [k for k in dbg._step_counters if k[0] == "cmp"]
+        assert all(dbg._step_counters[k] == 3 for k in cmp_keys), (
+            "all 3 forwards should have triggered compare"
+        )
+
+        dbg.detach()
+
+
+# ---------------------------------------------------------------------------
+# 6. Edge cases
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Introduce a non-invasive debug toolkit that supports:
- Dump: save input/output tensors of any MojoOperator at any layer to disk
- Compare: run accelerator backend output against torch reference, reporting max_abs_diff, max_rel_diff, and cosine similarity in real time
- Dynamic rule switching between forward passes via API or env vars
- Semantic layer_idx propagation from DecoderLayer modules
- Lazy torch shadow construction with weight sync for safe comparison

Also adds:
- Integration tests (19 cases) covering attach, dump, compare, dynamic switching, and edge cases with platform-aware device selection
- CI steps for tests/base on iluvatar and mlu pipelines
- User-facing documentation in docs/debug_suite.md

Made-with: Cursor