### PR TITLE
[ilu/ttx] Optimize ttx ops (FA/SWA/GroupGemm).

### DIFF
--- a/mojo_opset/backends/ttx/kernels/ilu/flash_attention.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/flash_attention.py
@@ -1,13 +1,7 @@
 """
-ILU: paged prefill GQA — KV gather + GQA expand in PyTorch; causal attention in Triton.
-Aligned with MojoPagedPrefillGQA (mask j <= i + (kv_seq_len - q_seq_len)).
-
-Paged decode (``paged_attention_decode_impl``)
------------------------------------------------
-Gathers paged KV to dense ``[T, H, D]`` per batch row, GQA-expands, then
-``_launch_causal_attn_triton`` with ``q_seq_len=1`` (same as prefill numerics).
-Works for any KV ``block_size`` (e.g. 32, 128, 1024).
-
+ILU Triton attention kernels:
+  - Paged prefill GQA (Flash Attention v2, online softmax, direct paged KV access)
+  - Paged decode GQA (KV gather + causal attention)
 """
 
 import math
@@ -18,6 +12,259 @@ import triton
 import triton.language as tl
 
 from .utils import libentry
+
+LOG2E: tl.constexpr = math.log2(math.e)
+
+
+@triton.jit
+def causal_mask_fn(mask_ptr, mask_size, mask_stride_m, mask_stride_n, q_start, kv_start, Q_BLOCK, KV_BLOCK):
+    offset_causal = min(max(kv_start - q_start, -mask_size), mask_size)
+    offsets_mask_causal = (
+        (tl.arange(0, Q_BLOCK)[:, None]) * mask_stride_m
+        + (mask_size + offset_causal + tl.arange(0, KV_BLOCK)[None, :]) * mask_stride_n
+    )
+    mask_causal = tl.load(mask_ptr + offsets_mask_causal).to(tl.int1)
+    return mask_causal
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 128}, num_warps=8, num_stages=2),
+    ],
+    key=["NUM_Q_HEADS", "HEAD_DIM", "PAGE_SIZE"],
+)
+@triton.jit
+def _paged_prefill_fav2_kernel(
+    Q,
+    K_cache,
+    V_cache,
+    Out,
+    aux_mask_ptr,
+    cu_seqlens_q_ptr,
+    seqlens_kv_ptr,
+    block_tables_ptr,
+    stride_qt, stride_qh, stride_qd,
+    stride_kb, stride_kh, stride_kn, stride_kd,
+    stride_vb, stride_vh, stride_vn, stride_vd,
+    stride_ot, stride_oh, stride_od,
+    stride_bt_batch, stride_bt_block,
+    stride_mask_m, stride_mask_n,
+    sm_scale,
+    AUX_MASK_SIZE: tl.constexpr,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    GQA_INTERLEAVE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    USE_AUX_MASK: tl.constexpr,
+):
+    tl.static_assert(HEAD_DIM <= BLOCK_D, "BLOCK_D must be >= HEAD_DIM")
+
+    local_q_block_id = tl.program_id(0)
+    q_head_id = tl.program_id(1)
+    b_id = tl.program_id(2)
+
+    q_start = tl.load(cu_seqlens_q_ptr + b_id).to(tl.int32)
+    q_seq_len = tl.load(cu_seqlens_q_ptr + b_id + 1).to(tl.int32) - q_start
+    kv_seq_len = tl.load(seqlens_kv_ptr + b_id).to(tl.int32)
+
+    q_blk_start = local_q_block_id * BLOCK_M
+    if q_blk_start >= q_seq_len:
+        return
+
+    if GQA_INTERLEAVE:
+        kv_head_id = q_head_id % NUM_KV_HEADS
+    else:
+        kv_head_id = q_head_id // (NUM_Q_HEADS // NUM_KV_HEADS)
+
+    q_blk_end = tl.minimum(q_blk_start + BLOCK_M, q_seq_len)
+    q_blk_len = q_blk_end - q_blk_start
+
+    Q_blk_ptr = tl.make_block_ptr(
+        base=Q + (q_start + q_blk_start) * stride_qt + q_head_id * stride_qh,
+        shape=(q_blk_len, HEAD_DIM),
+        strides=(stride_qt, stride_qd),
+        offsets=(0, 0),
+        block_shape=(BLOCK_M, BLOCK_D),
+        order=(1, 0),
+    )
+    q = tl.load(Q_blk_ptr, boundary_check=(0, 1), padding_option="zero")
+
+    m_i = tl.zeros((BLOCK_M,), dtype=tl.float32) - float("inf")
+    l_i = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_M, BLOCK_D), dtype=tl.float32)
+
+    kv_cache_len = kv_seq_len - q_seq_len
+
+    if IS_CAUSAL:
+        kv_loop_end = tl.minimum(kv_seq_len, q_blk_end + kv_cache_len)
+    else:
+        kv_loop_end = kv_seq_len
+
+    num_kv_pages = tl.cdiv(kv_loop_end, PAGE_SIZE)
+    num_full_pages = kv_seq_len // PAGE_SIZE
+    num_full_pages = tl.minimum(num_full_pages, num_kv_pages)
+
+    qk_scale = sm_scale * LOG2E
+
+    for page_idx in tl.range(0, num_full_pages):
+        physical_block = tl.load(
+            block_tables_ptr + b_id * stride_bt_batch + page_idx * stride_bt_block
+        )
+
+        K_T_blk_ptr = tl.make_block_ptr(
+            base=K_cache + physical_block * stride_kb + kv_head_id * stride_kh,
+            shape=(HEAD_DIM, PAGE_SIZE),
+            strides=(stride_kd, stride_kn),
+            offsets=(0, 0),
+            block_shape=(BLOCK_D, BLOCK_N),
+            order=(0, 1),
+        )
+        V_blk_ptr = tl.make_block_ptr(
+            base=V_cache + physical_block * stride_vb + kv_head_id * stride_vh,
+            shape=(PAGE_SIZE, HEAD_DIM),
+            strides=(stride_vn, stride_vd),
+            offsets=(0, 0),
+            block_shape=(BLOCK_N, BLOCK_D),
+            order=(1, 0),
+        )
+
+        for kv_inner_idx in tl.range(0, PAGE_SIZE // BLOCK_N):
+            kv_blk_start = page_idx * PAGE_SIZE + kv_inner_idx * BLOCK_N
+
+            if HEAD_DIM == BLOCK_D:
+                k_T = tl.load(K_T_blk_ptr)
+                v = tl.load(V_blk_ptr)
+            else:
+                k_T = tl.load(K_T_blk_ptr, boundary_check=(0,), padding_option="zero")
+                v = tl.load(V_blk_ptr, boundary_check=(1,), padding_option="zero")
+
+            qk = tl.dot(q, k_T)
+            qk = qk * qk_scale
+
+            if IS_CAUSAL:
+                if USE_AUX_MASK:
+                    mask = causal_mask_fn(
+                        aux_mask_ptr,
+                        AUX_MASK_SIZE,
+                        stride_mask_m,
+                        stride_mask_n,
+                        kv_cache_len + q_blk_start,
+                        kv_blk_start,
+                        BLOCK_M,
+                        BLOCK_N,
+                    )
+                    qk = tl.where(mask, qk, float("-inf"))
+                else:
+                    offs_m = q_blk_start + tl.arange(0, BLOCK_M)
+                    offs_n = kv_blk_start + tl.arange(0, BLOCK_N)
+                    causal_mask = (offs_m[:, None] + kv_cache_len) >= offs_n[None, :]
+                    qk = tl.where(causal_mask, qk, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            alpha = tl.math.exp2(m_i - m_ij)
+            p = tl.math.exp2(qk - m_ij[:, None])
+
+            acc = acc * alpha[:, None]
+            acc = tl.dot(p.to(K_cache.dtype.element_ty), v, acc=acc)
+
+            l_i = l_i * alpha + tl.sum(p, 1)
+            m_i = m_ij
+
+            K_T_blk_ptr = tl.advance(K_T_blk_ptr, (0, BLOCK_N))
+            V_blk_ptr = tl.advance(V_blk_ptr, (BLOCK_N, 0))
+
+    for page_idx in tl.range(num_full_pages, num_kv_pages):
+        kv_page_start = page_idx * PAGE_SIZE
+        kv_blk_end = tl.minimum(kv_page_start + PAGE_SIZE, kv_seq_len)
+        kv_blk_len = kv_blk_end - kv_page_start
+
+        physical_block = tl.load(
+            block_tables_ptr + b_id * stride_bt_batch + page_idx * stride_bt_block
+        )
+
+        K_T_blk_ptr = tl.make_block_ptr(
+            base=K_cache + physical_block * stride_kb + kv_head_id * stride_kh,
+            shape=(HEAD_DIM, kv_blk_len),
+            strides=(stride_kd, stride_kn),
+            offsets=(0, 0),
+            block_shape=(BLOCK_D, BLOCK_N),
+            order=(0, 1),
+        )
+        V_blk_ptr = tl.make_block_ptr(
+            base=V_cache + physical_block * stride_vb + kv_head_id * stride_vh,
+            shape=(kv_blk_len, HEAD_DIM),
+            strides=(stride_vn, stride_vd),
+            offsets=(0, 0),
+            block_shape=(BLOCK_N, BLOCK_D),
+            order=(1, 0),
+        )
+
+        num_inner_blocks = tl.cdiv(kv_blk_len, BLOCK_N)
+        for kv_inner_idx in tl.range(0, num_inner_blocks):
+            kv_blk_start = kv_page_start + kv_inner_idx * BLOCK_N
+
+            k_T = tl.load(K_T_blk_ptr, boundary_check=(0, 1), padding_option="zero")
+            v = tl.load(V_blk_ptr, boundary_check=(0, 1), padding_option="zero")
+
+            qk = tl.dot(q, k_T)
+            qk = qk * qk_scale
+
+            if IS_CAUSAL:
+                if USE_AUX_MASK:
+                    mask = causal_mask_fn(
+                        aux_mask_ptr,
+                        AUX_MASK_SIZE,
+                        stride_mask_m,
+                        stride_mask_n,
+                        kv_cache_len + q_blk_start,
+                        kv_blk_start,
+                        BLOCK_M,
+                        BLOCK_N,
+                    )
+                    qk = tl.where(mask, qk, float("-inf"))
+                else:
+                    offs_m = q_blk_start + tl.arange(0, BLOCK_M)
+                    offs_n = kv_blk_start + tl.arange(0, BLOCK_N)
+                    causal_mask = (offs_m[:, None] + kv_cache_len) >= offs_n[None, :]
+                    qk = tl.where(causal_mask, qk, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            alpha = tl.math.exp2(m_i - m_ij)
+            p = tl.math.exp2(qk - m_ij[:, None])
+
+            acc = acc * alpha[:, None]
+            acc = tl.dot(p.to(K_cache.dtype.element_ty), v, acc=acc)
+
+            l_i = l_i * alpha + tl.sum(p, 1)
+            m_i = m_ij
+
+            K_T_blk_ptr = tl.advance(K_T_blk_ptr, (0, BLOCK_N))
+            V_blk_ptr = tl.advance(V_blk_ptr, (BLOCK_N, 0))
+
+    l_i = tl.maximum(l_i, 1e-6)
+    acc = acc / l_i[:, None]
+
+    O_blk_ptr = tl.make_block_ptr(
+        base=Out + (q_start + q_blk_start) * stride_ot + q_head_id * stride_oh,
+        shape=(q_blk_len, HEAD_DIM),
+        strides=(stride_ot, stride_od),
+        offsets=(0, 0),
+        block_shape=(BLOCK_M, BLOCK_D),
+        order=(1, 0),
+    )
+    tl.store(O_blk_ptr, acc.to(Out.dtype.element_ty), boundary_check=(0, 1))
 
 
 @libentry()
@@ -154,6 +401,118 @@ def _launch_causal_attn_triton(
     )
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_N": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_N": 128}, num_warps=8, num_stages=2),
+    ],
+    key=["HQ", "D", "PAGE_SIZE"],
+)
+@libentry()
+@triton.jit
+def _paged_decode_gqa_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    o_ptr,
+    seqlens_ptr,
+    block_tables_ptr,
+    stride_qb,
+    stride_qh,
+    stride_qd,
+    stride_k_block,
+    stride_k_head,
+    stride_k_blksz,
+    stride_k_dim,
+    stride_v_block,
+    stride_v_head,
+    stride_v_blksz,
+    stride_v_dim,
+    stride_ob,
+    stride_oh,
+    stride_od,
+    stride_bt_batch,
+    stride_bt_block,
+    HQ,
+    HKV,
+    D,
+    GROUP,
+    SOFTMAX_SCALE,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    GQA_LAYOUT: tl.constexpr,
+    OUT_T: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    if pid_h >= HQ:
+        return
+
+    seq_len = tl.load(seqlens_ptr + pid_b).to(tl.int32)
+    kv_h = tl.where(GQA_LAYOUT == 0, pid_h % HKV, pid_h // GROUP)
+
+    offs_d = tl.arange(0, BLOCK_D)
+    d_mask = offs_d < D
+
+    q_ptrs = q_ptr + pid_b * stride_qb + pid_h * stride_qh + offs_d * stride_qd
+    q = tl.load(q_ptrs, mask=d_mask, other=0.0)
+
+    neg_inf = -1.0e30
+    m = tl.full((1,), neg_inf, tl.float32)
+    l = tl.zeros((1,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    num_blocks = tl.cdiv(seq_len, BLOCK_N)
+    for block_idx in tl.range(0, num_blocks):
+        start_n = block_idx * BLOCK_N
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        s_mask = offs_n < seq_len
+
+        logical_block_idx = offs_n // PAGE_SIZE
+        offset_in_block = offs_n % PAGE_SIZE
+        physical_block_id = tl.load(
+            block_tables_ptr + pid_b * stride_bt_batch + logical_block_idx * stride_bt_block,
+            mask=s_mask,
+            other=0,
+        )
+
+        k_ptrs = (
+            k_cache_ptr
+            + physical_block_id[:, None] * stride_k_block
+            + kv_h * stride_k_head
+            + offset_in_block[:, None] * stride_k_blksz
+            + offs_d[None, :] * stride_k_dim
+        )
+        v_ptrs = (
+            v_cache_ptr
+            + physical_block_id[:, None] * stride_v_block
+            + kv_h * stride_v_head
+            + offset_in_block[:, None] * stride_v_blksz
+            + offs_d[None, :] * stride_v_dim
+        )
+        k = tl.load(k_ptrs, mask=s_mask[:, None] & d_mask[None, :], other=0.0)
+        v = tl.load(v_ptrs, mask=s_mask[:, None] & d_mask[None, :], other=0.0)
+        scores = tl.sum(k * q[None, :], axis=1) * SOFTMAX_SCALE
+        scores = tl.where(s_mask, scores, neg_inf)
+        m_new = tl.maximum(m, tl.max(scores, axis=0))
+        alpha = tl.math.exp(m - m_new)
+        p = tl.where(s_mask, tl.math.exp(scores - m_new), 0.0)
+        l = l * alpha + tl.sum(p, axis=0)
+        acc = acc * alpha + tl.sum(p[:, None] * v.to(tl.float32), axis=0)
+        m = m_new
+
+    l = tl.maximum(l, 1e-6)
+    out = acc / l
+    out_ptrs = o_ptr + pid_b * stride_ob + pid_h * stride_oh + offs_d * stride_od
+    tl.store(out_ptrs, out.to(OUT_T), mask=d_mask)
+
+
 def paged_attention_prefill_impl(
     q: torch.Tensor,
     key_cache: torch.Tensor,
@@ -165,68 +524,70 @@ def paged_attention_prefill_impl(
     softmax_scale: Optional[float] = None,
     aux_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    del aux_mask
-
     total_q_tokens, num_q_heads, head_dim = q.shape
     _, num_kv_heads, block_size, _ = key_cache.shape
-    if softmax_scale is None:
-        softmax_scale = 1.0 / math.sqrt(head_dim)
+    batch_size = cu_seqlens_q.shape[0] - 1
 
-    outputs = torch.zeros(total_q_tokens, num_q_heads, head_dim, dtype=q.dtype, device=q.device)
+    sm_scale = softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim)
 
-    q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-    batch_size = len(q_lens)
+    if seqlens_kv is None:
+        seqlens_kv = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).to(torch.int32)
+    else:
+        seqlens_kv = seqlens_kv.to(torch.int32)
 
-    for i in range(batch_size):
-        q_seq_len = q_lens[i].item()
-        start_loc = cu_seqlens_q[i].item()
-        end_loc = cu_seqlens_q[i + 1].item()
-        q_batch = q[start_loc:end_loc].contiguous()
-        if seqlens_kv is None:
-            kv_seq_len = q_seq_len
-        else:
-            kv_seq_len = seqlens_kv[i].item()
+    use_aux_mask = aux_mask is not None
 
-        num_blocks_for_seq = (kv_seq_len + block_size - 1) // block_size
-        k_unpadded = torch.zeros(kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device)
-        v_unpadded = torch.zeros(kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device)
+    out = torch.empty_like(q)
+    block_tables_i32 = block_tables.to(torch.int32)
 
-        for j in range(num_blocks_for_seq):
-            physical_block_id = block_tables[i, j].item()
+    BLOCK_D = triton.next_power_of_2(head_dim)
 
-            start_pos_in_seq = j * block_size
-            end_pos_in_seq = min(start_pos_in_seq + block_size, kv_seq_len)
-            tokens_in_block = end_pos_in_seq - start_pos_in_seq
+    if use_aux_mask:
+        mask_ptr = aux_mask
+        mask_stride_m = aux_mask.stride(0)
+        mask_stride_n = aux_mask.stride(1)
+        mask_size = aux_mask.shape[0]
+    else:
+        mask_ptr = q
+        mask_stride_m = 0
+        mask_stride_n = 0
+        mask_size = 0
 
-            k_slice = key_cache[physical_block_id, :, :tokens_in_block, :]
-            k_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = k_slice.permute(1, 0, 2)
+    def grid(META):
+        bm = META["BLOCK_M"]
+        q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        max_q_blocks = ((q_lens + bm - 1) // bm).max().item()
+        return (max_q_blocks, num_q_heads, batch_size)
 
-            v_slice = value_cache[physical_block_id, :, :tokens_in_block, :]
-            v_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = v_slice.permute(1, 0, 2)
+    _paged_prefill_fav2_kernel[grid](
+        q,
+        key_cache,
+        value_cache,
+        out,
+        mask_ptr,
+        cu_seqlens_q,
+        seqlens_kv,
+        block_tables_i32,
+        q.stride(0), q.stride(1), q.stride(2),
+        key_cache.stride(0), key_cache.stride(1), key_cache.stride(2), key_cache.stride(3),
+        value_cache.stride(0), value_cache.stride(1), value_cache.stride(2), value_cache.stride(3),
+        out.stride(0), out.stride(1), out.stride(2),
+        block_tables_i32.stride(0), block_tables_i32.stride(1),
+        mask_stride_m, mask_stride_n,
+        float(sm_scale),
+        AUX_MASK_SIZE=mask_size,
+        NUM_Q_HEADS=num_q_heads,
+        NUM_KV_HEADS=num_kv_heads,
+        GQA_INTERLEAVE=gqa_interleave,
+        HEAD_DIM=head_dim,
+        BLOCK_D=BLOCK_D,
+        PAGE_SIZE=block_size,
+        BLOCK_N=min(block_size, 128),
+        IS_CAUSAL=True,
+        USE_AUX_MASK=use_aux_mask,
+    )
 
-        if num_q_heads != num_kv_heads:
-            g = num_q_heads // num_kv_heads
-            # repeat: head dim becomes [kv_0..kv_{K-1}] tiled g times → aligns with decode
-            #   kv_head_id = q_head_id % num_kv_heads when gqa_interleave / GQA_INTERLEAVE.
-            # repeat_interleave: each kv head repeated g times in order → aligns with
-            #   kv_head_id = q_head_id // g when not interleaved. See module docstring.
-            if gqa_interleave:
-                k_expanded = k_unpadded.repeat((1, g, 1))
-                v_expanded = v_unpadded.repeat((1, g, 1))
-            else:
-                k_expanded = k_unpadded.repeat_interleave(g, dim=1)
-                v_expanded = v_unpadded.repeat_interleave(g, dim=1)
-        else:
-            k_expanded = k_unpadded
-            v_expanded = v_unpadded
-
-        k_expanded = k_expanded.contiguous()
-        v_expanded = v_expanded.contiguous()
-        out_slice = torch.empty_like(q_batch)
-        _launch_causal_attn_triton(q_batch, k_expanded, v_expanded, out_slice, softmax_scale, q_seq_len, kv_seq_len)
-        outputs[start_loc:end_loc] = out_slice
-
-    return outputs
+    return out
 
 
 def _paged_decode_gather_and_causal(
@@ -238,55 +599,60 @@ def _paged_decode_gather_and_causal(
     gqa_interleave: bool,
     softmax_scale: float,
 ) -> torch.Tensor:
-    """ILU paged decode: unpage KV + causal attention (one query token per batch row)."""
+    """ILU paged decode: direct paged KV Triton, one Q token per batch row."""
     batch_size, num_q_heads, head_dim = q.shape
-    _, num_kv_heads, block_size, _ = key_cache.shape
+    _, num_kv_heads, page_size, head_dim_cache = key_cache.shape
+
+    assert head_dim == head_dim_cache
+    group = num_q_heads // num_kv_heads
     o = torch.empty_like(q)
+    block_d = triton.next_power_of_2(head_dim)
+    layout_id = 0 if gqa_interleave else 1
 
-    for i in range(batch_size):
-        kv_seq_len = int(seqlens[i].item())
-        q_batch = q[i : i + 1].contiguous()
-        num_blocks_for_seq = (kv_seq_len + block_size - 1) // block_size
+    if q.dtype == torch.float16:
+        out_t = tl.float16
+    elif q.dtype == torch.bfloat16:
+        out_t = tl.bfloat16
+    else:
+        out_t = tl.float32
 
-        k_unpadded = torch.zeros(
-            kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device
-        )
-        v_unpadded = torch.zeros(
-            kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device
-        )
+    seqlens_i32 = seqlens.to(torch.int32)
+    block_tables_i32 = block_tables.to(torch.int32)
 
-        for j in range(num_blocks_for_seq):
-            physical_block_id = int(block_tables[i, j].item())
-            start_pos_in_seq = j * block_size
-            end_pos_in_seq = min(start_pos_in_seq + block_size, kv_seq_len)
-            tokens_in_block = end_pos_in_seq - start_pos_in_seq
-
-            k_slice = key_cache[physical_block_id, :, :tokens_in_block, :]
-            k_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = k_slice.permute(1, 0, 2)
-
-            v_slice = value_cache[physical_block_id, :, :tokens_in_block, :]
-            v_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = v_slice.permute(1, 0, 2)
-
-        if num_q_heads != num_kv_heads:
-            g = num_q_heads // num_kv_heads
-            if gqa_interleave:
-                k_expanded = k_unpadded.repeat((1, g, 1))
-                v_expanded = v_unpadded.repeat((1, g, 1))
-            else:
-                k_expanded = k_unpadded.repeat_interleave(g, dim=1)
-                v_expanded = v_unpadded.repeat_interleave(g, dim=1)
-        else:
-            k_expanded = k_unpadded
-            v_expanded = v_unpadded
-
-        k_expanded = k_expanded.contiguous()
-        v_expanded = v_expanded.contiguous()
-        out_slice = torch.empty_like(q_batch)
-        _launch_causal_attn_triton(
-            q_batch, k_expanded, v_expanded, out_slice, softmax_scale, 1, kv_seq_len
-        )
-        o[i] = out_slice[0]
-
+    grid = (batch_size, num_q_heads)
+    _paged_decode_gqa_kernel[grid](
+        q,
+        key_cache,
+        value_cache,
+        o,
+        seqlens_i32,
+        block_tables_i32,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        key_cache.stride(0),
+        key_cache.stride(1),
+        key_cache.stride(2),
+        key_cache.stride(3),
+        value_cache.stride(0),
+        value_cache.stride(1),
+        value_cache.stride(2),
+        value_cache.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        block_tables_i32.stride(0),
+        block_tables_i32.stride(1),
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        group,
+        float(softmax_scale),
+        BLOCK_D=block_d,
+        PAGE_SIZE=page_size,
+        GQA_LAYOUT=layout_id,
+        OUT_T=out_t,
+    )
     return o
 
 

--- a/mojo_opset/backends/ttx/kernels/ilu/flash_attention.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/flash_attention.py
@@ -1,13 +1,7 @@
 """
-ILU: paged prefill GQA — KV gather + GQA expand in PyTorch; causal attention in Triton.
-Aligned with MojoPagedPrefillGQA (mask j <= i + (kv_seq_len - q_seq_len)).
-
-Paged decode (``paged_attention_decode_impl``)
------------------------------------------------
-Gathers paged KV to dense ``[T, H, D]`` per batch row, GQA-expands, then
-``_launch_causal_attn_triton`` with ``q_seq_len=1`` (same as prefill numerics).
-Works for any KV ``block_size`` (e.g. 32, 128, 1024).
-
+ILU Triton attention kernels:
+  - Paged prefill GQA (Flash Attention v2, online softmax, direct paged KV access)
+  - Paged decode GQA (KV gather + causal attention)
 """
 
 import math
@@ -18,6 +12,259 @@ import triton
 import triton.language as tl
 
 from .utils import libentry
+
+LOG2E: tl.constexpr = math.log2(math.e)
+
+
+@triton.jit
+def causal_mask_fn(mask_ptr, mask_size, mask_stride_m, mask_stride_n, q_start, kv_start, Q_BLOCK, KV_BLOCK):
+    offset_causal = min(max(kv_start - q_start, -mask_size), mask_size)
+    offsets_mask_causal = (
+        (tl.arange(0, Q_BLOCK)[:, None]) * mask_stride_m
+        + (mask_size + offset_causal + tl.arange(0, KV_BLOCK)[None, :]) * mask_stride_n
+    )
+    mask_causal = tl.load(mask_ptr + offsets_mask_causal).to(tl.int1)
+    return mask_causal
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_M": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_M": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_M": 128}, num_warps=8, num_stages=2),
+    ],
+    key=["NUM_Q_HEADS", "HEAD_DIM", "PAGE_SIZE"],
+)
+@triton.jit
+def _paged_prefill_fav2_kernel(
+    Q,
+    K_cache,
+    V_cache,
+    Out,
+    aux_mask_ptr,
+    cu_seqlens_q_ptr,
+    seqlens_kv_ptr,
+    block_tables_ptr,
+    stride_qt, stride_qh, stride_qd,
+    stride_kb, stride_kh, stride_kn, stride_kd,
+    stride_vb, stride_vh, stride_vn, stride_vd,
+    stride_ot, stride_oh, stride_od,
+    stride_bt_batch, stride_bt_block,
+    stride_mask_m, stride_mask_n,
+    sm_scale,
+    AUX_MASK_SIZE: tl.constexpr,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    GQA_INTERLEAVE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    USE_AUX_MASK: tl.constexpr,
+):
+    tl.static_assert(HEAD_DIM <= BLOCK_D, "BLOCK_D must be >= HEAD_DIM")
+
+    local_q_block_id = tl.program_id(0)
+    q_head_id = tl.program_id(1)
+    b_id = tl.program_id(2)
+
+    q_start = tl.load(cu_seqlens_q_ptr + b_id).to(tl.int32)
+    q_seq_len = tl.load(cu_seqlens_q_ptr + b_id + 1).to(tl.int32) - q_start
+    kv_seq_len = tl.load(seqlens_kv_ptr + b_id).to(tl.int32)
+
+    q_blk_start = local_q_block_id * BLOCK_M
+    if q_blk_start >= q_seq_len:
+        return
+
+    if GQA_INTERLEAVE:
+        kv_head_id = q_head_id % NUM_KV_HEADS
+    else:
+        kv_head_id = q_head_id // (NUM_Q_HEADS // NUM_KV_HEADS)
+
+    q_blk_end = tl.minimum(q_blk_start + BLOCK_M, q_seq_len)
+    q_blk_len = q_blk_end - q_blk_start
+
+    Q_blk_ptr = tl.make_block_ptr(
+        base=Q + (q_start + q_blk_start) * stride_qt + q_head_id * stride_qh,
+        shape=(q_blk_len, HEAD_DIM),
+        strides=(stride_qt, stride_qd),
+        offsets=(0, 0),
+        block_shape=(BLOCK_M, BLOCK_D),
+        order=(1, 0),
+    )
+    q = tl.load(Q_blk_ptr, boundary_check=(0, 1), padding_option="zero")
+
+    m_i = tl.zeros((BLOCK_M,), dtype=tl.float32) - float("inf")
+    l_i = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_M, BLOCK_D), dtype=tl.float32)
+
+    kv_cache_len = kv_seq_len - q_seq_len
+
+    if IS_CAUSAL:
+        kv_loop_end = tl.minimum(kv_seq_len, q_blk_end + kv_cache_len)
+    else:
+        kv_loop_end = kv_seq_len
+
+    num_kv_pages = tl.cdiv(kv_loop_end, PAGE_SIZE)
+    num_full_pages = kv_seq_len // PAGE_SIZE
+    num_full_pages = tl.minimum(num_full_pages, num_kv_pages)
+
+    qk_scale = sm_scale * LOG2E
+
+    for page_idx in tl.range(0, num_full_pages):
+        physical_block = tl.load(
+            block_tables_ptr + b_id * stride_bt_batch + page_idx * stride_bt_block
+        )
+
+        K_T_blk_ptr = tl.make_block_ptr(
+            base=K_cache + physical_block * stride_kb + kv_head_id * stride_kh,
+            shape=(HEAD_DIM, PAGE_SIZE),
+            strides=(stride_kd, stride_kn),
+            offsets=(0, 0),
+            block_shape=(BLOCK_D, BLOCK_N),
+            order=(0, 1),
+        )
+        V_blk_ptr = tl.make_block_ptr(
+            base=V_cache + physical_block * stride_vb + kv_head_id * stride_vh,
+            shape=(PAGE_SIZE, HEAD_DIM),
+            strides=(stride_vn, stride_vd),
+            offsets=(0, 0),
+            block_shape=(BLOCK_N, BLOCK_D),
+            order=(1, 0),
+        )
+
+        for kv_inner_idx in tl.range(0, PAGE_SIZE // BLOCK_N):
+            kv_blk_start = page_idx * PAGE_SIZE + kv_inner_idx * BLOCK_N
+
+            if HEAD_DIM == BLOCK_D:
+                k_T = tl.load(K_T_blk_ptr)
+                v = tl.load(V_blk_ptr)
+            else:
+                k_T = tl.load(K_T_blk_ptr, boundary_check=(0,), padding_option="zero")
+                v = tl.load(V_blk_ptr, boundary_check=(1,), padding_option="zero")
+
+            qk = tl.dot(q, k_T)
+            qk = qk * qk_scale
+
+            if IS_CAUSAL:
+                if USE_AUX_MASK:
+                    mask = causal_mask_fn(
+                        aux_mask_ptr,
+                        AUX_MASK_SIZE,
+                        stride_mask_m,
+                        stride_mask_n,
+                        kv_cache_len + q_blk_start,
+                        kv_blk_start,
+                        BLOCK_M,
+                        BLOCK_N,
+                    )
+                    qk = tl.where(mask, qk, float("-inf"))
+                else:
+                    offs_m = q_blk_start + tl.arange(0, BLOCK_M)
+                    offs_n = kv_blk_start + tl.arange(0, BLOCK_N)
+                    causal_mask = (offs_m[:, None] + kv_cache_len) >= offs_n[None, :]
+                    qk = tl.where(causal_mask, qk, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            alpha = tl.math.exp2(m_i - m_ij)
+            p = tl.math.exp2(qk - m_ij[:, None])
+
+            acc = acc * alpha[:, None]
+            acc = tl.dot(p.to(K_cache.dtype.element_ty), v, acc=acc)
+
+            l_i = l_i * alpha + tl.sum(p, 1)
+            m_i = m_ij
+
+            K_T_blk_ptr = tl.advance(K_T_blk_ptr, (0, BLOCK_N))
+            V_blk_ptr = tl.advance(V_blk_ptr, (BLOCK_N, 0))
+
+    for page_idx in tl.range(num_full_pages, num_kv_pages):
+        kv_page_start = page_idx * PAGE_SIZE
+        kv_blk_end = tl.minimum(kv_page_start + PAGE_SIZE, kv_seq_len)
+        kv_blk_len = kv_blk_end - kv_page_start
+
+        physical_block = tl.load(
+            block_tables_ptr + b_id * stride_bt_batch + page_idx * stride_bt_block
+        )
+
+        K_T_blk_ptr = tl.make_block_ptr(
+            base=K_cache + physical_block * stride_kb + kv_head_id * stride_kh,
+            shape=(HEAD_DIM, kv_blk_len),
+            strides=(stride_kd, stride_kn),
+            offsets=(0, 0),
+            block_shape=(BLOCK_D, BLOCK_N),
+            order=(0, 1),
+        )
+        V_blk_ptr = tl.make_block_ptr(
+            base=V_cache + physical_block * stride_vb + kv_head_id * stride_vh,
+            shape=(kv_blk_len, HEAD_DIM),
+            strides=(stride_vn, stride_vd),
+            offsets=(0, 0),
+            block_shape=(BLOCK_N, BLOCK_D),
+            order=(1, 0),
+        )
+
+        num_inner_blocks = tl.cdiv(kv_blk_len, BLOCK_N)
+        for kv_inner_idx in tl.range(0, num_inner_blocks):
+            kv_blk_start = kv_page_start + kv_inner_idx * BLOCK_N
+
+            k_T = tl.load(K_T_blk_ptr, boundary_check=(0, 1), padding_option="zero")
+            v = tl.load(V_blk_ptr, boundary_check=(0, 1), padding_option="zero")
+
+            qk = tl.dot(q, k_T)
+            qk = qk * qk_scale
+
+            if IS_CAUSAL:
+                if USE_AUX_MASK:
+                    mask = causal_mask_fn(
+                        aux_mask_ptr,
+                        AUX_MASK_SIZE,
+                        stride_mask_m,
+                        stride_mask_n,
+                        kv_cache_len + q_blk_start,
+                        kv_blk_start,
+                        BLOCK_M,
+                        BLOCK_N,
+                    )
+                    qk = tl.where(mask, qk, float("-inf"))
+                else:
+                    offs_m = q_blk_start + tl.arange(0, BLOCK_M)
+                    offs_n = kv_blk_start + tl.arange(0, BLOCK_N)
+                    causal_mask = (offs_m[:, None] + kv_cache_len) >= offs_n[None, :]
+                    qk = tl.where(causal_mask, qk, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            alpha = tl.math.exp2(m_i - m_ij)
+            p = tl.math.exp2(qk - m_ij[:, None])
+
+            acc = acc * alpha[:, None]
+            acc = tl.dot(p.to(K_cache.dtype.element_ty), v, acc=acc)
+
+            l_i = l_i * alpha + tl.sum(p, 1)
+            m_i = m_ij
+
+            K_T_blk_ptr = tl.advance(K_T_blk_ptr, (0, BLOCK_N))
+            V_blk_ptr = tl.advance(V_blk_ptr, (BLOCK_N, 0))
+
+    l_i = tl.maximum(l_i, 1e-6)
+    acc = acc / l_i[:, None]
+
+    O_blk_ptr = tl.make_block_ptr(
+        base=Out + (q_start + q_blk_start) * stride_ot + q_head_id * stride_oh,
+        shape=(q_blk_len, HEAD_DIM),
+        strides=(stride_ot, stride_od),
+        offsets=(0, 0),
+        block_shape=(BLOCK_M, BLOCK_D),
+        order=(1, 0),
+    )
+    tl.store(O_blk_ptr, acc.to(Out.dtype.element_ty), boundary_check=(0, 1))
 
 
 @libentry()
@@ -154,6 +401,118 @@ def _launch_causal_attn_triton(
     )
 
 
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_N": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_N": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_N": 128}, num_warps=8, num_stages=2),
+    ],
+    key=["HQ", "D", "PAGE_SIZE"],
+)
+@libentry()
+@triton.jit
+def _paged_decode_gqa_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    o_ptr,
+    seqlens_ptr,
+    block_tables_ptr,
+    stride_qb,
+    stride_qh,
+    stride_qd,
+    stride_k_block,
+    stride_k_head,
+    stride_k_blksz,
+    stride_k_dim,
+    stride_v_block,
+    stride_v_head,
+    stride_v_blksz,
+    stride_v_dim,
+    stride_ob,
+    stride_oh,
+    stride_od,
+    stride_bt_batch,
+    stride_bt_block,
+    HQ,
+    HKV,
+    D,
+    GROUP,
+    SOFTMAX_SCALE,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    GQA_LAYOUT: tl.constexpr,
+    OUT_T: tl.constexpr,
+):
+    pid_b = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    if pid_h >= HQ:
+        return
+
+    seq_len = tl.load(seqlens_ptr + pid_b).to(tl.int32)
+    kv_h = tl.where(GQA_LAYOUT == 0, pid_h % HKV, pid_h // GROUP)
+
+    offs_d = tl.arange(0, BLOCK_D)
+    d_mask = offs_d < D
+
+    q_ptrs = q_ptr + pid_b * stride_qb + pid_h * stride_qh + offs_d * stride_qd
+    q = tl.load(q_ptrs, mask=d_mask, other=0.0)
+
+    neg_inf = -1.0e30
+    m = tl.full((1,), neg_inf, tl.float32)
+    l = tl.zeros((1,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    num_blocks = tl.cdiv(seq_len, BLOCK_N)
+    for block_idx in tl.range(0, num_blocks):
+        start_n = block_idx * BLOCK_N
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        s_mask = offs_n < seq_len
+
+        logical_block_idx = offs_n // PAGE_SIZE
+        offset_in_block = offs_n % PAGE_SIZE
+        physical_block_id = tl.load(
+            block_tables_ptr + pid_b * stride_bt_batch + logical_block_idx * stride_bt_block,
+            mask=s_mask,
+            other=0,
+        )
+
+        k_ptrs = (
+            k_cache_ptr
+            + physical_block_id[:, None] * stride_k_block
+            + kv_h * stride_k_head
+            + offset_in_block[:, None] * stride_k_blksz
+            + offs_d[None, :] * stride_k_dim
+        )
+        v_ptrs = (
+            v_cache_ptr
+            + physical_block_id[:, None] * stride_v_block
+            + kv_h * stride_v_head
+            + offset_in_block[:, None] * stride_v_blksz
+            + offs_d[None, :] * stride_v_dim
+        )
+        k = tl.load(k_ptrs, mask=s_mask[:, None] & d_mask[None, :], other=0.0)
+        v = tl.load(v_ptrs, mask=s_mask[:, None] & d_mask[None, :], other=0.0)
+        scores = tl.sum(k * q[None, :], axis=1) * SOFTMAX_SCALE
+        scores = tl.where(s_mask, scores, neg_inf)
+        m_new = tl.maximum(m, tl.max(scores, axis=0))
+        alpha = tl.math.exp(m - m_new)
+        p = tl.where(s_mask, tl.math.exp(scores - m_new), 0.0)
+        l = l * alpha + tl.sum(p, axis=0)
+        acc = acc * alpha + tl.sum(p[:, None] * v.to(tl.float32), axis=0)
+        m = m_new
+
+    l = tl.maximum(l, 1e-6)
+    out = acc / l
+    out_ptrs = o_ptr + pid_b * stride_ob + pid_h * stride_oh + offs_d * stride_od
+    tl.store(out_ptrs, out.to(OUT_T), mask=d_mask)
+
+
 def paged_attention_prefill_impl(
     q: torch.Tensor,
     key_cache: torch.Tensor,
@@ -165,68 +524,70 @@ def paged_attention_prefill_impl(
     softmax_scale: Optional[float] = None,
     aux_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
-    del aux_mask
-
     total_q_tokens, num_q_heads, head_dim = q.shape
     _, num_kv_heads, block_size, _ = key_cache.shape
-    if softmax_scale is None:
-        softmax_scale = 1.0 / math.sqrt(head_dim)
+    batch_size = cu_seqlens_q.shape[0] - 1
 
-    outputs = torch.zeros(total_q_tokens, num_q_heads, head_dim, dtype=q.dtype, device=q.device)
+    sm_scale = softmax_scale if softmax_scale is not None else 1.0 / math.sqrt(head_dim)
 
-    q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-    batch_size = len(q_lens)
+    if seqlens_kv is None:
+        seqlens_kv = (cu_seqlens_q[1:] - cu_seqlens_q[:-1]).to(torch.int32)
+    else:
+        seqlens_kv = seqlens_kv.to(torch.int32)
 
-    for i in range(batch_size):
-        q_seq_len = q_lens[i].item()
-        start_loc = cu_seqlens_q[i].item()
-        end_loc = cu_seqlens_q[i + 1].item()
-        q_batch = q[start_loc:end_loc].contiguous()
-        if seqlens_kv is None:
-            kv_seq_len = q_seq_len
-        else:
-            kv_seq_len = seqlens_kv[i].item()
+    use_aux_mask = aux_mask is not None
 
-        num_blocks_for_seq = (kv_seq_len + block_size - 1) // block_size
-        k_unpadded = torch.zeros(kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device)
-        v_unpadded = torch.zeros(kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device)
+    out = torch.empty_like(q)
+    block_tables_i32 = block_tables.to(torch.int32)
 
-        for j in range(num_blocks_for_seq):
-            physical_block_id = block_tables[i, j].item()
+    BLOCK_D = triton.next_power_of_2(head_dim)
 
-            start_pos_in_seq = j * block_size
-            end_pos_in_seq = min(start_pos_in_seq + block_size, kv_seq_len)
-            tokens_in_block = end_pos_in_seq - start_pos_in_seq
+    if use_aux_mask:
+        mask_ptr = aux_mask
+        mask_stride_m = aux_mask.stride(0)
+        mask_stride_n = aux_mask.stride(1)
+        mask_size = aux_mask.shape[0]
+    else:
+        mask_ptr = q
+        mask_stride_m = 0
+        mask_stride_n = 0
+        mask_size = 0
 
-            k_slice = key_cache[physical_block_id, :, :tokens_in_block, :]
-            k_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = k_slice.permute(1, 0, 2)
+    def grid(META):
+        bm = META["BLOCK_M"]
+        q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        max_q_blocks = ((q_lens + bm - 1) // bm).max().item()
+        return (max_q_blocks, num_q_heads, batch_size)
 
-            v_slice = value_cache[physical_block_id, :, :tokens_in_block, :]
-            v_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = v_slice.permute(1, 0, 2)
+    _paged_prefill_fav2_kernel[grid](
+        q,
+        key_cache,
+        value_cache,
+        out,
+        mask_ptr,
+        cu_seqlens_q,
+        seqlens_kv,
+        block_tables_i32,
+        q.stride(0), q.stride(1), q.stride(2),
+        key_cache.stride(0), key_cache.stride(1), key_cache.stride(2), key_cache.stride(3),
+        value_cache.stride(0), value_cache.stride(1), value_cache.stride(2), value_cache.stride(3),
+        out.stride(0), out.stride(1), out.stride(2),
+        block_tables_i32.stride(0), block_tables_i32.stride(1),
+        mask_stride_m, mask_stride_n,
+        float(sm_scale),
+        AUX_MASK_SIZE=mask_size,
+        NUM_Q_HEADS=num_q_heads,
+        NUM_KV_HEADS=num_kv_heads,
+        GQA_INTERLEAVE=gqa_interleave,
+        HEAD_DIM=head_dim,
+        BLOCK_D=BLOCK_D,
+        PAGE_SIZE=block_size,
+        BLOCK_N=min(block_size, 128),
+        IS_CAUSAL=True,
+        USE_AUX_MASK=use_aux_mask,
+    )
 
-        if num_q_heads != num_kv_heads:
-            g = num_q_heads // num_kv_heads
-            # repeat: head dim becomes [kv_0..kv_{K-1}] tiled g times → aligns with decode
-            #   kv_head_id = q_head_id % num_kv_heads when gqa_interleave / GQA_INTERLEAVE.
-            # repeat_interleave: each kv head repeated g times in order → aligns with
-            #   kv_head_id = q_head_id // g when not interleaved. See module docstring.
-            if gqa_interleave:
-                k_expanded = k_unpadded.repeat((1, g, 1))
-                v_expanded = v_unpadded.repeat((1, g, 1))
-            else:
-                k_expanded = k_unpadded.repeat_interleave(g, dim=1)
-                v_expanded = v_unpadded.repeat_interleave(g, dim=1)
-        else:
-            k_expanded = k_unpadded
-            v_expanded = v_unpadded
-
-        k_expanded = k_expanded.contiguous()
-        v_expanded = v_expanded.contiguous()
-        out_slice = torch.empty_like(q_batch)
-        _launch_causal_attn_triton(q_batch, k_expanded, v_expanded, out_slice, softmax_scale, q_seq_len, kv_seq_len)
-        outputs[start_loc:end_loc] = out_slice
-
-    return outputs
+    return out
 
 
 def _paged_decode_gather_and_causal(
@@ -238,59 +599,60 @@ def _paged_decode_gather_and_causal(
     gqa_interleave: bool,
     softmax_scale: float,
 ) -> torch.Tensor:
-    """ILU paged decode: unpage KV + causal attention (one query token per batch row)."""
+    """ILU paged decode: direct paged KV Triton, one Q token per batch row."""
     batch_size, num_q_heads, head_dim = q.shape
-    _, num_kv_heads, block_size, _ = key_cache.shape
-    o = torch.zeros_like(q)
+    _, num_kv_heads, page_size, head_dim_cache = key_cache.shape
 
-    for i in range(batch_size):
-        kv_seq_len = int(seqlens[i].item())
-        if kv_seq_len <= 0 or int(block_tables[i, 0].item()) < 0:
-            continue
-        q_batch = q[i : i + 1].contiguous()
-        num_blocks_for_seq = (kv_seq_len + block_size - 1) // block_size
+    assert head_dim == head_dim_cache
+    group = num_q_heads // num_kv_heads
+    o = torch.empty_like(q)
+    block_d = triton.next_power_of_2(head_dim)
+    layout_id = 0 if gqa_interleave else 1
 
-        k_unpadded = torch.zeros(
-            kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device
-        )
-        v_unpadded = torch.zeros(
-            kv_seq_len, num_kv_heads, head_dim, dtype=q.dtype, device=q.device
-        )
+    if q.dtype == torch.float16:
+        out_t = tl.float16
+    elif q.dtype == torch.bfloat16:
+        out_t = tl.bfloat16
+    else:
+        out_t = tl.float32
 
-        for j in range(num_blocks_for_seq):
-            physical_block_id = int(block_tables[i, j].item())
-            if physical_block_id < 0:
-                break
-            start_pos_in_seq = j * block_size
-            end_pos_in_seq = min(start_pos_in_seq + block_size, kv_seq_len)
-            tokens_in_block = end_pos_in_seq - start_pos_in_seq
+    seqlens_i32 = seqlens.to(torch.int32)
+    block_tables_i32 = block_tables.to(torch.int32)
 
-            k_slice = key_cache[physical_block_id, :, :tokens_in_block, :]
-            k_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = k_slice.permute(1, 0, 2)
-
-            v_slice = value_cache[physical_block_id, :, :tokens_in_block, :]
-            v_unpadded[start_pos_in_seq:end_pos_in_seq, :, :] = v_slice.permute(1, 0, 2)
-
-        if num_q_heads != num_kv_heads:
-            g = num_q_heads // num_kv_heads
-            if gqa_interleave:
-                k_expanded = k_unpadded.repeat((1, g, 1))
-                v_expanded = v_unpadded.repeat((1, g, 1))
-            else:
-                k_expanded = k_unpadded.repeat_interleave(g, dim=1)
-                v_expanded = v_unpadded.repeat_interleave(g, dim=1)
-        else:
-            k_expanded = k_unpadded
-            v_expanded = v_unpadded
-
-        k_expanded = k_expanded.contiguous()
-        v_expanded = v_expanded.contiguous()
-        out_slice = torch.empty_like(q_batch)
-        _launch_causal_attn_triton(
-            q_batch, k_expanded, v_expanded, out_slice, softmax_scale, 1, kv_seq_len
-        )
-        o[i] = out_slice[0]
-
+    grid = (batch_size, num_q_heads)
+    _paged_decode_gqa_kernel[grid](
+        q,
+        key_cache,
+        value_cache,
+        o,
+        seqlens_i32,
+        block_tables_i32,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        key_cache.stride(0),
+        key_cache.stride(1),
+        key_cache.stride(2),
+        key_cache.stride(3),
+        value_cache.stride(0),
+        value_cache.stride(1),
+        value_cache.stride(2),
+        value_cache.stride(3),
+        o.stride(0),
+        o.stride(1),
+        o.stride(2),
+        block_tables_i32.stride(0),
+        block_tables_i32.stride(1),
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+        group,
+        float(softmax_scale),
+        BLOCK_D=block_d,
+        PAGE_SIZE=page_size,
+        GQA_LAYOUT=layout_id,
+        OUT_T=out_t,
+    )
     return o
 
 

--- a/mojo_opset/backends/ttx/kernels/ilu/group_gemm.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/group_gemm.py
@@ -39,48 +39,80 @@ def grouped_launch_diagonal(pid, num_pid_m, num_pid_n, BLOCK_TRESHHOLD: tl.const
     return task_m_idx, task_n_idx
 
 
+def m_grouped_matmul_autotune_config():
+    configs = []
+    for BM, BN, nw in [
+        (64, 64, 4), (64, 128, 4), (128, 64, 4),
+        (128, 128, 8), (128, 256, 8), (256, 128, 8),
+    ]:
+        for BK in [32, 64, 128]:
+            for ns in [2, 3]:
+                configs.append(triton.Config(
+                    {"BLOCK_M": BM, "BLOCK_N": BN, "BLOCK_K": BK},
+                    num_warps=nw, num_stages=ns,
+                ))
+    return configs
+
+
+@triton.autotune(configs=m_grouped_matmul_autotune_config(), key=["N", "K", "MAX_M"])
 @triton.jit
-def _group_matmul_kernel(
+def _m_grouped_matmul_kernel(
     A,
     B,
     C,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
+    group_offsets_ptr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    MAX_M,
+    stride_bg,
+    strideBK,
+    strideBN,
+    TRANS_B: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)
-    num_pid_n = tl.cdiv(N, BLOCK_N)
-    pid_m = pid // num_pid_n
-    pid_n = pid % num_pid_n
+    n_tile_id = tl.program_id(0)
+    m_tile_id = tl.program_id(1)
+    group_id = tl.program_id(2)
 
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    if m_tile_id * BLOCK_M >= MAX_M:
+        return
+
+    group_start = tl.load(group_offsets_ptr + group_id).to(tl.int32)
+    group_end = tl.load(group_offsets_ptr + group_id + 1).to(tl.int32)
+    m_g = group_end - group_start
+
+    if m_tile_id * BLOCK_M >= m_g:
+        return
+
+    offs_m = group_start + m_tile_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = n_tile_id * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_k = tl.arange(0, BLOCK_K)
 
-    a_ptrs = A + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
-    b_ptrs = B + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    a_ptrs = A + offs_m[:, None] * K + offs_k[None, :]
+    b_base = B + group_id * stride_bg
+    if TRANS_B:
+        b_ptrs = b_base + offs_n[:, None] * strideBN + offs_k[None, :] * strideBK
+    else:
+        b_ptrs = b_base + offs_k[:, None] * strideBK + offs_n[None, :] * strideBN
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
     for k0 in range(0, tl.cdiv(K, BLOCK_K)):
         k_mask = offs_k < (K - k0 * BLOCK_K)
-        a = tl.load(a_ptrs, mask=(offs_m[:, None] < M) & k_mask[None, :], other=0.0)
-        b = tl.load(b_ptrs, mask=k_mask[:, None] & (offs_n[None, :] < N), other=0.0)
+        a = tl.load(a_ptrs, mask=(offs_m[:, None] < group_end) & k_mask[None, :], other=0.0)
+        if TRANS_B:
+            b = tl.load(b_ptrs, mask=(offs_n[:, None] < N) & k_mask[None, :], other=0.0)
+            b = tl.trans(b)
+        else:
+            b = tl.load(b_ptrs, mask=k_mask[:, None] & (offs_n[None, :] < N), other=0.0)
         acc = tl.dot(a, b, acc=acc)
-        a_ptrs += BLOCK_K * stride_ak
-        b_ptrs += BLOCK_K * stride_bk
+        a_ptrs += BLOCK_K
+        b_ptrs += BLOCK_K * strideBK
 
     c = acc.to(C.dtype.element_ty)
-    c_ptrs = C + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
-    c_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    c_ptrs = C + offs_m[:, None] * N + offs_n[None, :]
+    c_mask = (offs_m[:, None] < group_end) & (offs_n[None, :] < N)
     tl.store(c_ptrs, c, mask=c_mask)
 
 
@@ -97,112 +129,98 @@ def m_grouped_matmul_impl(
     strideBK: int,
     trans_b: bool = False,
 ) -> torch.Tensor:
-    """Per-group matmul via ``_group_matmul_kernel`` (Triton).
+    cum = size_per_group.cumsum(0, dtype=torch.int32)
+    group_offsets = torch.zeros(num_groups + 1, dtype=torch.int32, device=A.device)
+    group_offsets[1:] = cum
+    max_m = size_per_group.max().item()
 
-    ``trans_b`` matches ``TTXGroupGemm`` (``not trans_weight``): weight storage is ``(G, K, N)``
-    when True and ``(G, N, K)`` when False. Each group uses ``B_g`` with shape ``(K, N)``.
-    ``strideBN`` / ``strideBK`` match the NPU/TTX custom-op signature but are unused here
-    (strides come from ``A_g`` / ``B_g`` slices).
-    """
-    _ = (strideBN, strideBK, num_groups, M)
-    BLOCK_M = 64
-    BLOCK_N = 64
-    BLOCK_K = 32
-
-    group_start = size_per_group.cumsum(0) - size_per_group
-    group_end = size_per_group.cumsum(0)
-    for g, (start, end) in enumerate(zip(group_start.tolist(), group_end.tolist())):
-        m_g = end - start
-        if m_g <= 0:
-            continue
-
-        A_g = A.narrow(0, start, m_g)
-        if trans_b:
-            B_g = B[g]
-        else:
-            B_g = B[g].transpose(0, 1).contiguous()
-        C_g = C.narrow(0, start, m_g)
-        grid = (triton.cdiv(m_g, BLOCK_M) * triton.cdiv(N, BLOCK_N),)
-        _group_matmul_kernel[grid](
-            A_g,
-            B_g,
-            C_g,
-            m_g,
-            N,
-            K,
-            A_g.stride(0),
-            A_g.stride(1),
-            B_g.stride(0),
-            B_g.stride(1),
-            C_g.stride(0),
-            C_g.stride(1),
-            BLOCK_M=BLOCK_M,
-            BLOCK_N=BLOCK_N,
-            BLOCK_K=BLOCK_K,
+    def grid(META):
+        return (
+            triton.cdiv(N, META["BLOCK_N"]),
+            triton.cdiv(max_m, META["BLOCK_M"]),
+            num_groups,
         )
+
+    _m_grouped_matmul_kernel[grid](
+        A,
+        B,
+        C,
+        group_offsets,
+        N,
+        K,
+        max_m,
+        B.stride(0),
+        strideBK,
+        strideBN,
+        trans_b,
+    )
     return C
 
 
+def k_grouped_matmul_autotune_config():
+    configs = []
+    for BM, BN, nw in [
+        (64, 64, 4), (64, 128, 4), (128, 64, 4),
+        (128, 128, 8), (128, 256, 8), (256, 128, 8),
+    ]:
+        for BK in [32, 64, 128]:
+            for ns in [2, 3]:
+                configs.append(triton.Config(
+                    {"BLOCK_M": BM, "BLOCK_N": BN, "BLOCK_K": BK},
+                    num_warps=nw, num_stages=ns,
+                ))
+    return configs
+
+
+@triton.autotune(configs=k_grouped_matmul_autotune_config(), key=["M", "N"])
 @triton.jit
 def _k_grouped_matmul_kernel(
     A,
     B,
     C,
-    group_size_ptr,
-    num_groups: tl.constexpr,
+    group_offsets_ptr,
     M: tl.constexpr,
     N: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
-    BLOCK_TRESHHOLD: tl.constexpr,
 ):
-    total_cores = tl.num_programs(axis=0)
-    core_idx = tl.program_id(axis=0)
-    last_count = 0
-    group_start = 0
-    group_end = 0
-    num_block_m = tl.cdiv(M, BLOCK_M)
-    num_block_n = tl.cdiv(N, BLOCK_N)
-    blocks_per_group = num_block_m * num_block_n
-    # group_size_k = tl.load(group_size_ptr + tl.arange(0, num_groups)).to(tl.int32)
-    for group_idx in range(num_groups):
-        # k = tl.extract_slice(group_size_k, [group_idx], [1], [1])
-        tokens = tl.load(group_size_ptr + group_idx).to(tl.int32)
-        group_end = group_start + tokens
-        cur_count = last_count + blocks_per_group
-        cur_block = core_idx if core_idx >= last_count else (core_idx + total_cores)
-        for cur_block in range(cur_block, cur_count, total_cores):
-            task_m_idx, task_n_idx = grouped_launch_diagonal(
-                cur_block - last_count, num_block_m, num_block_n, BLOCK_TRESHHOLD
-            )
-            # matmul begin
-            offs_am = task_m_idx * BLOCK_M + tl.arange(0, BLOCK_M)
-            offs_bn = task_n_idx * BLOCK_N + tl.arange(0, BLOCK_N)
-            offs_k = group_start + tl.arange(0, BLOCK_K)
-            a_ptrs_base = A + offs_k[:, None] * M + offs_am[None, :]
-            b_ptrs_base = B + offs_k[:, None] * N + offs_bn[None, :]
-            msk_m = offs_am < M
-            msk_n = offs_bn < N
-            accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-            for kk in tl.range(0, tl.cdiv(tokens, BLOCK_K)):
-                a_ptrs = a_ptrs_base + kk * BLOCK_K * M
-                b_ptrs = b_ptrs_base + kk * BLOCK_K * N
-                a = tl.load(a_ptrs, mask=(offs_k[:, None] < group_end - kk * BLOCK_K) and msk_m[None, :], other=0.0)
-                aa = tl.trans(a)
-                b = tl.load(b_ptrs, mask=(offs_k[:, None] < group_end - kk * BLOCK_K) and msk_n[None, :], other=0.0)
-                accumulator = tl.dot(aa, b, acc=accumulator)
+    n_tile_id = tl.program_id(0)
+    m_tile_id = tl.program_id(1)
+    group_id = tl.program_id(2)
 
-            c = accumulator.to(C.dtype.element_ty)
-            offs_cm = group_idx * M + task_m_idx * BLOCK_M + tl.arange(0, BLOCK_M)
-            offs_cn = task_n_idx * BLOCK_N + tl.arange(0, BLOCK_N)
-            c_ptrs = C + offs_cm[:, None] * N + offs_cn[None, :]
-            c_mask = (offs_cm[:, None] < (group_idx + 1) * M) and (offs_cn[None, :] < N)
-            tl.store(c_ptrs, c, mask=c_mask)
-            # matmul_end
-            # cur_block = cur_block + total_cores
-        last_count = cur_count % total_cores
-        group_start = group_end
+    group_start = tl.load(group_offsets_ptr + group_id).to(tl.int32)
+    group_end = tl.load(group_offsets_ptr + group_id + 1).to(tl.int32)
+    k_g = group_end - group_start
+
+    offs_m = m_tile_id * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = n_tile_id * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+    msk_m = offs_m < M
+    msk_n = offs_n < N
+
+    # A: [total_K, M] row-major, load [BLOCK_K, BLOCK_M] then transpose
+    a_ptrs = A + (group_start + offs_k)[:, None] * M + offs_m[None, :]
+    # B: [total_K, N] row-major, load [BLOCK_K, BLOCK_N]
+    b_ptrs = B + (group_start + offs_k)[:, None] * N + offs_n[None, :]
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    num_k_iters = (k_g + BLOCK_K - 1) // BLOCK_K
+
+    for k0 in tl.range(0, num_k_iters):
+        k_mask = offs_k < (k_g - k0 * BLOCK_K)
+        a = tl.load(a_ptrs, mask=k_mask[:, None] & msk_m[None, :], other=0.0)
+        a = tl.trans(a)
+        b = tl.load(b_ptrs, mask=k_mask[:, None] & msk_n[None, :], other=0.0)
+        acc = tl.dot(a, b, acc=acc)
+        a_ptrs += BLOCK_K * M
+        b_ptrs += BLOCK_K * N
+
+    c = acc.to(C.dtype.element_ty)
+    offs_cm = group_id * M + offs_m
+    c_ptrs = C + offs_cm[:, None] * N + offs_n[None, :]
+    c_mask = msk_m[:, None] & msk_n[None, :]
+    tl.store(c_ptrs, c, mask=c_mask)
 
 
 def k_grouped_matmul_impl(
@@ -214,28 +232,16 @@ def k_grouped_matmul_impl(
     M: int,
     N: int,
 ) -> torch.Tensor:
-    BLOCK_M = 64
-    BLOCK_N = 64
-    BLOCK_K = 64
-    BLOCK_TRESHHOLD = 4
+    cum = size_per_group.cumsum(0, dtype=torch.int32)
+    group_offsets = torch.zeros(num_groups + 1, dtype=torch.int32, device=A.device)
+    group_offsets[1:] = cum
 
-    n_tiles = num_groups * triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
-    if n_tiles == 0:
-        return C
-    BLOCK = max(1, triton.cdiv(n_tiles, _TARGET_GRID_PROGRAMS))
-    grid = (triton.cdiv(n_tiles, BLOCK),)
+    def grid(META):
+        return (
+            triton.cdiv(N, META["BLOCK_N"]),
+            triton.cdiv(M, META["BLOCK_M"]),
+            num_groups,
+        )
 
-    _k_grouped_matmul_kernel[grid](
-        A,
-        B,
-        C,
-        size_per_group,
-        num_groups,
-        M,
-        N,
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
-        BLOCK_K=BLOCK_K,
-        BLOCK_TRESHHOLD=BLOCK_TRESHHOLD,
-    )
+    _k_grouped_matmul_kernel[grid](A, B, C, group_offsets, M, N)
     return C

--- a/mojo_opset/backends/ttx/kernels/ilu/swa.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/swa.py
@@ -44,6 +44,26 @@ def _expand_kv_heads(x: torch.Tensor, num_q_heads: int, num_kv_heads: int, gqa_i
     return x.repeat_interleave(repeat, dim=1)
 
 
+def _swa_infer_autotune_configs() -> list[triton.Config]:
+    return [
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 64}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128}, num_warps=8, num_stages=1),
+    ]
+
+
+def _swa_paged_prefill_autotune_configs() -> list[triton.Config]:
+    return [
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 128}, num_warps=8, num_stages=1),
+    ]
+
+
 @libentry()
 @triton.jit
 def _swa_masked_fwd_kernel(
@@ -213,6 +233,44 @@ def _swa_acc_fwd_mxn(
 
 @libentry()
 @triton.jit
+def _swa_acc_fwd_nomask_mxn(
+    acc_ptr,
+    l_i,
+    m_i,
+    q,
+    k_block_ptr,
+    v_block_ptr,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    k = tl.load(k_block_ptr, boundary_check=(0, 1), padding_option="zero")
+    qk = tl.dot(q, tl.trans(k))
+    qk = qk * qk_scale
+
+    m_ij = tl.maximum(m_i, tl.max(qk, 1))
+    qk = qk - m_ij[:, None]
+    p = tl.math.exp(qk)
+    p_cast = p.to(k.dtype)
+
+    v = tl.load(v_block_ptr, boundary_check=(0, 1), padding_option="zero")
+    l_ij = tl.sum(p, 1)
+    alpha = tl.math.exp(m_i - m_ij)
+    l_i = l_i * alpha + l_ij
+    acc_ptr = acc_ptr * alpha[:, None]
+    acc_ptr = tl.dot(p_cast, v, acc_ptr)
+    m_i = m_ij
+    return acc_ptr, l_i, m_i
+
+
+@triton.autotune(
+    configs=_swa_infer_autotune_configs(),
+    key=["HEAD_DIM", "GLOBAL_WINDOW", "LOCAL_WINDOW", "NUM_Q_HEADS", "NUM_KV_HEADS"],
+)
+@libentry()
+@triton.jit
 def _swa_infer_kernel(
     o_ptr,
     q_ptr,
@@ -247,6 +305,8 @@ def _swa_infer_kernel(
 ):
     pid = tl.program_id(0)
     n_programs = tl.num_programs(0)
+    has_global_window = GLOBAL_WINDOW is not None
+    has_local_window = LOCAL_WINDOW is not None
 
     cu_q_chunks = 0
     q_offsets = tl.arange(0, BLOCK_M)
@@ -311,11 +371,17 @@ def _swa_infer_kernel(
                 mask = q_valid[:, None] & kv_valid[None, :]
                 if IS_CAUSAL:
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    global_mask = kv_abs[None, :] < GLOBAL_WINDOW
-                    if LOCAL_WINDOW is not None:
+                    if has_global_window and has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        global_mask = global_mask | local_mask
-                    mask = mask & causal_mask & global_mask
+                        global_mask = kv_abs[None, :] < GLOBAL_WINDOW
+                        mask = mask & causal_mask & (global_mask | local_mask)
+                    elif has_global_window:
+                        mask = mask & causal_mask & (kv_abs[None, :] < GLOBAL_WINDOW)
+                    elif has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
                 k_block_ptr = tl.make_block_ptr(
                     base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
@@ -348,52 +414,188 @@ def _swa_infer_kernel(
                     BLOCK_D,
                 )
 
-            for kv_block_id in range(non_global_window_start_block, num_total_blocks):
-                kv_block_start = kv_block_id * BLOCK_N
-                kv_abs = kv_block_start + kv_offsets
-                kv_valid = kv_abs < kv_seq_len
-                mask = q_valid[:, None] & kv_valid[None, :]
-                if IS_CAUSAL:
+            can_use_nomask_local = IS_CAUSAL and q_block_len == BLOCK_M
+            full_local_start_block = non_global_window_start_block
+            full_local_end_block = non_global_window_start_block - 1
+            if can_use_nomask_local:
+                q_abs_start = q_block_start + kv_computed_len
+                q_abs_end = q_abs_start + BLOCK_M - 1
+                last_causal_full_block = (q_abs_start - (BLOCK_N - 1)) // BLOCK_N
+                first_local_full_block = non_global_window_start_block
+                if has_local_window:
+                    first_local_full_block = tl.maximum(
+                        non_global_window_start_block,
+                        tl.cdiv(tl.maximum(q_abs_end - LOCAL_WINDOW, 0), BLOCK_N),
+                    )
+                full_local_start_block = first_local_full_block
+                full_local_end_block = tl.minimum(num_total_blocks - 1, last_causal_full_block)
+                can_use_nomask_local = full_local_start_block <= full_local_end_block
+
+            if can_use_nomask_local:
+                for kv_block_id in range(non_global_window_start_block, full_local_start_block):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    if LOCAL_WINDOW is not None:
+                    if has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        causal_mask = causal_mask & local_mask
-                    mask = mask & causal_mask
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
-                k_block_ptr = tl.make_block_ptr(
-                    base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
-                    shape=(kv_seq_len, HEAD_DIM),
-                    strides=(stride_kt, stride_kd),
-                    offsets=(kv_block_start.to(tl.int32), 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                v_block_ptr = tl.make_block_ptr(
-                    base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
-                    shape=(kv_seq_len, HEAD_DIM),
-                    strides=(stride_vt, stride_vd),
-                    offsets=(kv_block_start.to(tl.int32), 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                acc, l_i, m_i = _swa_acc_fwd_mxn(
-                    acc,
-                    l_i,
-                    m_i,
-                    q_block,
-                    k_block_ptr,
-                    v_block_ptr,
-                    mask,
-                    scale,
-                    HEAD_DIM,
-                    BLOCK_M,
-                    BLOCK_N,
-                    BLOCK_D,
-                )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
 
-            l_safe = tl.where(q_valid, l_i, 1.0)
-            out_block = acc / tl.where(l_safe[:, None] > 0, l_safe[:, None], 1.0)
-            out_block = tl.where(l_i[:, None] > 0, out_block, 0.0)
+                for kv_block_id in range(full_local_start_block, full_local_end_block + 1):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_nomask_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+                for kv_block_id in range(full_local_end_block + 1, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                    if has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
+
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+            else:
+                for kv_block_id in range(non_global_window_start_block, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    if IS_CAUSAL:
+                        causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                        if has_local_window:
+                            local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                            mask = mask & causal_mask & local_mask
+                        else:
+                            mask = mask & causal_mask
+
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+            l_i_safe = tl.where(l_i > 0, l_i, 1.0)
+            out_block = tl.where(l_i[:, None] > 0, acc / l_i_safe[:, None], 0.0)
             out_block = tl.where(q_valid[:, None], out_block, 0.0)
             o_block_ptr = tl.make_block_ptr(
                 base=o_ptr + q_start * stride_ot + q_head_id * stride_oh,
@@ -406,6 +608,10 @@ def _swa_infer_kernel(
             tl.store(o_block_ptr, out_block.to(o_ptr.type.element_ty), boundary_check=(0, 1))
 
 
+@triton.autotune(
+    configs=_swa_paged_prefill_autotune_configs(),
+    key=["HEAD_DIM", "GLOBAL_WINDOW", "LOCAL_WINDOW", "NUM_Q_HEADS", "NUM_KV_HEADS"],
+)
 @libentry()
 @triton.jit
 def _swa_paged_prefill_kernel(
@@ -449,6 +655,8 @@ def _swa_paged_prefill_kernel(
     tl.static_assert(PAGE_SIZE % BLOCK_N == 0, "BLOCK_N must divide PAGE_SIZE for paged KV tiling")
     pid = tl.program_id(0)
     n_programs = tl.num_programs(0)
+    has_global_window = GLOBAL_WINDOW is not None
+    has_local_window = LOCAL_WINDOW is not None
 
     cu_q_chunks = 0
     q_offsets = tl.arange(0, BLOCK_M)
@@ -510,20 +718,26 @@ def _swa_paged_prefill_kernel(
                 kv_block_len = kv_block_end - kv_block_start
                 logical_page_id = kv_block_start // PAGE_SIZE
                 kv_block_start_in_page = kv_block_start % PAGE_SIZE
-                physical_page_id = tl.load(
-                    block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
-                )
                 kv_abs = kv_block_start + kv_offsets
                 kv_valid = kv_abs < kv_seq_len
                 mask = q_valid[:, None] & kv_valid[None, :]
                 if IS_CAUSAL:
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    global_mask = kv_abs[None, :] < GLOBAL_WINDOW
-                    if LOCAL_WINDOW is not None:
+                    if has_global_window and has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        global_mask = global_mask | local_mask
-                    mask = mask & causal_mask & global_mask
+                        global_mask = kv_abs[None, :] < GLOBAL_WINDOW
+                        mask = mask & causal_mask & (global_mask | local_mask)
+                    elif has_global_window:
+                        mask = mask & causal_mask & (kv_abs[None, :] < GLOBAL_WINDOW)
+                    elif has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
+                physical_page_id = tl.load(
+                    block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                )
                 k_block_ptr = tl.make_block_ptr(
                     base=k_cache_ptr
                     + physical_page_id * stride_kp
@@ -561,64 +775,240 @@ def _swa_paged_prefill_kernel(
                     BLOCK_D,
                 )
 
-            for kv_block_id in range(non_global_window_start_block, num_total_blocks):
-                kv_block_start = kv_block_id * BLOCK_N
-                kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
-                kv_block_len = kv_block_end - kv_block_start
-                logical_page_id = kv_block_start // PAGE_SIZE
-                kv_block_start_in_page = kv_block_start % PAGE_SIZE
-                physical_page_id = tl.load(
-                    block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
-                )
-                kv_abs = kv_block_start + kv_offsets
-                kv_valid = kv_abs < kv_seq_len
-                mask = q_valid[:, None] & kv_valid[None, :]
-                if IS_CAUSAL:
+            can_use_nomask_local = IS_CAUSAL and q_block_len == BLOCK_M
+            full_local_start_block = non_global_window_start_block
+            full_local_end_block = non_global_window_start_block - 1
+            if can_use_nomask_local:
+                q_abs_start = q_block_start + kv_computed_len
+                q_abs_end = q_abs_start + BLOCK_M - 1
+                last_causal_full_block = (q_abs_start - (BLOCK_N - 1)) // BLOCK_N
+                first_local_full_block = non_global_window_start_block
+                if has_local_window:
+                    first_local_full_block = tl.maximum(
+                        non_global_window_start_block,
+                        tl.cdiv(tl.maximum(q_abs_end - LOCAL_WINDOW, 0), BLOCK_N),
+                    )
+                full_local_start_block = first_local_full_block
+                full_local_end_block = tl.minimum(num_total_blocks - 1, last_causal_full_block)
+                can_use_nomask_local = full_local_start_block <= full_local_end_block
+
+            if can_use_nomask_local:
+                for kv_block_id in range(non_global_window_start_block, full_local_start_block):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    if LOCAL_WINDOW is not None:
+                    if has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        causal_mask = causal_mask & local_mask
-                    mask = mask & causal_mask
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
-                k_block_ptr = tl.make_block_ptr(
-                    base=k_cache_ptr
-                    + physical_page_id * stride_kp
-                    + kv_head_id * stride_kh
-                    + kv_block_start_in_page * stride_kt,
-                    shape=(kv_block_len, HEAD_DIM),
-                    strides=(stride_kt, stride_kd),
-                    offsets=(0, 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                v_block_ptr = tl.make_block_ptr(
-                    base=v_cache_ptr
-                    + physical_page_id * stride_vp
-                    + kv_head_id * stride_vh
-                    + kv_block_start_in_page * stride_vt,
-                    shape=(kv_block_len, HEAD_DIM),
-                    strides=(stride_vt, stride_vd),
-                    offsets=(0, 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                acc, l_i, m_i = _swa_acc_fwd_mxn(
-                    acc,
-                    l_i,
-                    m_i,
-                    q_block,
-                    k_block_ptr,
-                    v_block_ptr,
-                    mask,
-                    scale,
-                    HEAD_DIM,
-                    BLOCK_M,
-                    BLOCK_N,
-                    BLOCK_D,
-                )
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
 
-            l_safe = tl.where(q_valid, l_i, 1.0)
-            out_block = acc / l_safe[:, None]
+                for kv_block_id in range(full_local_start_block, full_local_end_block + 1):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_nomask_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+                for kv_block_id in range(full_local_end_block + 1, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                    if has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
+
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+            else:
+                for kv_block_id in range(non_global_window_start_block, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    if IS_CAUSAL:
+                        causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                        if has_local_window:
+                            local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                            mask = mask & causal_mask & local_mask
+                        else:
+                            mask = mask & causal_mask
+
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+            l_i_safe = tl.where(l_i > 0, l_i, 1.0)
+            out_block = tl.where(l_i[:, None] > 0, acc / l_i_safe[:, None], 0.0)
             out_block = tl.where(q_valid[:, None], out_block, 0.0)
             o_block_ptr = tl.make_block_ptr(
                 base=o_ptr + q_start * stride_ot + q_head_id * stride_oh,
@@ -651,11 +1041,12 @@ def swa_infer_impl(
     outputs = torch.empty_like(q)
     batch_size = cu_seqlens_q.shape[0] - 1
     block_d = triton.next_power_of_2(head_dim)
-    block_m = 64 if (q.dtype == torch.float32 or block_d >= 128) else 128
-    block_n = 64
     q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-    total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
-    grid = (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
+
+    def grid(meta):
+        block_m = meta["BLOCK_M"]
+        total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
+        return (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
 
     _swa_infer_kernel[grid](
         outputs,
@@ -685,10 +1076,7 @@ def swa_infer_impl(
         num_kv_heads,
         gqa_interleave,
         head_dim,
-        BLOCK_M=block_m,
-        BLOCK_N=block_n,
         BLOCK_D=block_d,
-        num_stages=1,
     )
     return outputs
 
@@ -722,10 +1110,12 @@ def swa_paged_prefill_impl(
             "use a compatible page size (e.g. power of two, multiple of 128 for large pages)."
         )
     block_d = triton.next_power_of_2(head_dim)
-    block_m = 64 if (q.dtype == torch.float32 or block_d >= 128 or block_n >= 128) else 128
     q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-    total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
-    grid = (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
+
+    def grid(meta):
+        block_m = meta["BLOCK_M"]
+        total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
+        return (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
 
     _swa_paged_prefill_kernel[grid](
         outputs,
@@ -760,11 +1150,9 @@ def swa_paged_prefill_impl(
         num_kv_heads,
         gqa_interleave,
         head_dim,
-        BLOCK_M=block_m,
         BLOCK_N=block_n,
         BLOCK_D=block_d,
         PAGE_SIZE=block_size,
-        num_stages=1,
     )
     return outputs
 
@@ -837,6 +1225,43 @@ def _sdpa_acc_fwd_1xN(
 
     v = tl.load(V_block_ptr, boundary_check=(0, 1), padding_option="zero")
 
+    l_ij = tl.sum(p, axis=0)
+    alpha = tl.math.exp(m_i - m_ij)
+    l_i = l_i * alpha + l_ij
+    acc_ptr = acc_ptr * alpha
+    acc_ptr += tl.sum((p_cast[:, None] * v).to(tl.float32), axis=0)
+
+    m_i = m_ij
+    return acc_ptr, l_i, m_i
+
+
+@triton.jit
+def _sdpa_acc_fwd_1xT(
+    acc_ptr,
+    l_i,
+    m_i,
+    q,
+    k,
+    v,
+    mask,
+    qk_scale,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    fp8_v: tl.constexpr,
+):
+    if mask is False:
+        return acc_ptr, l_i, m_i
+
+    qk = tl.sum((q[None, :] * k).to(tl.float32), axis=1)
+    qk = qk * qk_scale
+    if mask is not None and mask is not True:
+        qk = tl.where(mask, qk, float("-inf"))
+
+    m_ij = tl.maximum(m_i, tl.max(qk, axis=0))
+    qk = qk - m_ij
+    p = tl.math.exp(qk)
+
+    p_cast = p.to(k.dtype)
     l_ij = tl.sum(p, axis=0)
     alpha = tl.math.exp(m_i - m_ij)
     l_i = l_i * alpha + l_ij
@@ -1019,7 +1444,8 @@ def _swa_infer_token_kernel(
                     v_ptr.dtype.element_ty == tl.float8e5,
                 )
 
-            out = acc / l_i
+            l_i_safe = tl.where(l_i > 0, l_i, 1.0)
+            out = tl.where(l_i > 0, acc / l_i_safe, 0.0)
             out_ptrs = o_ptr + (q_start + q_token_id) * stride_ot + q_head_id * stride_oh + offs_d * stride_od
             tl.store(out_ptrs, out.to(o_ptr.dtype.element_ty), mask=offs_d < HEAD_DIM)
 
@@ -1226,7 +1652,8 @@ def _swa_paged_prefill_token_kernel(
                     v_cache_ptr.dtype.element_ty == tl.float8e5,
                 )
 
-            out = acc / l_i
+            l_i_safe = tl.where(l_i > 0, l_i, 1.0)
+            out = tl.where(l_i > 0, acc / l_i_safe, 0.0)
             out_ptrs = o_ptr + (q_start + q_token_id) * stride_ot + q_head_id * stride_oh + offs_d * stride_od
             tl.store(out_ptrs, out.to(o_ptr.dtype.element_ty), mask=offs_d < HEAD_DIM)
 
@@ -1419,9 +1846,268 @@ def _paged_decode_kernel(
                 v_cache_ptr.dtype.element_ty == tl.float8e5,
             )
 
-        # Match torch reference: padded rows (kv_seq_len == 0) keep zero output; avoid acc / 0.
-        if kv_seq_len > 0:
-            acc = acc / l_i
+        l_i_safe = tl.where(l_i > 0, l_i, 1.0)
+        acc = tl.where(l_i > 0, acc / l_i_safe, 0.0)
+
+        o_ptrs = o_ptr + b_id * stride_ob + q_head_id * stride_oh + offs_d * stride_od
+        tl.store(o_ptrs, acc.to(OUT_T), mask=offs_d < HEAD_DIM)
+
+
+@libentry()
+@triton.jit
+def _paged_decode_kernel_tiny_global(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    o_ptr,
+    seqlens_ptr,
+    block_tables_ptr,
+    BATCH_SIZE,
+    NUM_TOTAL_BLOCKS,
+    MAX_NUM_BLOCKS_PER_SEQ,
+    stride_qb,
+    stride_qh,
+    stride_qd,
+    stride_k_block,
+    stride_k_head,
+    stride_k_blksz,
+    stride_k_dim,
+    stride_v_block,
+    stride_v_head,
+    stride_v_blksz,
+    stride_v_dim,
+    stride_ob,
+    stride_oh,
+    stride_od,
+    stride_bt_batch,
+    stride_bt_block,
+    softmax_scale,
+    GLOBAL_WINDOW: tl.constexpr,
+    LOCAL_WINDOW: tl.constexpr,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    GQA_INTERLEAVE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    TINY_GLOBAL_N: tl.constexpr,
+    OUT_T: tl.constexpr,
+):
+    tl.static_assert(HEAD_DIM <= BLOCK_SIZE_D, "HEAD_DIM should be <= BLOCK_SIZE_D")
+    tl.static_assert(PAGE_SIZE <= BLOCK_SIZE_N, "PAGE_SIZE should be <= BLOCK_SIZE_N")
+    tl.static_assert(TINY_GLOBAL_N <= BLOCK_SIZE_N, "TINY_GLOBAL_N should be <= BLOCK_SIZE_N")
+    pid = tl.program_id(0)
+    n_progs = tl.num_programs(0)
+
+    num_tasks = BATCH_SIZE * NUM_Q_HEADS
+
+    for q_task_id in tl.range(pid, num_tasks, n_progs):
+        q_head_id = q_task_id % NUM_Q_HEADS
+        b_id = q_task_id // NUM_Q_HEADS
+        if GQA_INTERLEAVE:
+            kv_head_id = q_head_id % NUM_KV_HEADS
+        else:
+            kv_head_id = q_head_id // (NUM_Q_HEADS // NUM_KV_HEADS)
+
+        kv_seq_len = tl.load(seqlens_ptr + b_id)
+
+        offs_d = tl.arange(0, BLOCK_SIZE_D)
+        offs_n = tl.arange(0, BLOCK_SIZE_N)
+        offs_t = tl.arange(0, TINY_GLOBAL_N)
+        q_ptrs = q_ptr + b_id * stride_qb + q_head_id * stride_qh + offs_d * stride_qd
+        q = tl.load(q_ptrs, mask=offs_d < HEAD_DIM, other=0.0)
+
+        m_i = -float("inf")
+        l_i = 0.0
+        acc = tl.zeros((BLOCK_SIZE_D,), dtype=tl.float32)
+
+        num_global_window_blocks, non_global_window_start_block, num_total_blocks = _swa_split_blocks(
+            kv_seq_len - 1,
+            1,
+            kv_seq_len,
+            PAGE_SIZE,
+            True,
+            GLOBAL_WINDOW,
+            LOCAL_WINDOW,
+        )
+
+        if num_global_window_blocks > 0:
+            page0_fully_covered_by_local = False
+            if LOCAL_WINDOW is not None:
+                page0_fully_covered_by_local = (PAGE_SIZE + LOCAL_WINDOW) >= kv_seq_len
+
+            physical_page_id = tl.load(block_tables_ptr + b_id * stride_bt_batch)
+            if page0_fully_covered_by_local:
+                kv_block_len = tl.minimum(PAGE_SIZE, kv_seq_len)
+                k_block_ptr = tl.make_block_ptr(
+                    base=k_cache_ptr + physical_page_id * stride_k_block + kv_head_id * stride_k_head,
+                    shape=(kv_block_len, HEAD_DIM),
+                    strides=(stride_k_blksz, stride_k_dim),
+                    offsets=(0, 0),
+                    block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                    order=(1, 0),
+                )
+                v_block_ptr = tl.make_block_ptr(
+                    base=v_cache_ptr + physical_page_id * stride_v_block + kv_head_id * stride_v_head,
+                    shape=(kv_block_len, HEAD_DIM),
+                    strides=(stride_v_blksz, stride_v_dim),
+                    offsets=(0, 0),
+                    block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                    order=(1, 0),
+                )
+                kv_mask = offs_n < kv_block_len
+                gw_mask = offs_n < GLOBAL_WINDOW
+                if LOCAL_WINDOW is not None:
+                    sw_mask = (offs_n + LOCAL_WINDOW) >= (kv_seq_len - 1)
+                    gw_mask = gw_mask | sw_mask
+                mask = kv_mask & gw_mask
+                acc, l_i, m_i = _sdpa_acc_fwd_1xN(
+                    acc,
+                    l_i,
+                    m_i,
+                    q,
+                    k_block_ptr,
+                    v_block_ptr,
+                    mask,
+                    softmax_scale,
+                    HEAD_DIM,
+                    BLOCK_SIZE_D,
+                    BLOCK_SIZE_N,
+                    BLOCK_SIZE_D,
+                    v_cache_ptr.dtype.element_ty == tl.float8e5,
+                )
+            else:
+                k_ptrs = (
+                    k_cache_ptr
+                    + physical_page_id * stride_k_block
+                    + kv_head_id * stride_k_head
+                    + offs_t[:, None] * stride_k_blksz
+                    + offs_d[None, :] * stride_k_dim
+                )
+                v_ptrs = (
+                    v_cache_ptr
+                    + physical_page_id * stride_v_block
+                    + kv_head_id * stride_v_head
+                    + offs_t[:, None] * stride_v_blksz
+                    + offs_d[None, :] * stride_v_dim
+                )
+                tiny_load_mask = (offs_t[:, None] < GLOBAL_WINDOW) & (offs_d[None, :] < HEAD_DIM)
+                k_tiny = tl.load(k_ptrs, mask=tiny_load_mask, other=0.0)
+                v_tiny = tl.load(v_ptrs, mask=tiny_load_mask, other=0.0)
+                tiny_mask = offs_t < GLOBAL_WINDOW
+                acc, l_i, m_i = _sdpa_acc_fwd_1xT(
+                    acc,
+                    l_i,
+                    m_i,
+                    q,
+                    k_tiny,
+                    v_tiny,
+                    tiny_mask,
+                    softmax_scale,
+                    TINY_GLOBAL_N,
+                    BLOCK_SIZE_D,
+                    v_cache_ptr.dtype.element_ty == tl.float8e5,
+                )
+
+        for logical_page_id in tl.range(1, num_global_window_blocks):
+            kv_block_start = logical_page_id * PAGE_SIZE
+            kv_block_end = tl.minimum(kv_block_start + PAGE_SIZE, kv_seq_len)
+            kv_block_len = kv_block_end - kv_block_start
+            physical_page_id = tl.load(
+                block_tables_ptr + b_id * stride_bt_batch + logical_page_id * stride_bt_block
+            )
+            k_block_ptr = tl.make_block_ptr(
+                base=k_cache_ptr + physical_page_id * stride_k_block + kv_head_id * stride_k_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_k_blksz, stride_k_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            v_block_ptr = tl.make_block_ptr(
+                base=v_cache_ptr + physical_page_id * stride_v_block + kv_head_id * stride_v_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_v_blksz, stride_v_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            gw_mask = (kv_block_start + offs_n) < GLOBAL_WINDOW
+            if LOCAL_WINDOW is not None:
+                sw_mask = (kv_block_start + offs_n + LOCAL_WINDOW) >= (kv_seq_len - 1)
+                gw_mask = gw_mask | sw_mask
+            kv_mask = offs_n < kv_block_len
+            mask = gw_mask & kv_mask
+
+            acc, l_i, m_i = _sdpa_acc_fwd_1xN(
+                acc,
+                l_i,
+                m_i,
+                q,
+                k_block_ptr,
+                v_block_ptr,
+                mask,
+                softmax_scale,
+                HEAD_DIM,
+                BLOCK_SIZE_D,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_D,
+                v_cache_ptr.dtype.element_ty == tl.float8e5,
+            )
+
+
+        n_local_pages = num_total_blocks - non_global_window_start_block
+        for j in tl.range(0, n_local_pages):
+            logical_page_id = non_global_window_start_block + j
+            kv_block_start = logical_page_id * PAGE_SIZE
+            kv_block_end = tl.minimum(kv_block_start + PAGE_SIZE, kv_seq_len)
+            kv_block_len = kv_block_end - kv_block_start
+            physical_page_id = tl.load(
+                block_tables_ptr + b_id * stride_bt_batch + logical_page_id * stride_bt_block
+            )
+            k_block_ptr = tl.make_block_ptr(
+                base=k_cache_ptr + physical_page_id * stride_k_block + kv_head_id * stride_k_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_k_blksz, stride_k_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            v_block_ptr = tl.make_block_ptr(
+                base=v_cache_ptr + physical_page_id * stride_v_block + kv_head_id * stride_v_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_v_blksz, stride_v_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+
+            kv_mask = offs_n < kv_block_len
+            if LOCAL_WINDOW is not None:
+                sw_mask = (kv_block_start + offs_n + LOCAL_WINDOW) >= (kv_seq_len - 1)
+                mask = kv_mask & sw_mask
+            else:
+                mask = kv_mask
+
+            acc, l_i, m_i = _sdpa_acc_fwd_1xN(
+                acc,
+                l_i,
+                m_i,
+                q,
+                k_block_ptr,
+                v_block_ptr,
+                mask,
+                softmax_scale,
+                HEAD_DIM,
+                BLOCK_SIZE_D,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_D,
+                v_cache_ptr.dtype.element_ty == tl.float8e5,
+            )
+
+        l_i_safe = tl.where(l_i > 0, l_i, 1.0)
+        acc = tl.where(l_i > 0, acc / l_i_safe, 0.0)
 
         o_ptrs = o_ptr + b_id * stride_ob + q_head_id * stride_oh + offs_d * stride_od
         tl.store(o_ptrs, acc.to(OUT_T), mask=offs_d < HEAD_DIM)
@@ -1475,46 +2161,93 @@ def swa_paged_decode_impl(
     else:
         out_t = tl.float32
 
-    bt = block_tables if block_tables.dtype == torch.int32 else block_tables.to(torch.int32)
-    num_warps = _paged_decode_launch_config(head_dim, block_size_n)
-
-    _paged_decode_kernel[grid](
-        q,
-        key_cache,
-        value_cache,
-        o,
-        seqlens,
-        bt,
-        batch_size,
-        num_total_blocks,
-        max_num_blocks_per_seq,
-        q.stride(0),
-        q.stride(1),
-        q.stride(2),
-        key_cache.stride(0),
-        key_cache.stride(1),
-        key_cache.stride(2),
-        key_cache.stride(3),
-        value_cache.stride(0),
-        value_cache.stride(1),
-        value_cache.stride(2),
-        value_cache.stride(3),
-        o.stride(0),
-        o.stride(1),
-        o.stride(2),
-        bt.stride(0),
-        bt.stride(1),
-        softmax_scale,
-        global_window_size,
-        local_window_size,
-        num_q_heads,
-        num_kv_heads,
-        gqa_interleave,
-        head_dim,
-        block_size,
-        BLOCK_SIZE_D=BLOCK_SIZE_D,
-        BLOCK_SIZE_N=block_size_n,
-        OUT_T=out_t,
-        num_warps=num_warps,
+    num_warps = _paged_decode_launch_config(head_dim, block_size)
+    use_tiny_global = (
+        global_window_size is not None
+        and global_window_size <= 8
+        and head_dim == 128
+        and block_size == 128
     )
+
+    if use_tiny_global:
+        _paged_decode_kernel_tiny_global[grid](
+            q,
+            key_cache,
+            value_cache,
+            o,
+            seqlens,
+            block_tables,
+            batch_size,
+            num_total_blocks,
+            max_num_blocks_per_seq,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            key_cache.stride(0),
+            key_cache.stride(1),
+            key_cache.stride(2),
+            key_cache.stride(3),
+            value_cache.stride(0),
+            value_cache.stride(1),
+            value_cache.stride(2),
+            value_cache.stride(3),
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            block_tables.stride(0),
+            block_tables.stride(1),
+            softmax_scale,
+            global_window_size,
+            local_window_size,
+            num_q_heads,
+            num_kv_heads,
+            gqa_interleave,
+            head_dim,
+            block_size,
+            BLOCK_SIZE_D=BLOCK_SIZE_D,
+            BLOCK_SIZE_N=block_size,
+            TINY_GLOBAL_N=8,
+            OUT_T=out_t,
+            num_warps=num_warps,
+        )
+    else:
+        _paged_decode_kernel[grid](
+            q,
+            key_cache,
+            value_cache,
+            o,
+            seqlens,
+            block_tables,
+            batch_size,
+            num_total_blocks,
+            max_num_blocks_per_seq,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            key_cache.stride(0),
+            key_cache.stride(1),
+            key_cache.stride(2),
+            key_cache.stride(3),
+            value_cache.stride(0),
+            value_cache.stride(1),
+            value_cache.stride(2),
+            value_cache.stride(3),
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            block_tables.stride(0),
+            block_tables.stride(1),
+            softmax_scale,
+            global_window_size,
+            local_window_size,
+            num_q_heads,
+            num_kv_heads,
+            gqa_interleave,
+            head_dim,
+            block_size,
+            BLOCK_SIZE_D=BLOCK_SIZE_D,
+            BLOCK_SIZE_N=block_size,
+            OUT_T=out_t,
+            num_warps=num_warps,
+        )
     return o

--- a/mojo_opset/backends/ttx/kernels/ilu/swa.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/swa.py
@@ -44,6 +44,26 @@ def _expand_kv_heads(x: torch.Tensor, num_q_heads: int, num_kv_heads: int, gqa_i
     return x.repeat_interleave(repeat, dim=1)
 
 
+def _swa_infer_autotune_configs() -> list[triton.Config]:
+    return [
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64, "BLOCK_N": 128}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 32}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 64}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128}, num_warps=8, num_stages=1),
+    ]
+
+
+def _swa_paged_prefill_autotune_configs() -> list[triton.Config]:
+    return [
+        triton.Config({"BLOCK_M": 64}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 64}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_M": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_M": 128}, num_warps=8, num_stages=1),
+    ]
+
+
 @libentry()
 @triton.jit
 def _swa_masked_fwd_kernel(
@@ -213,6 +233,44 @@ def _swa_acc_fwd_mxn(
 
 @libentry()
 @triton.jit
+def _swa_acc_fwd_nomask_mxn(
+    acc_ptr,
+    l_i,
+    m_i,
+    q,
+    k_block_ptr,
+    v_block_ptr,
+    qk_scale,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+):
+    k = tl.load(k_block_ptr, boundary_check=(0, 1), padding_option="zero")
+    qk = tl.dot(q, tl.trans(k))
+    qk = qk * qk_scale
+
+    m_ij = tl.maximum(m_i, tl.max(qk, 1))
+    qk = qk - m_ij[:, None]
+    p = tl.math.exp(qk)
+    p_cast = p.to(k.dtype)
+
+    v = tl.load(v_block_ptr, boundary_check=(0, 1), padding_option="zero")
+    l_ij = tl.sum(p, 1)
+    alpha = tl.math.exp(m_i - m_ij)
+    l_i = l_i * alpha + l_ij
+    acc_ptr = acc_ptr * alpha[:, None]
+    acc_ptr = tl.dot(p_cast, v, acc_ptr)
+    m_i = m_ij
+    return acc_ptr, l_i, m_i
+
+
+@triton.autotune(
+    configs=_swa_infer_autotune_configs(),
+    key=["HEAD_DIM", "GLOBAL_WINDOW", "LOCAL_WINDOW", "NUM_Q_HEADS", "NUM_KV_HEADS"],
+)
+@libentry()
+@triton.jit
 def _swa_infer_kernel(
     o_ptr,
     q_ptr,
@@ -247,6 +305,8 @@ def _swa_infer_kernel(
 ):
     pid = tl.program_id(0)
     n_programs = tl.num_programs(0)
+    has_global_window = GLOBAL_WINDOW is not None
+    has_local_window = LOCAL_WINDOW is not None
 
     cu_q_chunks = 0
     q_offsets = tl.arange(0, BLOCK_M)
@@ -311,11 +371,17 @@ def _swa_infer_kernel(
                 mask = q_valid[:, None] & kv_valid[None, :]
                 if IS_CAUSAL:
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    global_mask = kv_abs[None, :] < GLOBAL_WINDOW
-                    if LOCAL_WINDOW is not None:
+                    if has_global_window and has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        global_mask = global_mask | local_mask
-                    mask = mask & causal_mask & global_mask
+                        global_mask = kv_abs[None, :] < GLOBAL_WINDOW
+                        mask = mask & causal_mask & (global_mask | local_mask)
+                    elif has_global_window:
+                        mask = mask & causal_mask & (kv_abs[None, :] < GLOBAL_WINDOW)
+                    elif has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
                 k_block_ptr = tl.make_block_ptr(
                     base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
@@ -348,52 +414,188 @@ def _swa_infer_kernel(
                     BLOCK_D,
                 )
 
-            for kv_block_id in range(non_global_window_start_block, num_total_blocks):
-                kv_block_start = kv_block_id * BLOCK_N
-                kv_abs = kv_block_start + kv_offsets
-                kv_valid = kv_abs < kv_seq_len
-                mask = q_valid[:, None] & kv_valid[None, :]
-                if IS_CAUSAL:
+            can_use_nomask_local = IS_CAUSAL and q_block_len == BLOCK_M
+            full_local_start_block = non_global_window_start_block
+            full_local_end_block = non_global_window_start_block - 1
+            if can_use_nomask_local:
+                q_abs_start = q_block_start + kv_computed_len
+                q_abs_end = q_abs_start + BLOCK_M - 1
+                last_causal_full_block = (q_abs_start - (BLOCK_N - 1)) // BLOCK_N
+                first_local_full_block = non_global_window_start_block
+                if has_local_window:
+                    first_local_full_block = tl.maximum(
+                        non_global_window_start_block,
+                        tl.cdiv(tl.maximum(q_abs_end - LOCAL_WINDOW, 0), BLOCK_N),
+                    )
+                full_local_start_block = first_local_full_block
+                full_local_end_block = tl.minimum(num_total_blocks - 1, last_causal_full_block)
+                can_use_nomask_local = full_local_start_block <= full_local_end_block
+
+            if can_use_nomask_local:
+                for kv_block_id in range(non_global_window_start_block, full_local_start_block):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    if LOCAL_WINDOW is not None:
+                    if has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        causal_mask = causal_mask & local_mask
-                    mask = mask & causal_mask
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
-                k_block_ptr = tl.make_block_ptr(
-                    base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
-                    shape=(kv_seq_len, HEAD_DIM),
-                    strides=(stride_kt, stride_kd),
-                    offsets=(kv_block_start.to(tl.int32), 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                v_block_ptr = tl.make_block_ptr(
-                    base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
-                    shape=(kv_seq_len, HEAD_DIM),
-                    strides=(stride_vt, stride_vd),
-                    offsets=(kv_block_start.to(tl.int32), 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                acc, l_i, m_i = _swa_acc_fwd_mxn(
-                    acc,
-                    l_i,
-                    m_i,
-                    q_block,
-                    k_block_ptr,
-                    v_block_ptr,
-                    mask,
-                    scale,
-                    HEAD_DIM,
-                    BLOCK_M,
-                    BLOCK_N,
-                    BLOCK_D,
-                )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+                for kv_block_id in range(full_local_start_block, full_local_end_block + 1):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_nomask_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+                for kv_block_id in range(full_local_end_block + 1, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                    if has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
+
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+            else:
+                for kv_block_id in range(non_global_window_start_block, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    if IS_CAUSAL:
+                        causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                        if has_local_window:
+                            local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                            mask = mask & causal_mask & local_mask
+                        else:
+                            mask = mask & causal_mask
+
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
+                        shape=(kv_seq_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(kv_block_start.to(tl.int32), 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
 
             l_safe = tl.where(q_valid, l_i, 1.0)
-            out_block = acc / tl.where(l_safe[:, None] > 0, l_safe[:, None], 1.0)
-            out_block = tl.where(l_i[:, None] > 0, out_block, 0.0)
+            out_block = acc / l_safe[:, None]
             out_block = tl.where(q_valid[:, None], out_block, 0.0)
             o_block_ptr = tl.make_block_ptr(
                 base=o_ptr + q_start * stride_ot + q_head_id * stride_oh,
@@ -406,6 +608,10 @@ def _swa_infer_kernel(
             tl.store(o_block_ptr, out_block.to(o_ptr.type.element_ty), boundary_check=(0, 1))
 
 
+@triton.autotune(
+    configs=_swa_paged_prefill_autotune_configs(),
+    key=["HEAD_DIM", "GLOBAL_WINDOW", "LOCAL_WINDOW", "NUM_Q_HEADS", "NUM_KV_HEADS"],
+)
 @libentry()
 @triton.jit
 def _swa_paged_prefill_kernel(
@@ -449,6 +655,8 @@ def _swa_paged_prefill_kernel(
     tl.static_assert(PAGE_SIZE % BLOCK_N == 0, "BLOCK_N must divide PAGE_SIZE for paged KV tiling")
     pid = tl.program_id(0)
     n_programs = tl.num_programs(0)
+    has_global_window = GLOBAL_WINDOW is not None
+    has_local_window = LOCAL_WINDOW is not None
 
     cu_q_chunks = 0
     q_offsets = tl.arange(0, BLOCK_M)
@@ -510,20 +718,26 @@ def _swa_paged_prefill_kernel(
                 kv_block_len = kv_block_end - kv_block_start
                 logical_page_id = kv_block_start // PAGE_SIZE
                 kv_block_start_in_page = kv_block_start % PAGE_SIZE
-                physical_page_id = tl.load(
-                    block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
-                )
                 kv_abs = kv_block_start + kv_offsets
                 kv_valid = kv_abs < kv_seq_len
                 mask = q_valid[:, None] & kv_valid[None, :]
                 if IS_CAUSAL:
                     causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    global_mask = kv_abs[None, :] < GLOBAL_WINDOW
-                    if LOCAL_WINDOW is not None:
+                    if has_global_window and has_local_window:
                         local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        global_mask = global_mask | local_mask
-                    mask = mask & causal_mask & global_mask
+                        global_mask = kv_abs[None, :] < GLOBAL_WINDOW
+                        mask = mask & causal_mask & (global_mask | local_mask)
+                    elif has_global_window:
+                        mask = mask & causal_mask & (kv_abs[None, :] < GLOBAL_WINDOW)
+                    elif has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
 
+                physical_page_id = tl.load(
+                    block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                )
                 k_block_ptr = tl.make_block_ptr(
                     base=k_cache_ptr
                     + physical_page_id * stride_kp
@@ -561,61 +775,237 @@ def _swa_paged_prefill_kernel(
                     BLOCK_D,
                 )
 
-            for kv_block_id in range(non_global_window_start_block, num_total_blocks):
-                kv_block_start = kv_block_id * BLOCK_N
-                kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
-                kv_block_len = kv_block_end - kv_block_start
-                logical_page_id = kv_block_start // PAGE_SIZE
-                kv_block_start_in_page = kv_block_start % PAGE_SIZE
-                physical_page_id = tl.load(
-                    block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
-                )
-                kv_abs = kv_block_start + kv_offsets
-                kv_valid = kv_abs < kv_seq_len
-                mask = q_valid[:, None] & kv_valid[None, :]
-                if IS_CAUSAL:
-                    causal_mask = q_abs[:, None] >= kv_abs[None, :]
-                    if LOCAL_WINDOW is not None:
-                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
-                        causal_mask = causal_mask & local_mask
-                    mask = mask & causal_mask
+            can_use_nomask_local = IS_CAUSAL and q_block_len == BLOCK_M
+            full_local_start_block = non_global_window_start_block
+            full_local_end_block = non_global_window_start_block - 1
+            if can_use_nomask_local:
+                q_abs_start = q_block_start + kv_computed_len
+                q_abs_end = q_abs_start + BLOCK_M - 1
+                last_causal_full_block = (q_abs_start - (BLOCK_N - 1)) // BLOCK_N
+                first_local_full_block = non_global_window_start_block
+                if has_local_window:
+                    first_local_full_block = tl.maximum(
+                        non_global_window_start_block,
+                        tl.cdiv(tl.maximum(q_abs_end - LOCAL_WINDOW, 0), BLOCK_N),
+                    )
+                full_local_start_block = first_local_full_block
+                full_local_end_block = tl.minimum(num_total_blocks - 1, last_causal_full_block)
+                can_use_nomask_local = full_local_start_block <= full_local_end_block
 
-                k_block_ptr = tl.make_block_ptr(
-                    base=k_cache_ptr
-                    + physical_page_id * stride_kp
-                    + kv_head_id * stride_kh
-                    + kv_block_start_in_page * stride_kt,
-                    shape=(kv_block_len, HEAD_DIM),
-                    strides=(stride_kt, stride_kd),
-                    offsets=(0, 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                v_block_ptr = tl.make_block_ptr(
-                    base=v_cache_ptr
-                    + physical_page_id * stride_vp
-                    + kv_head_id * stride_vh
-                    + kv_block_start_in_page * stride_vt,
-                    shape=(kv_block_len, HEAD_DIM),
-                    strides=(stride_vt, stride_vd),
-                    offsets=(0, 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                acc, l_i, m_i = _swa_acc_fwd_mxn(
-                    acc,
-                    l_i,
-                    m_i,
-                    q_block,
-                    k_block_ptr,
-                    v_block_ptr,
-                    mask,
-                    scale,
-                    HEAD_DIM,
-                    BLOCK_M,
-                    BLOCK_N,
-                    BLOCK_D,
-                )
+            if can_use_nomask_local:
+                for kv_block_id in range(non_global_window_start_block, full_local_start_block):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                    if has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
+
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+                for kv_block_id in range(full_local_start_block, full_local_end_block + 1):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_nomask_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+
+                for kv_block_id in range(full_local_end_block + 1, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                    if has_local_window:
+                        local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                        mask = mask & causal_mask & local_mask
+                    else:
+                        mask = mask & causal_mask
+
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
+            else:
+                for kv_block_id in range(non_global_window_start_block, num_total_blocks):
+                    kv_block_start = kv_block_id * BLOCK_N
+                    kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
+                    kv_block_len = kv_block_end - kv_block_start
+                    logical_page_id = kv_block_start // PAGE_SIZE
+                    kv_block_start_in_page = kv_block_start % PAGE_SIZE
+                    kv_abs = kv_block_start + kv_offsets
+                    kv_valid = kv_abs < kv_seq_len
+                    mask = q_valid[:, None] & kv_valid[None, :]
+                    if IS_CAUSAL:
+                        causal_mask = q_abs[:, None] >= kv_abs[None, :]
+                        if has_local_window:
+                            local_mask = q_abs[:, None] <= (kv_abs + LOCAL_WINDOW)[None, :]
+                            mask = mask & causal_mask & local_mask
+                        else:
+                            mask = mask & causal_mask
+
+                    physical_page_id = tl.load(
+                        block_table_ptr + b_id * stride_block_table_b + logical_page_id * stride_block_table_p
+                    )
+                    k_block_ptr = tl.make_block_ptr(
+                        base=k_cache_ptr
+                        + physical_page_id * stride_kp
+                        + kv_head_id * stride_kh
+                        + kv_block_start_in_page * stride_kt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_kt, stride_kd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    v_block_ptr = tl.make_block_ptr(
+                        base=v_cache_ptr
+                        + physical_page_id * stride_vp
+                        + kv_head_id * stride_vh
+                        + kv_block_start_in_page * stride_vt,
+                        shape=(kv_block_len, HEAD_DIM),
+                        strides=(stride_vt, stride_vd),
+                        offsets=(0, 0),
+                        block_shape=(BLOCK_N, BLOCK_D),
+                        order=(1, 0),
+                    )
+                    acc, l_i, m_i = _swa_acc_fwd_mxn(
+                        acc,
+                        l_i,
+                        m_i,
+                        q_block,
+                        k_block_ptr,
+                        v_block_ptr,
+                        mask,
+                        scale,
+                        HEAD_DIM,
+                        BLOCK_M,
+                        BLOCK_N,
+                        BLOCK_D,
+                    )
 
             l_safe = tl.where(q_valid, l_i, 1.0)
             out_block = acc / l_safe[:, None]
@@ -651,11 +1041,12 @@ def swa_infer_impl(
     outputs = torch.empty_like(q)
     batch_size = cu_seqlens_q.shape[0] - 1
     block_d = triton.next_power_of_2(head_dim)
-    block_m = 64 if (q.dtype == torch.float32 or block_d >= 128) else 128
-    block_n = 64
     q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-    total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
-    grid = (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
+
+    def grid(meta):
+        block_m = meta["BLOCK_M"]
+        total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
+        return (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
 
     _swa_infer_kernel[grid](
         outputs,
@@ -685,10 +1076,7 @@ def swa_infer_impl(
         num_kv_heads,
         gqa_interleave,
         head_dim,
-        BLOCK_M=block_m,
-        BLOCK_N=block_n,
         BLOCK_D=block_d,
-        num_stages=1,
     )
     return outputs
 
@@ -722,10 +1110,12 @@ def swa_paged_prefill_impl(
             "use a compatible page size (e.g. power of two, multiple of 128 for large pages)."
         )
     block_d = triton.next_power_of_2(head_dim)
-    block_m = 64 if (q.dtype == torch.float32 or block_d >= 128 or block_n >= 128) else 128
     q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
-    total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
-    grid = (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
+
+    def grid(meta):
+        block_m = meta["BLOCK_M"]
+        total_q_chunks = int(torch.div(q_lens + block_m - 1, block_m, rounding_mode="floor").sum().item())
+        return (ilu_grid_dim_from_row_tasks(total_q_chunks * num_q_heads),)
 
     _swa_paged_prefill_kernel[grid](
         outputs,
@@ -760,11 +1150,9 @@ def swa_paged_prefill_impl(
         num_kv_heads,
         gqa_interleave,
         head_dim,
-        BLOCK_M=block_m,
         BLOCK_N=block_n,
         BLOCK_D=block_d,
         PAGE_SIZE=block_size,
-        num_stages=1,
     )
     return outputs
 
@@ -837,6 +1225,43 @@ def _sdpa_acc_fwd_1xN(
 
     v = tl.load(V_block_ptr, boundary_check=(0, 1), padding_option="zero")
 
+    l_ij = tl.sum(p, axis=0)
+    alpha = tl.math.exp(m_i - m_ij)
+    l_i = l_i * alpha + l_ij
+    acc_ptr = acc_ptr * alpha
+    acc_ptr += tl.sum((p_cast[:, None] * v).to(tl.float32), axis=0)
+
+    m_i = m_ij
+    return acc_ptr, l_i, m_i
+
+
+@triton.jit
+def _sdpa_acc_fwd_1xT(
+    acc_ptr,
+    l_i,
+    m_i,
+    q,
+    k,
+    v,
+    mask,
+    qk_scale,
+    BLOCK_T: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    fp8_v: tl.constexpr,
+):
+    if mask is False:
+        return acc_ptr, l_i, m_i
+
+    qk = tl.sum((q[None, :] * k).to(tl.float32), axis=1)
+    qk = qk * qk_scale
+    if mask is not None and mask is not True:
+        qk = tl.where(mask, qk, float("-inf"))
+
+    m_ij = tl.maximum(m_i, tl.max(qk, axis=0))
+    qk = qk - m_ij
+    p = tl.math.exp(qk)
+
+    p_cast = p.to(k.dtype)
     l_ij = tl.sum(p, axis=0)
     alpha = tl.math.exp(m_i - m_ij)
     l_i = l_i * alpha + l_ij
@@ -1419,8 +1844,267 @@ def _paged_decode_kernel(
                 v_cache_ptr.dtype.element_ty == tl.float8e5,
             )
 
-        # Match torch reference: padded rows (kv_seq_len == 0) keep zero output; avoid acc / 0.
-        if kv_seq_len > 0:
+        if l_i != 0.0:
+            acc = acc / l_i
+
+        o_ptrs = o_ptr + b_id * stride_ob + q_head_id * stride_oh + offs_d * stride_od
+        tl.store(o_ptrs, acc.to(OUT_T), mask=offs_d < HEAD_DIM)
+
+
+@libentry()
+@triton.jit
+def _paged_decode_kernel_tiny_global(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    o_ptr,
+    seqlens_ptr,
+    block_tables_ptr,
+    BATCH_SIZE,
+    NUM_TOTAL_BLOCKS,
+    MAX_NUM_BLOCKS_PER_SEQ,
+    stride_qb,
+    stride_qh,
+    stride_qd,
+    stride_k_block,
+    stride_k_head,
+    stride_k_blksz,
+    stride_k_dim,
+    stride_v_block,
+    stride_v_head,
+    stride_v_blksz,
+    stride_v_dim,
+    stride_ob,
+    stride_oh,
+    stride_od,
+    stride_bt_batch,
+    stride_bt_block,
+    softmax_scale,
+    GLOBAL_WINDOW: tl.constexpr,
+    LOCAL_WINDOW: tl.constexpr,
+    NUM_Q_HEADS: tl.constexpr,
+    NUM_KV_HEADS: tl.constexpr,
+    GQA_INTERLEAVE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    TINY_GLOBAL_N: tl.constexpr,
+    OUT_T: tl.constexpr,
+):
+    tl.static_assert(HEAD_DIM <= BLOCK_SIZE_D, "HEAD_DIM should be <= BLOCK_SIZE_D")
+    tl.static_assert(PAGE_SIZE <= BLOCK_SIZE_N, "PAGE_SIZE should be <= BLOCK_SIZE_N")
+    tl.static_assert(TINY_GLOBAL_N <= BLOCK_SIZE_N, "TINY_GLOBAL_N should be <= BLOCK_SIZE_N")
+    pid = tl.program_id(0)
+    n_progs = tl.num_programs(0)
+
+    num_tasks = BATCH_SIZE * NUM_Q_HEADS
+
+    for q_task_id in tl.range(pid, num_tasks, n_progs):
+        q_head_id = q_task_id % NUM_Q_HEADS
+        b_id = q_task_id // NUM_Q_HEADS
+        if GQA_INTERLEAVE:
+            kv_head_id = q_head_id % NUM_KV_HEADS
+        else:
+            kv_head_id = q_head_id // (NUM_Q_HEADS // NUM_KV_HEADS)
+
+        kv_seq_len = tl.load(seqlens_ptr + b_id)
+
+        offs_d = tl.arange(0, BLOCK_SIZE_D)
+        offs_n = tl.arange(0, BLOCK_SIZE_N)
+        offs_t = tl.arange(0, TINY_GLOBAL_N)
+        q_ptrs = q_ptr + b_id * stride_qb + q_head_id * stride_qh + offs_d * stride_qd
+        q = tl.load(q_ptrs, mask=offs_d < HEAD_DIM, other=0.0)
+
+        m_i = -float("inf")
+        l_i = 0.0
+        acc = tl.zeros((BLOCK_SIZE_D,), dtype=tl.float32)
+
+        num_global_window_blocks, non_global_window_start_block, num_total_blocks = _swa_split_blocks(
+            kv_seq_len - 1,
+            1,
+            kv_seq_len,
+            PAGE_SIZE,
+            True,
+            GLOBAL_WINDOW,
+            LOCAL_WINDOW,
+        )
+
+        if num_global_window_blocks > 0:
+            page0_fully_covered_by_local = False
+            if LOCAL_WINDOW is not None:
+                page0_fully_covered_by_local = (PAGE_SIZE + LOCAL_WINDOW) >= kv_seq_len
+
+            physical_page_id = tl.load(block_tables_ptr + b_id * stride_bt_batch)
+            if page0_fully_covered_by_local:
+                kv_block_len = tl.minimum(PAGE_SIZE, kv_seq_len)
+                k_block_ptr = tl.make_block_ptr(
+                    base=k_cache_ptr + physical_page_id * stride_k_block + kv_head_id * stride_k_head,
+                    shape=(kv_block_len, HEAD_DIM),
+                    strides=(stride_k_blksz, stride_k_dim),
+                    offsets=(0, 0),
+                    block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                    order=(1, 0),
+                )
+                v_block_ptr = tl.make_block_ptr(
+                    base=v_cache_ptr + physical_page_id * stride_v_block + kv_head_id * stride_v_head,
+                    shape=(kv_block_len, HEAD_DIM),
+                    strides=(stride_v_blksz, stride_v_dim),
+                    offsets=(0, 0),
+                    block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                    order=(1, 0),
+                )
+                kv_mask = offs_n < kv_block_len
+                gw_mask = offs_n < GLOBAL_WINDOW
+                if LOCAL_WINDOW is not None:
+                    sw_mask = (offs_n + LOCAL_WINDOW) >= (kv_seq_len - 1)
+                    gw_mask = gw_mask | sw_mask
+                mask = kv_mask & gw_mask
+                acc, l_i, m_i = _sdpa_acc_fwd_1xN(
+                    acc,
+                    l_i,
+                    m_i,
+                    q,
+                    k_block_ptr,
+                    v_block_ptr,
+                    mask,
+                    softmax_scale,
+                    HEAD_DIM,
+                    BLOCK_SIZE_D,
+                    BLOCK_SIZE_N,
+                    BLOCK_SIZE_D,
+                    v_cache_ptr.dtype.element_ty == tl.float8e5,
+                )
+            else:
+                k_ptrs = (
+                    k_cache_ptr
+                    + physical_page_id * stride_k_block
+                    + kv_head_id * stride_k_head
+                    + offs_t[:, None] * stride_k_blksz
+                    + offs_d[None, :] * stride_k_dim
+                )
+                v_ptrs = (
+                    v_cache_ptr
+                    + physical_page_id * stride_v_block
+                    + kv_head_id * stride_v_head
+                    + offs_t[:, None] * stride_v_blksz
+                    + offs_d[None, :] * stride_v_dim
+                )
+                tiny_load_mask = (offs_t[:, None] < GLOBAL_WINDOW) & (offs_d[None, :] < HEAD_DIM)
+                k_tiny = tl.load(k_ptrs, mask=tiny_load_mask, other=0.0)
+                v_tiny = tl.load(v_ptrs, mask=tiny_load_mask, other=0.0)
+                tiny_mask = offs_t < GLOBAL_WINDOW
+                acc, l_i, m_i = _sdpa_acc_fwd_1xT(
+                    acc,
+                    l_i,
+                    m_i,
+                    q,
+                    k_tiny,
+                    v_tiny,
+                    tiny_mask,
+                    softmax_scale,
+                    TINY_GLOBAL_N,
+                    BLOCK_SIZE_D,
+                    v_cache_ptr.dtype.element_ty == tl.float8e5,
+                )
+
+        for logical_page_id in tl.range(1, num_global_window_blocks):
+            kv_block_start = logical_page_id * PAGE_SIZE
+            kv_block_end = tl.minimum(kv_block_start + PAGE_SIZE, kv_seq_len)
+            kv_block_len = kv_block_end - kv_block_start
+            physical_page_id = tl.load(
+                block_tables_ptr + b_id * stride_bt_batch + logical_page_id * stride_bt_block
+            )
+            k_block_ptr = tl.make_block_ptr(
+                base=k_cache_ptr + physical_page_id * stride_k_block + kv_head_id * stride_k_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_k_blksz, stride_k_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            v_block_ptr = tl.make_block_ptr(
+                base=v_cache_ptr + physical_page_id * stride_v_block + kv_head_id * stride_v_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_v_blksz, stride_v_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            gw_mask = (kv_block_start + offs_n) < GLOBAL_WINDOW
+            if LOCAL_WINDOW is not None:
+                sw_mask = (kv_block_start + offs_n + LOCAL_WINDOW) >= (kv_seq_len - 1)
+                gw_mask = gw_mask | sw_mask
+            kv_mask = offs_n < kv_block_len
+            mask = gw_mask & kv_mask
+
+            acc, l_i, m_i = _sdpa_acc_fwd_1xN(
+                acc,
+                l_i,
+                m_i,
+                q,
+                k_block_ptr,
+                v_block_ptr,
+                mask,
+                softmax_scale,
+                HEAD_DIM,
+                BLOCK_SIZE_D,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_D,
+                v_cache_ptr.dtype.element_ty == tl.float8e5,
+            )
+
+
+        n_local_pages = num_total_blocks - non_global_window_start_block
+        for j in tl.range(0, n_local_pages):
+            logical_page_id = non_global_window_start_block + j
+            kv_block_start = logical_page_id * PAGE_SIZE
+            kv_block_end = tl.minimum(kv_block_start + PAGE_SIZE, kv_seq_len)
+            kv_block_len = kv_block_end - kv_block_start
+            physical_page_id = tl.load(
+                block_tables_ptr + b_id * stride_bt_batch + logical_page_id * stride_bt_block
+            )
+            k_block_ptr = tl.make_block_ptr(
+                base=k_cache_ptr + physical_page_id * stride_k_block + kv_head_id * stride_k_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_k_blksz, stride_k_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+            v_block_ptr = tl.make_block_ptr(
+                base=v_cache_ptr + physical_page_id * stride_v_block + kv_head_id * stride_v_head,
+                shape=(kv_block_len, HEAD_DIM),
+                strides=(stride_v_blksz, stride_v_dim),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_N, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
+
+            kv_mask = offs_n < kv_block_len
+            if LOCAL_WINDOW is not None:
+                sw_mask = (kv_block_start + offs_n + LOCAL_WINDOW) >= (kv_seq_len - 1)
+                mask = kv_mask & sw_mask
+            else:
+                mask = kv_mask
+
+            acc, l_i, m_i = _sdpa_acc_fwd_1xN(
+                acc,
+                l_i,
+                m_i,
+                q,
+                k_block_ptr,
+                v_block_ptr,
+                mask,
+                softmax_scale,
+                HEAD_DIM,
+                BLOCK_SIZE_D,
+                BLOCK_SIZE_N,
+                BLOCK_SIZE_D,
+                v_cache_ptr.dtype.element_ty == tl.float8e5,
+            )
+
+        if l_i != 0.0:
             acc = acc / l_i
 
         o_ptrs = o_ptr + b_id * stride_ob + q_head_id * stride_oh + offs_d * stride_od
@@ -1475,46 +2159,93 @@ def swa_paged_decode_impl(
     else:
         out_t = tl.float32
 
-    bt = block_tables if block_tables.dtype == torch.int32 else block_tables.to(torch.int32)
-    num_warps = _paged_decode_launch_config(head_dim, block_size_n)
-
-    _paged_decode_kernel[grid](
-        q,
-        key_cache,
-        value_cache,
-        o,
-        seqlens,
-        bt,
-        batch_size,
-        num_total_blocks,
-        max_num_blocks_per_seq,
-        q.stride(0),
-        q.stride(1),
-        q.stride(2),
-        key_cache.stride(0),
-        key_cache.stride(1),
-        key_cache.stride(2),
-        key_cache.stride(3),
-        value_cache.stride(0),
-        value_cache.stride(1),
-        value_cache.stride(2),
-        value_cache.stride(3),
-        o.stride(0),
-        o.stride(1),
-        o.stride(2),
-        bt.stride(0),
-        bt.stride(1),
-        softmax_scale,
-        global_window_size,
-        local_window_size,
-        num_q_heads,
-        num_kv_heads,
-        gqa_interleave,
-        head_dim,
-        block_size,
-        BLOCK_SIZE_D=BLOCK_SIZE_D,
-        BLOCK_SIZE_N=block_size_n,
-        OUT_T=out_t,
-        num_warps=num_warps,
+    num_warps = _paged_decode_launch_config(head_dim, block_size)
+    use_tiny_global = (
+        global_window_size is not None
+        and global_window_size <= 8
+        and head_dim == 128
+        and block_size == 128
     )
+
+    if use_tiny_global:
+        _paged_decode_kernel_tiny_global[grid](
+            q,
+            key_cache,
+            value_cache,
+            o,
+            seqlens,
+            block_tables,
+            batch_size,
+            num_total_blocks,
+            max_num_blocks_per_seq,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            key_cache.stride(0),
+            key_cache.stride(1),
+            key_cache.stride(2),
+            key_cache.stride(3),
+            value_cache.stride(0),
+            value_cache.stride(1),
+            value_cache.stride(2),
+            value_cache.stride(3),
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            block_tables.stride(0),
+            block_tables.stride(1),
+            softmax_scale,
+            global_window_size,
+            local_window_size,
+            num_q_heads,
+            num_kv_heads,
+            gqa_interleave,
+            head_dim,
+            block_size,
+            BLOCK_SIZE_D=BLOCK_SIZE_D,
+            BLOCK_SIZE_N=block_size,
+            TINY_GLOBAL_N=8,
+            OUT_T=out_t,
+            num_warps=num_warps,
+        )
+    else:
+        _paged_decode_kernel[grid](
+            q,
+            key_cache,
+            value_cache,
+            o,
+            seqlens,
+            block_tables,
+            batch_size,
+            num_total_blocks,
+            max_num_blocks_per_seq,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            key_cache.stride(0),
+            key_cache.stride(1),
+            key_cache.stride(2),
+            key_cache.stride(3),
+            value_cache.stride(0),
+            value_cache.stride(1),
+            value_cache.stride(2),
+            value_cache.stride(3),
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            block_tables.stride(0),
+            block_tables.stride(1),
+            softmax_scale,
+            global_window_size,
+            local_window_size,
+            num_q_heads,
+            num_kv_heads,
+            gqa_interleave,
+            head_dim,
+            block_size,
+            BLOCK_SIZE_D=BLOCK_SIZE_D,
+            BLOCK_SIZE_N=block_size,
+            OUT_T=out_t,
+            num_warps=num_warps,
+        )
     return o


### PR DESCRIPTION
   Lots of optimizations introduced. 
1.Add triton kernel autotune for FA/SWA/GroupGemm.
2.FA prefill:
  (1)Split KV page loop into full-page and tail-page loops.
  (2)Replace tl.math.exp with tl.math.exp2 + pre-scaled softmax factor.
3.FA decode:
   (1)Early return for the invalid index.
   (2)Implement mainly based on the online-softmax approach.
4.SWA:
   (1) [prefill]: Optimize separately for each combination of mask and global/local windows.
   (2) [decode] optimize the case of tiny global window.
5.GroupGemm:
   (1) Optimize both m_group and k_group cases, although m_group was the primary requirement.
   (2) Replace 1D persistent grid with 3D grid (n_tiles, m_tiles, num_groups)
   (3) Use group_offsets prefix-sum for O(1) group boundary lookup
   (4) Add MAX_M to autotune key with early-return for inactive tiles.
   (5) Handle trans_b inside kernel via tl.trans, removing host-side B.transpose().contiguous() overhead.