### PR TITLE
add runtime.py: decouple runtime states with modeling

### DIFF
--- a/mojo_opset/runtime/runtime.py
+++ b/mojo_opset/runtime/runtime.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from mojo_opset.runtime.config import MojoConfig
+from mojo_opset.runtime.generation import MojoSession
+from mojo_opset.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+@dataclass
+class AttentionMetadata:
+    cu_seqlens_q: torch.Tensor
+    query_lengths: torch.Tensor
+    seqlens_kv: torch.Tensor
+    block_tables: torch.Tensor
+    slot_mapping: torch.Tensor
+    key_caches: list[torch.Tensor]
+    value_caches: list[torch.Tensor]
+    is_prefill: bool
+
+
+class PagedAttentionRuntimeState(MojoSession):
+    def __init__(
+        self,
+        config: MojoConfig,
+        batch_size: int,
+        device,
+        dtype,
+        block_size: int = 128,
+    ):
+        self.config = config
+        self.batch_size = batch_size
+        self.num_layers = config.model_config.num_layers
+        self.device = device
+        self.dtype = dtype
+        self.block_size = block_size
+        self.num_kv_heads = getattr(config.model_config, "local_num_kv_heads", config.model_config.num_kv_heads)
+        self.head_dim = config.model_config.head_dim
+
+        self.max_blocks_per_seq = (config.model_config.max_position_embeddings + block_size - 1) // block_size
+        total_blocks = batch_size * self.max_blocks_per_seq
+
+        self.block_tables = torch.full(
+            (batch_size, self.max_blocks_per_seq),
+            -1,
+            dtype=torch.int32,
+            device=device,
+        )
+        self.seqlens_kv = torch.zeros((batch_size,), dtype=torch.int64, device=device)
+        self.free_blocks = torch.arange(total_blocks, dtype=torch.int32, device=device)
+        self.num_free_blocks = total_blocks
+
+        cache_shape = (total_blocks, self.num_kv_heads, block_size, self.head_dim)
+        self.key_caches = [None] * self.num_layers
+        self.value_caches = [None] * self.num_layers
+
+        kv_mirror_layers = getattr(config.model_config, "kv_mirror_layers", [])
+        kv_mirror_imitated_layers = getattr(config.model_config, "kv_mirror_imitated_layers", [])
+        mirror_map = {
+            mirror_layer - 1: imitated_layer - 1
+            for mirror_layer, imitated_layer in zip(kv_mirror_layers, kv_mirror_imitated_layers)
+        }
+
+        for layer_idx in range(self.num_layers):
+            if layer_idx in mirror_map:
+                source_layer_idx = mirror_map[layer_idx]
+                if self.key_caches[source_layer_idx] is None or self.value_caches[source_layer_idx] is None:
+                    raise ValueError(
+                        f"Source layer {source_layer_idx + 1} for mirror layer {layer_idx + 1} must exist first."
+                    )
+                logger.debug(f"Layer {layer_idx + 1} is mirroring layer {source_layer_idx + 1}.")
+                self.key_caches[layer_idx] = self.key_caches[source_layer_idx]
+                self.value_caches[layer_idx] = self.value_caches[source_layer_idx]
+                continue
+
+            logger.debug(f"Creating new cache tensors for layer {layer_idx + 1}.")
+            self.key_caches[layer_idx] = torch.zeros(cache_shape, dtype=dtype, device=device)
+            self.value_caches[layer_idx] = torch.zeros(cache_shape, dtype=dtype, device=device)
+
+    @property
+    def kv_cache(self):
+        return self
+
+    @classmethod
+    def from_model(
+        cls,
+        model: nn.Module,
+        batch_size: int,
+        *,
+        block_size: int = 128,
+        device=None,
+        dtype=None,
+    ) -> "PagedAttentionRuntimeState":
+        if device is None:
+            device = model.lm_head.weight.device
+        if dtype is None:
+            dtype = model.lm_head.weight.dtype
+        return cls(
+            model.config,
+            batch_size,
+            device=device,
+            dtype=dtype,
+            block_size=block_size,
+        )
+
+    def _allocate_blocks(self, num_blocks: int) -> torch.Tensor:
+        if num_blocks > self.num_free_blocks:
+            raise ValueError("PagedAttentionRuntimeState: Out of paged KV cache memory.")
+        allocated = self.free_blocks[self.num_free_blocks - num_blocks : self.num_free_blocks]
+        self.num_free_blocks -= num_blocks
+        return allocated
+
+    def _normalize_query_lengths(self, query_lengths: Optional[torch.Tensor]) -> torch.Tensor:
+        if query_lengths is None:
+            return torch.ones(self.batch_size, dtype=torch.int64, device=self.device)
+        return query_lengths.to(device=self.device, dtype=torch.int64)
+
+    def _reserve(self, query_lengths: torch.Tensor) -> torch.Tensor:
+        query_lengths = self._normalize_query_lengths(query_lengths)
+        previous_seqlens = self.seqlens_kv.clone()
+
+        for batch_idx in range(self.batch_size):
+            context_len = int(previous_seqlens[batch_idx].item())
+            append_len = int(query_lengths[batch_idx].item())
+            old_num_blocks = (context_len + self.block_size - 1) // self.block_size
+            new_total_len = context_len + append_len
+            new_num_blocks = (new_total_len + self.block_size - 1) // self.block_size
+
+            if new_num_blocks > old_num_blocks:
+                newly_allocated = self._allocate_blocks(new_num_blocks - old_num_blocks)
+                self.block_tables[batch_idx, old_num_blocks:new_num_blocks] = newly_allocated
+
+        self.seqlens_kv = previous_seqlens + query_lengths
+        return previous_seqlens
+
+    def _build_positions(self, kv_lens_before_store: torch.Tensor, query_lengths: torch.Tensor) -> torch.Tensor:
+        positions = []
+        for batch_idx in range(self.batch_size):
+            start = int(kv_lens_before_store[batch_idx].item())
+            query_len = int(query_lengths[batch_idx].item())
+            if query_len <= 0:
+                continue
+            positions.append(torch.arange(start, start + query_len, dtype=torch.int64, device=self.device))
+
+        if not positions:
+            return torch.empty((0,), dtype=torch.int64, device=self.device)
+        return torch.cat(positions, dim=0)
+
+    def _build_slot_mapping(self, kv_lens_before_store: torch.Tensor, query_lengths: torch.Tensor) -> torch.Tensor:
+        block_start = (self.block_tables.to(torch.int64) * self.block_size).unsqueeze(-1)
+        offsets = torch.arange(self.block_size, dtype=torch.int64, device=self.device)
+        slot_mapping = (block_start + offsets).flatten(-2, -1)
+
+        slot_mapping_chunks = []
+        for batch_idx in range(self.batch_size):
+            start = int(kv_lens_before_store[batch_idx].item())
+            query_len = int(query_lengths[batch_idx].item())
+            if query_len <= 0:
+                continue
+            slot_mapping_chunks.append(slot_mapping[batch_idx, start : start + query_len])
+
+        if not slot_mapping_chunks:
+            return torch.empty((0,), dtype=torch.int64, device=self.device)
+        return torch.cat(slot_mapping_chunks, dim=0)
+
+    def _build_attention_metadata(
+        self,
+        *,
+        cu_seqlens_q: Optional[torch.Tensor],
+        kv_lens_before_store: torch.Tensor,
+        query_lengths: torch.Tensor,
+    ) -> AttentionMetadata:
+        return AttentionMetadata(
+            cu_seqlens_q=cu_seqlens_q,
+            query_lengths=query_lengths,
+            seqlens_kv=self.seqlens_kv.clone(),
+            block_tables=self.block_tables,
+            slot_mapping=self._build_slot_mapping(kv_lens_before_store, query_lengths),
+            key_caches=self.key_caches,
+            value_caches=self.value_caches,
+            is_prefill=cu_seqlens_q is not None,
+        )
+
+    def prepare_prefill_inputs(
+        self,
+        input_ids: torch.Tensor,
+        query_lengths: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, AttentionMetadata]:
+        input_ids = input_ids.reshape(-1).to(device=self.device, dtype=torch.int64)
+        query_lengths = self._normalize_query_lengths(query_lengths)
+
+        if int(query_lengths.sum().item()) != input_ids.numel():
+            raise ValueError(
+                "Prefill input_ids length must match the sum of query_lengths: "
+                f"{input_ids.numel()} != {int(query_lengths.sum().item())}"
+            )
+
+        kv_lens_before_store = self._reserve(query_lengths)
+        positions = self._build_positions(kv_lens_before_store, query_lengths)
+        cu_seqlens_q = F.pad(query_lengths.cumsum(-1), (1, 0)).to(torch.int32)
+        attention_metadata = self._build_attention_metadata(
+            cu_seqlens_q=cu_seqlens_q,
+            kv_lens_before_store=kv_lens_before_store,
+            query_lengths=query_lengths,
+        )
+        return input_ids, positions, attention_metadata
+
+    def prepare_decode_inputs(
+        self,
+        input_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, AttentionMetadata]:
+        input_ids = input_ids.reshape(-1).to(device=self.device, dtype=torch.int64)
+        if input_ids.numel() != self.batch_size:
+            raise ValueError(
+                f"Decode input_ids must provide exactly one token per sequence: {input_ids.numel()} != {self.batch_size}"
+            )
+
+        query_lengths = torch.ones(self.batch_size, dtype=torch.int64, device=self.device)
+        cu_seqlens_q = F.pad(query_lengths.cumsum(-1), (1, 0)).to(torch.int32)
+        positions = self.seqlens_kv.clone()
+        kv_lens_before_store = self._reserve(query_lengths)
+        attention_metadata = self._build_attention_metadata(
+            cu_seqlens_q=cu_seqlens_q,
+            kv_lens_before_store=kv_lens_before_store,
+            query_lengths=query_lengths,
+        )
+        return input_ids, positions, attention_metadata
+
+
+class PagedAttentionGenerationModel(nn.Module):
+    def __init__(
+        self,
+        model: nn.Module,
+        *,
+        block_size: int = 128,
+        session_cls: type[PagedAttentionRuntimeState] = PagedAttentionRuntimeState,
+    ):
+        super().__init__()
+        self.model = model
+        self.block_size = block_size
+        self.session_cls = session_cls
+
+    def _new_session(
+        self,
+        input_ids: torch.Tensor,
+        context_input_len: Optional[torch.Tensor],
+    ) -> PagedAttentionRuntimeState:
+        batch_size = int(context_input_len.size(0)) if context_input_len is not None else int(input_ids.numel())
+        return self.session_cls.from_model(self.model, batch_size, block_size=self.block_size)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        context_input_len: torch.Tensor = None,
+        session: PagedAttentionRuntimeState = None,
+        **kwargs,
+    ):
+        lm_head_indices = None
+        if session is None:
+            session = self._new_session(input_ids, context_input_len)
+
+        if context_input_len is not None:
+            model_inputs = session.prepare_prefill_inputs(input_ids, context_input_len)
+            cu_seqlens = model_inputs[-1].cu_seqlens_q[1:]
+            lm_head_indices = cu_seqlens - 1
+        else:
+            model_inputs = session.prepare_decode_inputs(input_ids)
+
+        logits = self.model(*model_inputs, lm_head_indices=lm_head_indices)
+        return logits, session

--- a/mojo_opset/runtime/runtime.py
+++ b/mojo_opset/runtime/runtime.py
@@ -45,6 +45,7 @@ class PagedAttentionRuntimeState(MojoSession):
 
         self.max_blocks_per_seq = (config.model_config.max_position_embeddings + block_size - 1) // block_size
         total_blocks = batch_size * self.max_blocks_per_seq
+        self.offsets = torch.arange(self.block_size, dtype=torch.int64, device=self.device)
 
         self.block_tables = torch.full(
             (batch_size, self.max_blocks_per_seq),
@@ -153,17 +154,21 @@ class PagedAttentionRuntimeState(MojoSession):
         return torch.cat(positions, dim=0)
 
     def _build_slot_mapping(self, kv_lens_before_store: torch.Tensor, query_lengths: torch.Tensor) -> torch.Tensor:
-        block_start = (self.block_tables.to(torch.int64) * self.block_size).unsqueeze(-1)
-        offsets = torch.arange(self.block_size, dtype=torch.int64, device=self.device)
-        slot_mapping = (block_start + offsets).flatten(-2, -1)
-
         slot_mapping_chunks = []
         for batch_idx in range(self.batch_size):
-            start = int(kv_lens_before_store[batch_idx].item())
-            query_len = int(query_lengths[batch_idx].item())
+            query_len = query_lengths[batch_idx]
             if query_len <= 0:
                 continue
-            slot_mapping_chunks.append(slot_mapping[batch_idx, start : start + query_len])
+
+            curr_block_tables = self.block_tables[batch_idx]
+            first_pad_index = torch.nonzero(curr_block_tables == -1)[0]
+            curr_block_tables = curr_block_tables[:first_pad_index]
+
+            block_start = curr_block_tables * self.block_size
+            slot_mapping = (block_start.unsqueeze(-1) + self.offsets.unsqueeze(0)).flatten()
+
+            start = kv_lens_before_store[batch_idx]
+            slot_mapping_chunks.append(slot_mapping[start:start+query_len])
 
         if not slot_mapping_chunks:
             return torch.empty((0,), dtype=torch.int64, device=self.device)


### PR DESCRIPTION
解耦 runtime 状态 与模型 modeling:
- 使 modeling 无状态, 它仅接收 runtime 构造的输入, 专注于运算逻辑
- runtime提供 seqlens更新、block_tables分配、slots分配等 request 相关的状态维护
- **wip**: 本PR仅提供 runtime 实现, 开源模型基于runtime的重构将在后面的PR中实现