### PR TITLE
Enable torch deterministic config for mojo deterministic mode

### DIFF
--- a/.github/workflows/iluvatar_accuracy_ci.yml
+++ b/.github/workflows/iluvatar_accuracy_ci.yml
@@ -70,10 +70,7 @@ jobs:
             python3 -m build .
             pip install dist/*.whl --force-reinstall --no-deps
             pip3 uninstall -y ixformer
-            curl -x http://sys-proxy-rd-relay.byted.org:3128 \
-                 -O \
-                 -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" \
-                 http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260416-cp310-cp310-linux_x86_64.whl
+            curl -O -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260416-cp310-cp310-linux_x86_64.whl
             pip3 install ixformer*.whl
           "
 

--- a/.github/workflows/iluvatar_accuracy_ci.yml
+++ b/.github/workflows/iluvatar_accuracy_ci.yml
@@ -70,7 +70,10 @@ jobs:
             python3 -m build .
             pip install dist/*.whl --force-reinstall --no-deps
             pip3 uninstall -y ixformer
-            curl -O -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260416-cp310-cp310-linux_x86_64.whl
+            curl -x http://sys-proxy-rd-relay.byted.org:3128 \
+                 -O \
+                 -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" \
+                 http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260416-cp310-cp310-linux_x86_64.whl
             pip3 install ixformer*.whl
           "
 

--- a/mojo_opset/backends/__init__.py
+++ b/mojo_opset/backends/__init__.py
@@ -1,10 +1,20 @@
 from mojo_opset.utils.logging import get_logger
-from mojo_opset.utils.platform import get_platform
+from mojo_opset.utils.misc import configure_torch_deterministic
 from mojo_opset.utils.misc import get_bool_env
+from mojo_opset.utils.platform import get_platform
 
 logger = get_logger(__name__)
 
 platform = get_platform()
+is_deterministic = get_bool_env("MOJO_DETERMINISTIC", default=False)
+
+if is_deterministic:
+    if platform == "npu":
+        import os
+
+        # special setting for npu deterministic matmul
+        os.environ["CLOSE_MATMUL_K_SHIFT"] = "1"
+    configure_torch_deterministic()
 
 _SUPPORT_TTX_PLATFROM = ["npu", "ilu", "mlu"]
 _SUPPORT_TORCH_NPU_PLATFROM = ["npu"]
@@ -21,9 +31,3 @@ if platform in _SUPPORT_TTX_PLATFROM:
 
 if platform in _SUPPORT_TORCH_NPU_PLATFROM:
     from .torch_npu import *
-
-if platform == "npu" and get_bool_env("MOJO_DETERMINISTIC", default=False):
-    import os
-    
-    # special setting for npu deterministic matmul
-    os.environ["CLOSE_MATMUL_K_SHIFT"] = "1"

--- a/mojo_opset/tests/base/test_deterministic_config.py
+++ b/mojo_opset/tests/base/test_deterministic_config.py
@@ -1,0 +1,48 @@
+import pytest
+import torch
+
+from mojo_opset.utils.misc import configure_torch_deterministic
+
+
+@pytest.fixture(autouse=True)
+def restore_torch_state():
+    rng_state = torch.random.get_rng_state()
+    deterministic_algorithms_enabled = torch.are_deterministic_algorithms_enabled()
+    cudnn_benchmark = torch.backends.cudnn.benchmark
+    cudnn_deterministic = torch.backends.cudnn.deterministic
+
+    yield
+
+    torch.random.set_rng_state(rng_state)
+    torch.use_deterministic_algorithms(deterministic_algorithms_enabled)
+    torch.backends.cudnn.benchmark = cudnn_benchmark
+    torch.backends.cudnn.deterministic = cudnn_deterministic
+
+
+def test_configure_torch_deterministic_enables_deterministic_algorithms():
+    torch.use_deterministic_algorithms(False)
+
+    configure_torch_deterministic()
+
+    assert torch.are_deterministic_algorithms_enabled()
+
+
+def test_configure_torch_deterministic_sets_manual_seed():
+    configure_torch_deterministic()
+    actual = torch.rand(4)
+
+    torch.manual_seed(0)
+    expected = torch.rand(4)
+
+    assert torch.equal(actual, expected)
+
+
+def test_configure_torch_deterministic_sets_cudnn_flags_when_cuda_available(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cudnn.deterministic = False
+
+    configure_torch_deterministic()
+
+    assert not torch.backends.cudnn.benchmark
+    assert torch.backends.cudnn.deterministic

--- a/mojo_opset/utils/misc.py
+++ b/mojo_opset/utils/misc.py
@@ -13,6 +13,17 @@ def get_bool_env(key, default=True):
         return default
 
 
+def configure_torch_deterministic(seed=0):
+    import torch
+
+    torch.manual_seed(seed)
+    torch.use_deterministic_algorithms(True)
+
+    if torch.cuda.is_available():
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
 def get_tensor_factory_kwargs(**kwargs):
     factory_kwargs = {}
     for k, v in kwargs.items():


### PR DESCRIPTION
## Summary

- Configure PyTorch deterministic behavior when `MOJO_DETERMINISTIC=1` is enabled.
- Add `configure_torch_deterministic()` to call `torch.manual_seed(0)` and `torch.use_deterministic_algorithms(True)`.
- Add focused tests for the deterministic algorithm flag and manual seed behavior.

## Validation

- `python -m pytest mojo_opset/tests/base/test_deterministic_config.py mojo_opset/tests/base/test_backend_dispatch.py`
- `git diff --check`
- `python -m py_compile mojo_opset/utils/misc.py mojo_opset/backends/__init__.py mojo_opset/tests/base/test_deterministic_config.py`