### PR TITLE
Expose backend registry accessors

### DIFF
--- a/mojo_opset/core/backend_registry.py
+++ b/mojo_opset/core/backend_registry.py
@@ -1,4 +1,5 @@
 from typing import Dict
+from typing import Optional
 from typing import Union
 
 from mojo_opset.utils.logging import get_logger
@@ -23,6 +24,15 @@ BACKEND_PRIORITY_MAP = {
     "torchnpu": "torch_npu"
 }  ## Avoid the issue of failed identification of underscore "_" in the torch_npu backend name
 
+
+def _normalize_backend_name(backend_name: Optional[str] = None) -> Optional[str]:
+    if backend_name is None:
+        return None
+
+    normalized_backend_name = backend_name.strip().lower()
+    return BACKEND_PRIORITY_MAP.get(normalized_backend_name, normalized_backend_name)
+
+
 class MojoBackendRegistry:
     def __init__(self, core_op_cls: Union[MojoOperator, MojoFunction]):
         assert core_op_cls.__name__.startswith("Mojo"), (
@@ -41,12 +51,9 @@ class MojoBackendRegistry:
             f"Operator {cls.__name__} who be a subclass of {self._core_op_cls.__name__} must "
             f"contain {self._operator_name} in its name."
         )
-        impl_backend_name = cls.__name__[:idx].lower()
+        impl_backend_name = _normalize_backend_name(cls.__name__[:idx])
 
         curr_platform = get_platform()
-
-        if impl_backend_name not in BACKEND_PRIORITY_LIST and impl_backend_name in BACKEND_PRIORITY_MAP:
-            impl_backend_name = BACKEND_PRIORITY_MAP[impl_backend_name]
 
         # Hard code for some special cases
         assert impl_backend_name != "mojo", "should not register base backend"
@@ -88,6 +95,8 @@ class MojoBackendRegistry:
         # may lead to missing registrations. To avoid this, we first ensure that all
         # backends are fully registered before accessing or executing the registry
         # of a specific backend.
+        backend_name = _normalize_backend_name(backend_name)
+
         if (backend_name is None) or (backend_name not in self._registry.keys()):  # get first class
             assert len(self._registry) > 0, f"{self._operator_name} does not implement any backend."
             fallback = list(self._registry.values())[0]
@@ -98,15 +107,7 @@ class MojoBackendRegistry:
             )
             return fallback
 
-        try:
-            return self._registry[backend_name]
-        except Exception as e:
-            logger.warning(
-                f"Failed to get backend '{backend_name}' for "
-                f"{self._operator_name}, falling back to '{fallback.__class__.__name__}'. "
-                f"Error: {e}"
-            )
-            return list(self._registry.values())[0]
+        return self._registry[backend_name]
 
     def sort(self):
         def _prio_key(item):

--- a/mojo_opset/core/backend_registry.py
+++ b/mojo_opset/core/backend_registry.py
@@ -13,6 +13,7 @@ PLATFORM_BACKEND_PRIORITY = {
     "npu": ["ttx", "torch_npu", "torch"],
     "ilu": ["ixformer", "ttx", "torch"],
     "mlu": ["ttx", "torch"],
+    "meta_device": ["torch"],
 }
 
 # All known backend name prefixes (used for registration validation).

--- a/mojo_opset/core/function.py
+++ b/mojo_opset/core/function.py
@@ -37,8 +37,7 @@ class MojoFunction(Function):
             cls._registry.register(cls)
             cls._registry.sort()
 
-            _raw = os.environ.get("MOJO_BACKEND")
-            target_backend = _raw.strip().lower() if _raw else None
+            target_backend = os.environ.get("MOJO_BACKEND")
             core_op_cls = cls._registry.get_core_op_cls()
 
             core_op_cls.forward = cls._registry.get(target_backend).forward
@@ -54,8 +53,7 @@ class MojoFunction(Function):
     @classmethod
     def get_backend_impl(cls, backend_name: Optional[str] = None):
         """Return the registered implementation class for the requested backend."""
-        normalized_backend = backend_name.strip().lower() if backend_name else None
-        return cls.get_registry().get(normalized_backend)
+        return cls.get_registry().get(backend_name)
 
     @staticmethod
     def forward(ctx, *args, **kwargs):

--- a/mojo_opset/core/function.py
+++ b/mojo_opset/core/function.py
@@ -1,5 +1,7 @@
 import os
 
+from typing import Optional
+
 from torch.autograd import Function
 
 from mojo_opset.utils.logging import get_logger
@@ -41,6 +43,19 @@ class MojoFunction(Function):
 
             core_op_cls.forward = cls._registry.get(target_backend).forward
             core_op_cls.backward = cls._registry.get(target_backend).backward
+
+    @classmethod
+    def get_registry(cls):
+        """Return the backend registry attached to this Mojo function class."""
+        if not hasattr(cls, "_registry") or cls._registry is None:
+            raise NotImplementedError(f"No {cls.__name__} implementation found, please register at least one.")
+        return cls._registry
+
+    @classmethod
+    def get_backend_impl(cls, backend_name: Optional[str] = None):
+        """Return the registered implementation class for the requested backend."""
+        normalized_backend = backend_name.strip().lower() if backend_name else None
+        return cls.get_registry().get(normalized_backend)
 
     @staticmethod
     def forward(ctx, *args, **kwargs):

--- a/mojo_opset/core/operator.py
+++ b/mojo_opset/core/operator.py
@@ -3,6 +3,7 @@ import os
 from abc import ABC
 from abc import abstractmethod
 from typing import Any
+from typing import Optional
 from typing import Tuple
 
 import torch
@@ -51,6 +52,19 @@ class MojoOperator(ABC, torch.nn.Module):
             return instance
         else:
             return super().__new__(cls)
+
+    @classmethod
+    def get_registry(cls):
+        """Return the backend registry attached to this Mojo operator class."""
+        if not hasattr(cls, "_registry") or cls._registry is None:
+            raise NotImplementedError(f"No {cls.__name__} implementation found, please register at least one.")
+        return cls._registry
+
+    @classmethod
+    def get_backend_impl(cls, backend_name: Optional[str] = None):
+        """Return the registered implementation class for the requested backend."""
+        normalized_backend = backend_name.strip().lower() if backend_name else None
+        return cls.get_registry().get(normalized_backend)
 
     def __init__(self, **kwargs):
         torch.nn.Module.__init__(self)

--- a/mojo_opset/core/operator.py
+++ b/mojo_opset/core/operator.py
@@ -42,10 +42,7 @@ class MojoOperator(ABC, torch.nn.Module):
             if not hasattr(cls, "_registry") or not cls._registry:
                 raise NotImplementedError(f"No {cls.__name__} implementation found, please register at least one.")
 
-            import os
-
-            _raw = os.environ.get("MOJO_BACKEND")
-            target_backend = _raw.strip().lower() if _raw else None
+            target_backend = os.environ.get("MOJO_BACKEND")
 
             target_class = cls._registry.get(target_backend)
             instance = target_class.__new__(target_class, *args, **kwargs)
@@ -63,8 +60,7 @@ class MojoOperator(ABC, torch.nn.Module):
     @classmethod
     def get_backend_impl(cls, backend_name: Optional[str] = None):
         """Return the registered implementation class for the requested backend."""
-        normalized_backend = backend_name.strip().lower() if backend_name else None
-        return cls.get_registry().get(normalized_backend)
+        return cls.get_registry().get(backend_name)
 
     def __init__(self, **kwargs):
         torch.nn.Module.__init__(self)

--- a/mojo_opset/tests/base/test_backend_dispatch.py
+++ b/mojo_opset/tests/base/test_backend_dispatch.py
@@ -27,7 +27,10 @@ def test_operator_dispatch(MojoOpCls):
 
     TorchOpCls = MojoOpCls.get_backend_impl("torch")
     assert TorchOpCls is registry.get("torch")
+    assert registry.get(" Torch ") is TorchOpCls
     assert MojoOpCls.get_backend_impl(" Torch ") is TorchOpCls
+    if "torch_npu" in registry._registry:
+        assert MojoOpCls.get_backend_impl("torchnpu") is registry.get("torch_npu")
     op_torch = TorchOpCls()
     assert (
         type(op_torch) == TorchOpCls
@@ -54,7 +57,10 @@ def test_function_dispatch(MojoFunc):
 
     func_torch = MojoFunc.get_backend_impl("torch")
     assert func_torch is registry.get("torch")
+    assert registry.get(" Torch ") is func_torch
     assert MojoFunc.get_backend_impl(" Torch ") is func_torch
+    if "torch_npu" in registry._registry:
+        assert MojoFunc.get_backend_impl("torchnpu") is registry.get("torch_npu")
     if "ttx" in registry._registry:
         assert func_default.forward != func_torch.forward and func_default.backward != func_torch.backward
     else:

--- a/mojo_opset/tests/base/test_backend_dispatch.py
+++ b/mojo_opset/tests/base/test_backend_dispatch.py
@@ -15,11 +15,19 @@ from mojo_opset import MojoSiluFunction
 @bypass_not_implemented
 def test_operator_dispatch(MojoOpCls):
     op_default = MojoOpCls()
-    TTXOpCls = MojoOpCls._registry.get("ttx")
-    op_ttx = TTXOpCls()
-    assert type(op_default) == type(op_ttx) == TTXOpCls and TTXOpCls.__name__.startswith("TTX")
+    registry = MojoOpCls.get_registry()
+    assert registry is MojoOpCls._registry
+    assert type(op_default) == MojoOpCls.get_backend_impl()
 
-    TorchOpCls = MojoOpCls._registry.get("torch")
+    TTXOpCls = MojoOpCls.get_backend_impl("ttx")
+    assert TTXOpCls is registry.get("ttx")
+    if "ttx" in registry._registry:
+        op_ttx = TTXOpCls()
+        assert type(op_default) == type(op_ttx) == TTXOpCls and TTXOpCls.__name__.startswith("TTX")
+
+    TorchOpCls = MojoOpCls.get_backend_impl("torch")
+    assert TorchOpCls is registry.get("torch")
+    assert MojoOpCls.get_backend_impl(" Torch ") is TorchOpCls
     op_torch = TorchOpCls()
     assert (
         type(op_torch) == TorchOpCls
@@ -36,11 +44,21 @@ def test_operator_dispatch(MojoOpCls):
 @bypass_not_implemented
 def test_function_dispatch(MojoFunc):
     func_default = MojoFunc
-    func_ttx = MojoFunc._registry.get("ttx")
-    assert func_default.forward == func_ttx.forward and func_default.backward == func_ttx.backward
+    registry = MojoFunc.get_registry()
+    assert registry is MojoFunc._registry
 
-    func_torch = MojoFunc._registry.get("torch")
-    assert func_default.forward != func_torch.forward and func_default.backward != func_torch.backward
+    func_ttx = MojoFunc.get_backend_impl("ttx")
+    assert func_ttx is registry.get("ttx")
+    if "ttx" in registry._registry:
+        assert func_default.forward == func_ttx.forward and func_default.backward == func_ttx.backward
+
+    func_torch = MojoFunc.get_backend_impl("torch")
+    assert func_torch is registry.get("torch")
+    assert MojoFunc.get_backend_impl(" Torch ") is func_torch
+    if "ttx" in registry._registry:
+        assert func_default.forward != func_torch.forward and func_default.backward != func_torch.backward
+    else:
+        assert func_default.forward == func_torch.forward and func_default.backward == func_torch.backward
 
 
 def test_accuracy_helper_raises_when_requested_backend_missing(monkeypatch):


### PR DESCRIPTION
## Summary
- add public registry/backend implementation accessors to MojoOperator and MojoFunction
- normalize requested backend names before lookup
- support meta_device fallback priority and cover public API dispatch tests

## Validation
- python -m pytest mojo_opset/tests/base/test_backend_dispatch.py
- python -m compileall -q mojo_opset/core mojo_opset/tests/base/test_backend_dispatch.py