### PR TITLE
[ilu/ixformer] Add IxformerPagedPrefillGQA and IxformerPagedDecodeGQA…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ When multiple backends are added, Mojo Opset selects the backend implementation 
 | ComputeComm | MojoGemmReduceScatter         | ✅           | TBD       | TBD | TBD      |
 | Attention   | MojoSdpa                      | ✅           | TBD       | ✅  | TBD      |
 | Attention   | MojoPrefillGQA                | ✅           | ✅        | ✅  | TBD      |
-| Attention   | MojoPagedPrefillGQA           | ✅           | ✅        | ✅  | TBD      |
+| Attention   | MojoPagedPrefillGQA           | ✅           | ✅        | ✅  | ✅      |
 | Attention   | MojoDecodeGQA                 | ✅           | TBD       | TBD | TBD      |
-| Attention   | MojoPagedDecodeGQA            | ✅           | ✅        | 🚧  | TBD      |
+| Attention   | MojoPagedDecodeGQA            | ✅           | ✅        | 🚧  | ✅      |
 | Attention   | MojoDecodeMLA                 | ✅           | TBD       | TBD | TBD      |
 | Attention   | MojoPagedDecodeMLA            | ✅           | TBD       | TBD | TBD      |
 | Attention   | MojoPrefillMLA                | ✅           | TBD       | TBD | TBD      |

--- a/mojo_opset/backends/ixformer/operators/attention.py
+++ b/mojo_opset/backends/ixformer/operators/attention.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import math
+
+from typing import Any, Optional, Tuple
+
+import torch
+
+from ixformer import functions as ixf_f
+from ixformer.contrib import vllm_flash_attn as ix_fa
+
+from mojo_opset.core import MojoPagedPrefillGQA
+from mojo_opset.core import MojoPagedDecodeGQA
+
+_IXFORMER_PAGED_DECODE_SUPPORTED_HEAD_DIMS = frozenset(
+    {32, 64, 80, 96, 128, 160, 192, 224, 256}
+)
+
+
+class IxformerPagedPrefillGQA(MojoPagedPrefillGQA):
+    """Ixformer implementation for paged prefill GQA."""
+
+    supported_platforms_list = ["ilu"]
+
+    def __init__(
+        self,
+        is_causal: bool = True,
+        gqa_layout: str = "AABB",
+        window_size: int = -1,
+    ):
+        super().__init__(is_causal=is_causal, gqa_layout=gqa_layout, window_size=window_size)
+
+        if self.window_size != -1:
+            raise NotImplementedError("IxformerPagedPrefillGQA only supports window_size == -1")
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        block_tables: torch.Tensor,
+        softmax_scale: Optional[float] = None,
+        seqlens_kv: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        *,
+        cu_seqlens_kv: Optional[torch.Tensor] = None,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_k: Optional[int] = None,
+    ) -> Tuple[Any]:
+        """
+        Paged prefill attention with grouped query heads (GQA) using a blocked KV cache.
+
+        Args:
+            query (torch.Tensor): Query tokens of shape (T, Hq, D).
+                Hq->q head num , D->head dim.dtype must be fp16 or bf16.
+            key_cache (torch.Tensor): Key cache of shape (N_blocks, Hkv, block_size, D). 
+                HKv-> kv head num , D->head dim.dtype must be fp16 or bf16.
+                block_size must be <= 256 and % 16 == 0.
+            value_cache (torch.Tensor): Value cache of shape (N_blocks, Hkv, block_size, D). 
+                HKv-> kv head num , D->head dim.dtype must be fp16 or bf16.
+                block_size must be <= 256 and % 16 == 0.
+            cu_seqlens_q (torch.Tensor): Cumulative query lengths, shape (B+1,);
+                `cu_seqlens_q[i]` is the start offset for query at batch i; `cu_seqlens_q[-1] == T`.
+                dtype must be int32.
+            cu_seqlens_kv (torch.Tensor): Cumulative key/value lengths, shape (B+1,);
+                `cu_seqlens_kv[i]` is the start offset for key/value at batch i; `cu_seqlens_kv[-1] == K`.
+                dtype must be int32.
+            max_seqlen_q (int): Maximum query sequence length across the batch. >0 and must be int.
+            max_seqlen_k (int): Maximum key/value sequence length across the batch. >0 and must be int.
+            block_tables (torch.Tensor): Logical-to-physical block IDs per batch,
+                shape (B, num_blocks).
+                dtype must be int32.
+            softmax_scale (Optional[float]): Attention scaling factor; defaults to 1/sqrt(D).
+            seqlens_kv (Optional[torch.Tensor]): key/value lengths, shape (B,). Used to derive
+                cu_seqlens_kv when the cumulative lengths are not provided.
+            mask (Optional[torch.Tensor]): Attention mask; defaults to None.
+                Not support custom mask yet.
+        Returns:
+            torch.Tensor: Attention output of shape (T, Hq, D).
+
+        Notes:
+            - If Hq != Hkv, expands K/V heads to match Hq via repeat_interleave.
+            - Applies a causal lower-triangular mask and restricts attention within each sequence.
+            - Softmax is computed in float32 and cast back to the input dtype.
+            - Despite the type annotation Tuple[Any], this implementation returns a single tensor.
+        """
+
+        if query.dtype not in (torch.float16, torch.bfloat16):
+            raise NotImplementedError(f"query dtype must be fp16 or bf16, got {query.dtype}.")
+        if mask is not None:
+            raise NotImplementedError("IxformerPagedPrefillGQA does not support custom mask yet.")
+        if self.gqa_layout != "AABB":
+            raise NotImplementedError("IxformerPagedPrefillGQA only supports AABB layout.")
+        page_block_size = key_cache.shape[2]
+        if page_block_size > 256 or page_block_size % 16 != 0:
+            raise NotImplementedError(
+                f"IxformerPagedPrefillGQA only supports page_block_size <= 256 and % 16 == 0, got {page_block_size}."
+            )
+
+        if cu_seqlens_q.dtype != torch.int32:
+            raise ValueError(f"cu_seqlens_q must be int32, got {cu_seqlens_q.dtype}.")
+        if block_tables.dtype != torch.int32:
+            raise ValueError(f"block_tables must be int32, got {block_tables.dtype}.")
+
+        q_lens = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        if q_lens.dtype != torch.int32:
+            raise ValueError(f"q_lens must be int32, got {q_lens.dtype}.")
+        if (q_lens <= 0).any():
+            raise NotImplementedError(
+                "IxformerPagedPrefillGQA does not support zero/negative q_lens. "
+                "Please provide cu_seqlens_q such that all sequence lengths are >= 1."
+            )
+        if not isinstance(cu_seqlens_kv, torch.Tensor):
+            raise ValueError(f"cu_seqlens_kv must be torch.Tensor, got {type(cu_seqlens_kv)}.")
+        if cu_seqlens_kv.dtype != torch.int32:
+            raise ValueError(f"cu_seqlens_kv must be int32, got {cu_seqlens_kv.dtype}.")
+        if cu_seqlens_kv.ndim != 1:
+            raise ValueError(f"cu_seqlens_kv must be 1D, got shape {tuple(cu_seqlens_kv.shape)}.")
+        if not isinstance(max_seqlen_q, int) or max_seqlen_q <= 0:
+            raise ValueError(
+                f"max_seqlen_q must be a positive int, got {max_seqlen_q} ({type(max_seqlen_q)})."
+            )
+        if not isinstance(max_seqlen_k, int) or max_seqlen_k <= 0:
+            raise ValueError(
+                f"max_seqlen_k must be a positive int, got {max_seqlen_k} ({type(max_seqlen_k)})."
+            )
+
+        if softmax_scale is None:
+            head_dim = query.shape[-1]
+            softmax_scale = 1.0 / math.sqrt(head_dim)
+
+        return ix_fa.flash_attn_varlen_func(
+            query,
+            key_cache,
+            value_cache,
+            cu_seqlens_q,
+            cu_seqlens_kv,
+            max_seqlen_q,
+            max_seqlen_k,
+            causal=self.is_causal,
+            softmax_scale=softmax_scale,
+            block_table=block_tables,
+        )
+
+class IxformerPagedDecodeGQA(MojoPagedDecodeGQA):
+    """Ixformer implementation for paged decode GQA."""
+
+    supported_platforms_list = ["ilu"]
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        seqlens: torch.Tensor,
+        block_tables: torch.Tensor,
+        softmax_scale: Optional[float] = None,
+        cu_seq_lens: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        *,
+        max_context_len: Optional[int] = None,
+    ):
+        """
+        Paged decode attention with grouped query heads (GQA) using a blocked KV cache.
+
+        Args:
+            query (torch.Tensor): Query of shape (B, Hq, D).
+            key_cache (torch.Tensor): Key cache of shape (N_blocks, Hkv, block_size, D).
+            value_cache (torch.Tensor): Value cache of shape (N_blocks, Hkv, block_size, D).
+            seqlens (torch.Tensor): Sequence lengths (B).
+            block_tables (torch.Tensor): (B, num_blocks) mapping logical blocks to physical IDs.
+            max_context_len (int): Max sequence length, should be equal to seqlens.max().
+            softmax_scale (Optional[float]): Scale factor; defaults to 1/sqrt(D).
+
+        Returns:
+            torch.Tensor: Attention output of shape (B, Hq, D).
+
+        Notes:
+            - Head dim D only support [32, 64, 80, 96, 128, 160, 192, 224, 256].
+            - Block size must be a multiple of 16.
+            - If Hq > Hkv, K/V heads are repeated to match query heads.
+            - Softmax is computed in float32 and cast back to the input dtype.
+            - This implementation references variables `query` and `seqlens`; ensure they
+              correspond to `query` and the sequence-lengths tensor in the caller.
+        """
+
+        if mask is not None:
+            raise NotImplementedError("IxformerPagedDecodeGQA does not support custom mask yet.")
+
+        if self.gqa_layout == "ABAB":
+            raise NotImplementedError("IxformerPagedDecodeGQA does not support ABAB layout.")
+
+        if self.window_size != -1:
+            raise NotImplementedError(
+                "IxformerPagedDecodeGQA only supports window_size == -1 (no sliding window)."
+            )
+
+        batch_size, num_q_heads, head_dim_q = query.shape
+        _, num_kv_heads, block_size, head_dim_kv = key_cache.shape
+
+        if head_dim_q != head_dim_kv:
+            raise ValueError(
+                f"query head_dim ({head_dim_q}) must match key_cache head_dim ({head_dim_kv})."
+            )
+        head_dim = head_dim_q
+
+        if head_dim not in _IXFORMER_PAGED_DECODE_SUPPORTED_HEAD_DIMS:
+            raise NotImplementedError(
+                "IxformerPagedDecodeGQA only supports head_dim in "
+                f"{sorted(_IXFORMER_PAGED_DECODE_SUPPORTED_HEAD_DIMS)}, got {head_dim}."
+            )
+
+        if query.dtype not in (torch.float16, torch.bfloat16):
+            raise NotImplementedError(
+                f"IxformerPagedDecodeGQA only supports fp16/bf16 query, got {query.dtype}."
+            )
+
+        if key_cache.dtype != query.dtype or value_cache.dtype != query.dtype:
+            raise NotImplementedError(
+                "IxformerPagedDecodeGQA requires key_cache/value_cache dtype to match query dtype."
+            )
+
+        if not self.is_causal:
+            raise NotImplementedError("IxformerPagedDecodeGQA only supports causal attention.")
+
+        # vllm_paged_attention expects a positive KV length for every batch row.
+        if bool((seqlens < 1).any().item()):
+            raise NotImplementedError(
+                "IxformerPagedDecodeGQA requires context_lens >= 1 for every batch row."
+            )
+
+        # GQA + small page size is not supported by the fused kernel vs. eager reference parity.
+        if num_q_heads != num_kv_heads and block_size < 128:
+            raise NotImplementedError(
+                "IxformerPagedDecodeGQA does not support GQA (Hq != Hkv) when block_size < 128."
+            )
+
+        output = torch.empty(batch_size, num_q_heads, head_dim, dtype=query.dtype, device=query.device)
+
+        if softmax_scale is None:
+            softmax_scale = 1.0 / math.sqrt(head_dim)
+
+        if block_size % 16 != 0:
+            raise NotImplementedError("Block size must be a multiple of 16.")
+
+        if block_tables.dtype != torch.int32:
+            raise NotImplementedError("IxformerPagedDecodeGQA only support block_tables dtype = torch.int32.")
+
+        if cu_seq_lens is not None:
+            raise NotImplementedError("IxformerPagedDecodeGQA does not support varlen decode.")
+        if seqlens.dtype != torch.int32:
+            raise ValueError(f"seqlens must be int32, got {seqlens.dtype}.")
+        if not isinstance(max_context_len, int) or max_context_len <= 0:
+            raise ValueError(f"max_context_len must be > 0 and int, got {max_context_len}.")
+        if (seqlens <= 0).any():
+            raise NotImplementedError("IxformerPagedDecodeGQA does not support zero/negative seqlens.")
+        if max_context_len <= 1:
+            raise NotImplementedError("IxformerPagedDecodeGQA only supports max_context_len > 1.")
+
+        ixf_f.vllm_paged_attention(
+            output=output,
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            num_kv_heads=num_kv_heads,
+            scale=softmax_scale,
+            block_tables=block_tables,
+            context_lens=seqlens,
+            block_size=block_size,
+            max_context_len=max_context_len,
+            causal=self.is_causal,
+            window_left=self.window_size,
+        )
+
+        return output

--- a/mojo_opset/backends/ixformer/operators/normalization.py
+++ b/mojo_opset/backends/ixformer/operators/normalization.py
@@ -1,16 +1,11 @@
 import torch
 
+from ixformer import functions as ixf_f
+
 from mojo_opset.core import MojoLayerNorm
 from mojo_opset.core import MojoResidualAddLayerNorm
 from mojo_opset.core import MojoResidualAddRMSNorm
 from mojo_opset.core import MojoRMSNorm
-
-def _get_ixf_and_check_device(tensor: torch.Tensor, class_name: str):
-    """Helper to import ixformer and check for CUDA device."""
-    if not tensor.is_cuda:
-        raise RuntimeError(f"{class_name} expects CUDA tensors on Iluvatar.")
-    from ixformer import functions as ixf_f
-    return ixf_f
 
 
 class IxformerResidualAddRMSNorm(MojoResidualAddRMSNorm):
@@ -19,7 +14,8 @@ class IxformerResidualAddRMSNorm(MojoResidualAddRMSNorm):
     supported_platforms_list = ["ilu"]
 
     def forward(self, hidden_state: torch.Tensor, residual: torch.Tensor):
-        ixf_f = _get_ixf_and_check_device(hidden_state, self.__class__.__name__)
+        if not hidden_state.is_cuda:
+            raise RuntimeError(f"{self.__class__.__name__} expects CUDA tensors on Iluvatar.")
 
         is_post = self.norm_pos == "post"
         out, res_out = ixf_f.residual_rms_norm(
@@ -44,7 +40,8 @@ class IxformerResidualAddLayerNorm(MojoResidualAddLayerNorm):
     supported_platforms_list = ["ilu"]
 
     def forward(self, hidden_state: torch.Tensor, residual: torch.Tensor):
-        ixf_f = _get_ixf_and_check_device(hidden_state, self.__class__.__name__)
+        if not hidden_state.is_cuda:
+            raise RuntimeError(f"{self.__class__.__name__} expects CUDA tensors on Iluvatar.")
 
         if self.norm_pos == "pre":
             out, res_out = ixf_f.residual_layer_norm(
@@ -80,7 +77,8 @@ class IxformerLayerNorm(MojoLayerNorm):
                 "IxformerLayerNorm requires elementwise_affine=True with weight and bias (ixformer infer kernel)."
             )
 
-        ixf_f = _get_ixf_and_check_device(hidden_state, self.__class__.__name__)
+        if not hidden_state.is_cuda:
+            raise RuntimeError(f"{self.__class__.__name__} expects CUDA tensors on Iluvatar.")
 
         out, _ = ixf_f.residual_layer_norm(
             hidden_state,
@@ -99,7 +97,8 @@ class IxformerRMSNorm(MojoRMSNorm):
     supported_platforms_list = ["ilu"]
 
     def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
-        ixf_f = _get_ixf_and_check_device(hidden_state, self.__class__.__name__)
+        if not hidden_state.is_cuda:
+            raise RuntimeError(f"{self.__class__.__name__} expects CUDA tensors on Iluvatar.")
 
         # Aligns with ixformer tests: plain RMSNorm uses residual_rms_norm with residual=None
         # (dispatches to ops.infer.rms_norm); optional fused bias is unused by MojoRMSNorm.

--- a/mojo_opset/backends/torch_npu/operators/attention.py
+++ b/mojo_opset/backends/torch_npu/operators/attention.py
@@ -81,6 +81,10 @@ class TorchNpuPagedPrefillGQA(MojoPagedPrefillGQA, default_priority=0):
         softmax_scale: Optional[float] = None,
         seqlens_kv: Optional[torch.Tensor] = None,
         mask: Optional[torch.Tensor] = None,
+        *,
+        cu_seqlens_kv: Optional[torch.Tensor] = None,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_k: Optional[int] = None,
     ) -> torch.Tensor:
         assert_paged_prefill_contract(cu_seqlens_q, block_tables, seqlens_kv)
         _, num_q_heads, head_dim = query.shape
@@ -94,7 +98,19 @@ class TorchNpuPagedPrefillGQA(MojoPagedPrefillGQA, default_priority=0):
 
         if block_size % 128 != 0 or block_size > 512:
             # high performance attention kernel only supports block_size % 128 == 0 and block_size <= 512
-            return super().forward(query, key_cache, value_cache, cu_seqlens_q, block_tables, softmax_scale, seqlens_kv, mask)
+            return super().forward(
+                query,
+                key_cache,
+                value_cache,
+                cu_seqlens_q,
+                block_tables,
+                softmax_scale,
+                seqlens_kv,
+                mask,
+                cu_seqlens_kv=cu_seqlens_kv,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+            )
 
         if softmax_scale is None:
             softmax_scale = head_dim**-0.5
@@ -136,6 +152,10 @@ class TorchNpuPagedDecodeGQA(MojoPagedDecodeGQA, default_priority=0):
         block_tables: torch.Tensor,
         softmax_scale: Optional[float] = None,
         input_layout: Optional[str] = None,
+        cu_seq_lens: Optional[torch.Tensor] = None,
+        mask: Optional[torch.Tensor] = None,
+        *,
+        max_context_len: Optional[int] = None,
     ) -> Tuple[Any]:
         batch_size, num_q_heads, head_dim = query.shape
         _, head_nums, block_size, _ = k_cache.shape
@@ -144,7 +164,16 @@ class TorchNpuPagedDecodeGQA(MojoPagedDecodeGQA, default_priority=0):
             raise NotImplementedError(f"NPU kernel npu_fused_infer_attention_score currently produces incorrect results for head_dim={head_dim} (not a multiple of 128)")
 
         if block_size % 128 != 0 or block_size > 512:
-            return super().forward(query, k_cache, v_cache, seqlens, block_tables, softmax_scale)
+            return super().forward(
+                query,
+                k_cache,
+                v_cache,
+                seqlens,
+                block_tables,
+                softmax_scale=softmax_scale,
+                mask=mask,
+                max_context_len=max_context_len,
+            )
 
         if softmax_scale is None:
             softmax_scale = 1.0 / (head_dim**0.5)
@@ -169,7 +198,7 @@ class TorchNpuPagedDecodeGQA(MojoPagedDecodeGQA, default_priority=0):
             num_heads=num_q_heads,
             num_key_value_heads=head_nums,
             actual_seq_lengths=actual_seq_lengths_q,
-            actual_seq_lengths_kv=kv_seq_lens,
+            actual_seq_lengths_kv=seqlens.to(torch.int32),
             scale=softmax_scale,
         )
 

--- a/mojo_opset/backends/ttx/operators/attention.py
+++ b/mojo_opset/backends/ttx/operators/attention.py
@@ -36,6 +36,10 @@ class TTXPagedPrefillGQA(MojoPagedPrefillGQA):
         softmax_scale: Optional[float] = None,
         seqlens_kv: Optional[torch.Tensor] = None,
         mask: Optional[torch.Tensor] = None,
+        *,
+        cu_seqlens_kv: Optional[torch.Tensor] = None,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_k: Optional[int] = None,
     ):
         assert_paged_prefill_contract(cu_seqlens_q, block_tables, seqlens_kv)
         assert self.window_size == -1, (
@@ -45,6 +49,12 @@ class TTXPagedPrefillGQA(MojoPagedPrefillGQA):
             f"[TTXPagedPrefillGQA] TTX only support causal attention, but got is_causal={self.is_causal}"
         )
         assert mask is None, f"[TTXPagedPrefillGQA] TTX does not support mask, but got mask={mask}"
+        if seqlens_kv is None:
+            if cu_seqlens_kv is not None:
+                seqlens_kv = cu_seqlens_kv[1:] - cu_seqlens_kv[:-1]
+            else:
+                seqlens_kv = cu_seqlens_q[1:] - cu_seqlens_q[:-1]
+        # max_seqlen_q / max_seqlen_k / kwargs: core·Ixformer API compatibility; kernel uses per-seq lengths only.
         if self.aux_mask is None:
             self.aux_mask = torch.ones(
                 self.AUX_MASK_SIZE,
@@ -79,7 +89,10 @@ class TTXPagedDecodeGQA(MojoPagedDecodeGQA):
         seqlens: torch.Tensor,
         block_tables: torch.Tensor,
         softmax_scale: Optional[float] = None,
+        cu_seq_lens: Optional[torch.Tensor] = None,
         mask: Optional[torch.Tensor] = None,
+        *,
+        max_context_len: Optional[int] = None,
     ):
         assert seqlens.dtype == torch.int32
         assert block_tables.dtype == torch.int32
@@ -91,6 +104,8 @@ class TTXPagedDecodeGQA(MojoPagedDecodeGQA):
             f"[TTXPagedDecodeGQA] TTX only support causal attention, but got is_causal={self.is_causal}"
         )
         assert mask is None, f"[TTXPagedDecodeGQA] TTX does not support mask, but got mask={mask}"
+        assert cu_seq_lens is None, "varlen is not supported"
+        _ = max_context_len  # API parity with core / Ixformer; ILU kernel uses ``seqlens`` per row.
         output = paged_attention_decode(
             q=query,
             key_cache=key_cache,

--- a/mojo_opset/core/operators/attention.py
+++ b/mojo_opset/core/operators/attention.py
@@ -153,6 +153,8 @@ class MojoPagedDecodeGQA(MojoOperator):
         block_tables: torch.Tensor,
         softmax_scale: Optional[float] = None,
         mask: Optional[torch.Tensor] = None,
+        *,
+        max_context_len: Optional[int] = None,
     ):
         """
         Paged decode attention with grouped query heads (GQA) using a blocked KV cache.
@@ -361,6 +363,10 @@ class MojoPagedPrefillGQA(MojoOperator):
         softmax_scale: Optional[float] = None,
         seqlens_kv: Optional[torch.Tensor] = None,
         mask: Optional[torch.Tensor] = None,
+        *,
+        cu_seqlens_kv: Optional[torch.Tensor] = None,
+        max_seqlen_q: Optional[int] = None,
+        max_seqlen_k: Optional[int] = None,
     ) -> Tuple[Any]:
         """
         Paged prefill attention with grouped query heads (GQA) using a blocked KV cache.

--- a/mojo_opset/tests/accuracy/operators/test_attention.py
+++ b/mojo_opset/tests/accuracy/operators/test_attention.py
@@ -42,7 +42,8 @@ def generate_paged_decode_data(
     else:
         seqlens = torch.randperm(batch_size, dtype=torch.int32)
 
-    max_num_blocks_per_seq = (seqlens.max().item() + block_size - 1) // block_size
+    max_context_len = seqlens.max().item()
+    max_num_blocks_per_seq = (max_context_len + block_size - 1) // block_size
     total_blocks_needed = int(torch.div(seqlens + block_size - 1, block_size, rounding_mode="floor").sum().item())
 
     if total_blocks_needed == 0:
@@ -68,7 +69,7 @@ def generate_paged_decode_data(
         block_tables[i, :num_blocks_for_seq] = assigned_blocks
         current_block_offset += num_blocks_for_seq
 
-    return query, k_cache, v_cache, seqlens, block_tables
+    return query, k_cache, v_cache, seqlens, block_tables, max_context_len
 
 
 test_configs_decode = [
@@ -81,7 +82,7 @@ test_configs_decode = [
 
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, seqlens, block_tables",
+    "query, k_cache, v_cache, seqlens, block_tables, max_context_len",
     [
         pytest.param(
             *generate_paged_decode_data(
@@ -107,6 +108,7 @@ def test_paged_decode_gqa(
     v_cache: torch.Tensor,
     seqlens: torch.Tensor,
     block_tables: torch.Tensor,
+    max_context_len: int,
     gqa_layout: str,
 ):
     head_dim = query.shape[-1]
@@ -132,6 +134,7 @@ def test_paged_decode_gqa(
         seqlens,
         block_tables,
         softmax_scale=softmax_scale,
+        max_context_len=max_context_len,
         atol=atol,
         rtol=rtol,
     )
@@ -208,7 +211,10 @@ def generate_paged_prefill_data(
             k_cache[physical_block_id, :, :tokens_in_block, :] = k_slice
             v_cache[physical_block_id, :, :tokens_in_block, :] = v_slice
 
-    return query, k_cache, v_cache, cu_seqlens_q, block_tables, None if kv_cache_lens is None else kv_lens
+    seqlens_kv = None if kv_cache_lens is None else kv_lens
+    max_seqlen_q = int((cu_seqlens_q[1:] - cu_seqlens_q[:-1]).max().item()) if cu_seqlens_q.numel() > 1 else 0
+    max_seqlen_k = int(kv_lens.max().item()) if kv_lens.numel() > 0 else 0
+    return query, k_cache, v_cache, cu_seqlens_q, cu_seqlens_kv, block_tables, seqlens_kv, max_seqlen_q, max_seqlen_k
 
 
 test_configs_prefill = [
@@ -221,7 +227,7 @@ test_configs_prefill = [
 
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, cu_seqlens_q, block_tables, seqlens_kv",
+    "query, k_cache, v_cache, cu_seqlens_q, cu_seqlens_kv, block_tables, seqlens_kv, max_seqlen_q, max_seqlen_k",
     [
         pytest.param(
             *generate_paged_prefill_data(
@@ -247,9 +253,12 @@ def test_paged_prefill_gqa(
     k_cache: torch.Tensor,
     v_cache: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
+    cu_seqlens_kv: torch.Tensor,
     block_tables: torch.Tensor,
     gqa_layout: str,
     seqlens_kv: Optional[torch.Tensor],
+    max_seqlen_q: int,
+    max_seqlen_k: int,
 ):
     paged_prefill_attn = MojoPagedPrefillGQA(
         is_causal=True,
@@ -270,9 +279,12 @@ def test_paged_prefill_gqa(
         k_cache,
         v_cache,
         cu_seqlens_q,
-        block_tables,
+        block_tables=block_tables,
         softmax_scale=softmax_scale,
         seqlens_kv=seqlens_kv,
+        cu_seqlens_kv=cu_seqlens_kv,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
         atol=2e-2 if query.dtype != torch.float32 else 1e-5,
         rtol=2e-2 if query.dtype != torch.float32 else 1e-6,
     )
@@ -704,7 +716,7 @@ def test_paged_prefill_mla(B, H, d_nope, d_rope, d_v, d_c, max_q, blk):
 )
 @bypass_not_implemented
 def test_paged_decode_nsa(B, H, D, S, blk):
-    query, k_cache, v_cache, seqlens, bt = generate_paged_decode_data(
+    query, k_cache, v_cache, seqlens, bt, _ = generate_paged_decode_data(
         batch_size=B, num_q_heads=H, num_kv_heads=H,
         head_dim=D, max_seq_len=S, block_size=blk, dtype=torch.bfloat16,
     )
@@ -765,7 +777,7 @@ def test_prefill_nsa(H, D):
 @bypass_not_implemented
 def test_paged_prefill_nsa(H, D, blk):
     B = 2
-    query, k_cache, v_cache, cu, bt, _ = generate_paged_prefill_data(
+    query, k_cache, v_cache, cu, _, bt, _, _, _ = generate_paged_prefill_data(
         batch_size=B, num_q_heads=H, num_kv_heads=H,
         head_dim=D, max_q_len=32, max_kv_computed_len=0,
         block_size=blk, dtype=torch.bfloat16,
@@ -805,7 +817,7 @@ test_configs_swa_prefill = [
     "query, k_cache, v_cache, cu_seqlens_q, block_tables, seqlens_kv",
     [
         pytest.param(
-            *generate_paged_prefill_data(
+            *(lambda d: (d[0], d[1], d[2], d[3], d[5], d[6]))(generate_paged_prefill_data(
                 batch_size=B,
                 num_q_heads=Q_H,
                 num_kv_heads=KV_H,
@@ -814,7 +826,7 @@ test_configs_swa_prefill = [
                 max_kv_computed_len=KV_COMPUTED_LEN,
                 block_size=BLK_S,
                 dtype=dtype,
-            ),
+            )),
             id=ID,
         )
         for B, Q_H, KV_H, D, Q_LEN, KV_COMPUTED_LEN, BLK_S, dtype, ID in test_configs_swa_prefill
@@ -880,7 +892,7 @@ test_configs_swa_decode = [
 ]
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, seqlens, block_tables",
+    "query, k_cache, v_cache, seqlens, block_tables, max_context_len",
     [
         pytest.param(
             *generate_paged_decode_data(
@@ -909,6 +921,7 @@ def test_paged_decode_swa(
     v_cache: torch.Tensor,
     seqlens: torch.Tensor,
     block_tables: torch.Tensor,
+    max_context_len: int,
     gqa_layout: str,
     global_window: int,
     local_window: int,


### PR DESCRIPTION
On iluvatar platform, add the ixformer backend operator IxformerPagedPrefillGQA and IxformerPagedDecodeGQA . Several points warrant attention：

(1)To achieve higher performance, it can eliminate some redundant operations in the forward pass. For example, precomputing max_context_len as mentioned in the PR. Anthor potential optimizations also include transforming tensors (e.g., transposing) to better match the kernel’s expected layout. Howerver, this alters the original interface.

(2)Since only int32 datatype blocktable is supported for ixformer backend, so the test is modified accordingly. It worth further discussion: whether int32 is sufficient for the majority of cases.