### PR TITLE
[ilu/ttx] opt swa paged decode: use paged_attention_decode when window size greater than sequence lens

### DIFF
--- a/mojo_opset/backends/ttx/operators/attention.py
+++ b/mojo_opset/backends/ttx/operators/attention.py
@@ -352,6 +352,15 @@ class TTXPagedDecodeSWA(MojoPagedDecodeSWA):
     ) -> torch.Tensor:
         # Note: is_causal = False should never happen
         assert_paged_decode_contract(block_table, total_seq_lens)
+        if max_total_seq_len is not None:
+            g_window_size = self.global_window_size if self.global_window_size is not None else 0
+            l_window_size = self.local_window_size if self.local_window_size is not None else 0
+            if g_window_size + l_window_size >= max_total_seq_len:
+                o = paged_attention_decode(
+                    q, k_cache, v_cache, total_seq_lens, block_table,
+                    self.gqa_interleave, softmax_scale,
+                )
+                return o
         o = swa_paged_decode(
             q,
             k_cache,

--- a/mojo_opset/tests/perf/test_attention.py
+++ b/mojo_opset/tests/perf/test_attention.py
@@ -28,7 +28,8 @@ def generate_paged_decode_data(
 
     total_seq_lens = torch.randint(1, max_seq_len, (batch_size,), dtype=torch.int32)
 
-    max_num_blocks_per_seq = (total_seq_lens.max().item() + block_size - 1) // block_size
+    max_total_seq_len = total_seq_lens.max().item()
+    max_num_blocks_per_seq = (max_total_seq_len + block_size - 1) // block_size
     total_blocks_needed = int(torch.div(total_seq_lens + block_size - 1, block_size, rounding_mode="floor").sum().item())
 
     if total_blocks_needed == 0:
@@ -54,7 +55,7 @@ def generate_paged_decode_data(
         block_tables[i, :num_blocks_for_seq] = assigned_blocks
         current_block_offset += num_blocks_for_seq
 
-    return query, k_cache, v_cache, total_seq_lens, block_tables
+    return query, k_cache, v_cache, total_seq_lens, block_tables, max_total_seq_len
 
 
 test_configs_decode = [
@@ -65,7 +66,7 @@ test_configs_decode = [
 
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, total_seq_lens, block_tables",
+    "query, k_cache, v_cache, total_seq_lens, block_tables, max_total_seq_len",
     [
         pytest.param(
             *generate_paged_decode_data(
@@ -91,6 +92,7 @@ def test_paged_decode_gqa(
     v_cache: torch.Tensor,
     total_seq_lens: torch.Tensor,
     block_tables: torch.Tensor,
+    max_total_seq_len: int,
     gqa_layout: str,
 ):
     head_dim = query.shape[-1]
@@ -361,7 +363,7 @@ test_configs_swa_decode = [
 
 
 @pytest.mark.parametrize(
-    "query, k_cache, v_cache, total_seq_lens, block_tables",
+    "query, k_cache, v_cache, total_seq_lens, block_tables, max_total_seq_len",
     [
         pytest.param(
             *generate_paged_decode_data(
@@ -389,6 +391,7 @@ def test_paged_decode_swa(
     v_cache: torch.Tensor,
     total_seq_lens: torch.Tensor,
     block_tables: torch.Tensor,
+    max_total_seq_len: int,
     gqa_layout: str,
     global_window: int,
     local_window: int,
@@ -411,6 +414,7 @@ def test_paged_decode_swa(
             total_seq_lens,
             block_tables,
             softmax_scale=softmax_scale,
+            max_total_seq_len=max_total_seq_len,
         )
     )
 


### PR DESCRIPTION
Enhance TTXPagedDecodeSWA with global and local window size checks. use paged_attention_decode when global_window_size + local_window_size >= max_slen - 1
Update test cases to include max_total_seq_len in data generation and parameterization for improved attention decoding performance.