### PR TITLE
[ilu/ixformer] add max_context_len & update generate_paged_decode_data

### DIFF
--- a/mojo_opset/backends/ixformer/operators/attention.py
+++ b/mojo_opset/backends/ixformer/operators/attention.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import math
+
+from mojo_opset.backends.ixformer.utils import _get_ixf_and_check_device
+from mojo_opset.core import MojoPagedDecodeGQA
+
+from ixformer.contrib import vllm_flash_attn as  ix_fa
+
+class IxformerPagedDecodeGQA(MojoPagedDecodeGQA):
+    """Ixformer implementation for paged decode GQA."""
+
+    supported_platforms_list = ["ilu"]
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        seqlens: torch.Tensor,
+        block_tables: torch.Tensor,
+        max_context_len: int,
+        softmax_scale: Optional[float] = None,
+        mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Paged decode attention with grouped query heads (GQA) using a blocked KV cache.
+
+        Args:
+            query (torch.Tensor): Query of shape (B, Hq, D).
+            key_cache (torch.Tensor): Key cache of shape (N_blocks, Hkv, block_size, D).
+            value_cache (torch.Tensor): Value cache of shape (N_blocks, Hkv, block_size, D).
+            seqlens (torch.Tensor): Sequence lengths (B).
+            block_tables (torch.Tensor): (B, num_blocks) mapping logical blocks to physical IDs.
+            max_context_len (int): Max sequence length, should be equal to seqlens.max().
+            softmax_scale (Optional[float]): Scale factor; defaults to 1/sqrt(D).
+
+        Returns:
+            torch.Tensor: Attention output of shape (B, Hq, D).
+
+        Notes:
+            - Head dim D only support [32, 64, 80, 96, 128, 160, 192, 224, 256].
+            - Block size must be a multiple of 16.
+            - If Hq > Hkv, K/V heads are repeated to match query heads.
+            - Softmax is computed in float32 and cast back to the input dtype.
+            - This implementation references variables `query` and `seqlens`; ensure they
+              correspond to `query` and the sequence-lengths tensor in the caller.
+        """
+
+        if mask is not None:
+            raise NotImplementedError("IxformerPagedDecodeGQA does not support custom mask yet.")
+
+        if self.gqa_layout == "ABAB":
+            raise NotImplementedError("IxformerPagedDecodeGQA does not support ABAB layout.")
+
+        ixf_f = _get_ixf_and_check_device(query, self.__class__.__name__)
+
+        batch_size, num_q_heads, head_dim = query.shape
+        _, num_kv_heads, block_size, head_dim = key_cache.shape
+
+        output = torch.empty(batch_size, num_q_heads, head_dim, dtype=query.dtype, device=query.device)
+
+        if softmax_scale is None:
+            softmax_scale = 1.0 / math.sqrt(head_dim)
+
+        if block_size % 16 != 0:
+            raise NotImplementedError("Block size must be a multiple of 16.")
+
+        if block_tables.dtype != torch.int32:
+            raise NotImplementedError("IxformerPagedDecodeGQA only support block_tables dtype = torch.int32.")
+
+        if max_context_len <= 1:
+            raise NotImplementedError("IxformerPagedDecodeGQA only support max_context_len > 1.")
+
+        ixf_f.vllm_paged_attention(
+            output=output,
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            num_kv_heads=num_kv_heads,
+            scale=softmax_scale,
+            block_tables=block_tables,
+            context_lens=seqlens,
+            block_size=block_size,
+            max_context_len=max_context_len,
+            causal=self.is_causal,
+            window_left=self.window_size
+        )
+
+        return output

--- a/mojo_opset/core/operators/attention.py
+++ b/mojo_opset/core/operators/attention.py
@@ -126,6 +126,7 @@ class MojoPagedDecodeGQA(MojoOperator):
         value_cache: torch.Tensor,
         seqlens: torch.Tensor,
         block_tables: torch.Tensor,
+        max_context_len: int,
         softmax_scale: Optional[float] = None,
         cu_seq_lens: Optional[torch.Tensor] = None,
         mask: Optional[torch.Tensor] = None,

--- a/tests/accuracy/operators/test_attention.py
+++ b/tests/accuracy/operators/test_attention.py
@@ -43,7 +43,8 @@ def generate_paged_decode_data(
     else:
         seqlens = torch.zeros(batch_size, dtype=torch.int32)
 
-    max_num_blocks_per_seq = (seqlens.max().item() + block_size - 1) // block_size
+    max_context_len = seqlens.max().item()
+    max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
     total_blocks_needed = int(torch.div(seqlens + block_size - 1, block_size, rounding_mode="floor").sum().item())
 
     if total_blocks_needed == 0:
@@ -54,7 +55,7 @@ def generate_paged_decode_data(
     k_cache = torch.randn(num_total_blocks, num_kv_heads, block_size, head_dim, dtype=dtype)
     v_cache = torch.randn(num_total_blocks, num_kv_heads, block_size, head_dim, dtype=dtype)
 
-    block_tables = torch.zeros(batch_size, max_num_blocks_per_seq, dtype=torch.long)
+    block_tables = torch.zeros(batch_size, max_num_blocks_per_seq, dtype=torch.int32)
     free_blocks = torch.randperm(num_total_blocks)
 
     current_block_offset = 0
@@ -69,7 +70,7 @@ def generate_paged_decode_data(
         block_tables[i, :num_blocks_for_seq] = assigned_blocks
         current_block_offset += num_blocks_for_seq
 
-    return query, k_cache, v_cache, seqlens, block_tables
+    return query, k_cache, v_cache, seqlens, block_tables, max_context_len
 
 
 test_configs_decode = [
@@ -82,7 +83,7 @@ test_configs_decode = [
 
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, seqlens, block_tables",
+    "query, k_cache, v_cache, seqlens, block_tables, max_context_len",
     [
         pytest.param(
             *generate_paged_decode_data(
@@ -108,6 +109,7 @@ def test_paged_decode_gqa(
     v_cache: torch.Tensor,
     seqlens: torch.Tensor,
     block_tables: torch.Tensor,
+    max_context_len: int,
     gqa_layout: str,
 ):
     head_dim = query.shape[-1]
@@ -132,6 +134,7 @@ def test_paged_decode_gqa(
         v_cache,
         seqlens,
         block_tables,
+        max_context_len,
         softmax_scale=softmax_scale,
         atol=atol,
         rtol=rtol,
@@ -627,7 +630,7 @@ def test_paged_prefill_mla(B, H, d_nope, d_rope, d_v, d_c, max_q, blk):
 )
 @bypass_not_implemented
 def test_paged_decode_nsa(B, H, D, S, blk):
-    query, k_cache, v_cache, seqlens, bt = generate_paged_decode_data(
+    query, k_cache, v_cache, seqlens, bt, _ = generate_paged_decode_data(
         batch_size=B, num_q_heads=H, num_kv_heads=H,
         head_dim=D, max_seq_len=S, block_size=blk, dtype=torch.bfloat16,
     )
@@ -803,7 +806,7 @@ test_configs_swa_decode = [
 ]
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, seqlens, block_tables",
+    "query, k_cache, v_cache, seqlens, block_tables, max_context_len",
     [
         pytest.param(
             *generate_paged_decode_data(
@@ -832,6 +835,7 @@ def test_paged_decode_swa(
     v_cache: torch.Tensor,
     seqlens: torch.Tensor,
     block_tables: torch.Tensor,
+    max_context_len: int,
     gqa_layout: str,
     global_window: int,
     local_window: int,


### PR DESCRIPTION
On iluvatar platform,  add the ixformer backend operator IxformerPagedDecodeGQA. Several points warrant attention：
1. To achieve higher performance, it can eliminate some redundant operations in the forward pass. For example, precomputing `max_context_len` as mentioned in the PR. Anthor potential optimizations also include transforming tensors (e.g., transposing) to better match the kernel’s expected layout. Howerver, this alters the original interface. 
2. Since only `int32` datatype blocktable is supported for ixformer backend, so the test is modified accordingly. It worth further discussion: whether `int32` is sufficient for the majority of cases.