### PR TITLE
[ttx/npu] Optimize lightning_indexer_kernel by deferring k_scale to post-dot

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/lightning_indexer.py
+++ b/mojo_opset/backends/ttx/kernels/npu/lightning_indexer.py
@@ -143,8 +143,6 @@ def lightning_indexer_kernel(
         )
         k_scale = tl.load(key_scale_ptrs, mask=mask, other=0.0)
 
-        k = k * k_scale[:, None]
-
         query_ptrs = (
             query_ptr
             + batch_idx * query_stride_b
@@ -154,7 +152,8 @@ def lightning_indexer_kernel(
         )
         q = tl.load(query_ptrs)
 
-        relu_qk = tl.maximum(tl.dot(q.to(k.dtype), tl.trans(k)), 0.0)
+        mul_qk = tl.dot(q.to(k.dtype), tl.trans(k))
+        relu_qk = tl.maximum(mul_qk * k_scale[None, :], 0.0)
 
         query_scale_ptrs = (
             query_scale_ptr


### PR DESCRIPTION
## Description

Optimize `lightning_indexer_kernel` by deferring `k_scale` application from pre-scaling K tensor
to post-dot product scaling, fully leveraging AIC and AIV core memory bandwidth.

### Changes

- Remove per-element K tensor pre-scaling (`k = k * k_scale[:, None]`)
- Apply `k_scale` after QK dot product as a lightweight broadcast multiply

## Performance

Benchmark on Ascend 910C NPU and triton-ascend 3.2.0 (device latency):

| Shape (B, M/N, K) | dtype | Before (us) | After (us) | Speedup |
|---|---|---|---|---|
| (128, 256, 128) | bf16 | 23041.37 | 3775.62 | **6.10x** |
| (128, 256, 128) | fp16 | 23086.30 | 3776.70 | **6.11x** |
| (128, 256, 128) | fp32 | 12731.75 | 4275.99 | **2.98x** |
| (24, 1024, 128) | bf16 | 81850.27 | 22634.35 | **3.62x** |
| (24, 1024, 128) | fp16 | 81893.52 | 22645.16 | **3.62x** |
| (24, 1024, 128) | fp32 | 65051.82 | 28828.05 | **2.26x** |
| (24, 16384, 128) | bf16 | 1410.02 | 420.78 | **3.35x** |
| (24, 16384, 128) | fp16 | 1402.41 | 420.66 | **3.33x** |
| (24, 16384, 128) | fp32 | 1041.73 | 502.65 | **2.07x** |

Average speedup: **~3.6x** (bf16/fp16 gains significantly higher than fp32).

## Accuracy

All accuracy tests passed across all test shapes and dtypes (bf16/fp16/fp32).