### PR TITLE
fix[ep]: modify ep_rank getting fn from get_rank to get_local_rank

### DIFF
--- a/mojo_opset/distributed/parallel/expert_parallel.py
+++ b/mojo_opset/distributed/parallel/expert_parallel.py
@@ -24,7 +24,7 @@ class _EPDispatchWrapper(nn.Module):
         assert isinstance(dispatch, MojoMoEDispatch)
         self._dispatch = dispatch
         ep_size = ep_mesh.size()
-        ep_rank = ep_mesh.get_rank()
+        ep_rank = ep_mesh.get_local_rank()
         base = dispatch.num_experts // ep_size
         rem = dispatch.num_experts % ep_size
         local = base + 1 if ep_rank < rem else base


### PR DESCRIPTION
The old way will cause an illegal address access error when using pp and ep.