### PR TITLE
[ilu/ttx] speed up ILU grouped matmul host path and autotune

### DIFF
--- a/mojo_opset/backends/ttx/kernels/__init__.py
+++ b/mojo_opset/backends/ttx/kernels/__init__.py
@@ -88,6 +88,7 @@ diffusion_attention_fwd_impl = _get_kernel_impl(ttx_backend_module, "diffusion_a
 diffusion_attention_bwd_impl = _get_kernel_impl(ttx_backend_module, "diffusion_attention_bwd_impl")
 
 m_grouped_matmul_impl = _get_kernel_impl(ttx_backend_module, "m_grouped_matmul_impl")
+m_grouped_matmul_capturable_impl = _get_kernel_impl(ttx_backend_module, "m_grouped_matmul_capturable_impl")
 k_grouped_matmul_impl = _get_kernel_impl(ttx_backend_module, "k_grouped_matmul_impl")
 
 moe_gating_impl = _get_kernel_impl(ttx_backend_module, "moe_gating_impl")
@@ -786,6 +787,50 @@ if os.getenv("MOJO_RUN_MODE", "EAGER") == "COMPILE":
     ) -> torch.Tensor:
         return torch.empty_like(C)
 
+    @torch.library.custom_op("ttx::m_grouped_matmul_capturable", mutates_args={})
+    def m_grouped_matmul_capturable(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        C: torch.Tensor,
+        size_per_group: torch.Tensor,
+        num_groups: int,
+        M: int,
+        N: int,
+        K: int,
+        strideBN: int,
+        strideBK: int,
+        trans_b: bool = False,
+    ) -> torch.Tensor:
+        return m_grouped_matmul_capturable_impl(
+            A,
+            B,
+            C,
+            size_per_group,
+            num_groups,
+            M,
+            N,
+            K,
+            strideBN,
+            strideBK,
+            trans_b,
+        )
+
+    @m_grouped_matmul_capturable.register_fake
+    def m_grouped_matmul_capturable_fake(
+        A: torch.Tensor,
+        B: torch.Tensor,
+        C: torch.Tensor,
+        size_per_group: torch.Tensor,
+        num_groups: int,
+        M: int,
+        N: int,
+        K: int,
+        strideBN: int,
+        strideBK: int,
+        trans_b: bool = False,
+    ) -> torch.Tensor:
+        return torch.empty_like(C)
+
     @torch.library.custom_op("ttx::k_grouped_matmul", mutates_args={})
     def k_grouped_matmul(
         A: torch.Tensor,
@@ -963,6 +1008,7 @@ else:
     diffusion_attention_fwd = diffusion_attention_fwd_impl
     diffusion_attention_bwd = diffusion_attention_bwd_impl
     m_grouped_matmul = m_grouped_matmul_impl
+    m_grouped_matmul_capturable = m_grouped_matmul_capturable_impl
     k_grouped_matmul = k_grouped_matmul_impl
     moe_gating = moe_gating_impl
     moe_dispatch = moe_dispatch_impl

--- a/mojo_opset/backends/ttx/kernels/ilu/__init__.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/__init__.py
@@ -17,6 +17,7 @@ from .gelu import gelu_bwd_impl
 from .gelu import gelu_fwd_impl
 from .group_gemm import k_grouped_matmul_impl
 from .group_gemm import m_grouped_matmul_impl
+from .group_gemm import m_grouped_matmul_capturable_impl
 from .moe import moe_gating_impl
 from .moe import moe_dispatch_impl
 from .moe import moe_experts_impl
@@ -80,6 +81,7 @@ __all__ = [
     "gelu_bwd_impl",
     "gelu_fwd_impl",
     "m_grouped_matmul_impl",
+    "m_grouped_matmul_capturable_impl",
     "k_grouped_matmul_impl",
     "moe_gating_impl",
     "moe_dispatch_impl",

--- a/mojo_opset/backends/ttx/kernels/ilu/group_gemm.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/group_gemm.py
@@ -55,7 +55,27 @@ def m_grouped_matmul_autotune_config():
                     {"BLOCK_M": BM, "BLOCK_N": BN, "BLOCK_K": BK},
                     num_warps=nw, num_stages=ns,
                 ))
+    for BN in [128, 256]:
+        for BK in [64, 128]:
+            for nw in [4, 8]:
+                for ns in [2, 3]:
+                    configs.append(triton.Config(
+                        {"BLOCK_M": 16, "BLOCK_N": BN, "BLOCK_K": BK},
+                        num_warps=nw, num_stages=ns,
+                    ))
     return configs
+
+
+def _bucket_max_m(m: int) -> int:
+    if m <= 16:
+        return 16
+    if m <= 64:
+        return 64
+    if m <= 256:
+        return 256
+    if m <= 1024:
+        return 1024
+    return 1 << (m - 1).bit_length()
 
 
 @smart_triton_autotune(configs=m_grouped_matmul_autotune_config(), selected_idx=0, key=["N", "K", "MAX_M"])
@@ -136,11 +156,19 @@ def m_grouped_matmul_impl(
     max_m: Optional[int] = None,
 ) -> torch.Tensor:
     if group_offsets is None:
-        cum = size_per_group.cumsum(0, dtype=torch.int32)
-        group_offsets = torch.zeros(num_groups + 1, dtype=torch.int32, device=A.device)
-        group_offsets[1:] = cum
-    if max_m is None:
-        max_m = size_per_group.max().item()
+        sizes = size_per_group.tolist()
+        offs = [0] * (num_groups + 1)
+        acc = 0
+        for i in range(num_groups):
+            acc += sizes[i]
+            offs[i + 1] = acc
+        group_offsets = torch.tensor(
+            offs, dtype=torch.int32, pin_memory=A.is_cuda
+        ).to(A.device, non_blocking=A.is_cuda)
+        if max_m is None:
+            max_m = max(sizes) if num_groups else 0
+    elif max_m is None:
+        max_m = int(size_per_group.max()) if size_per_group.numel() > 0 else 0
 
     def grid(META):
         return (
@@ -156,7 +184,55 @@ def m_grouped_matmul_impl(
         group_offsets,
         N,
         K,
-        max_m,
+        _bucket_max_m(max_m),
+        B.stride(0),
+        strideBK,
+        strideBN,
+        trans_b,
+    )
+    return C
+
+
+def m_grouped_matmul_capturable_impl(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    size_per_group: torch.Tensor,
+    num_groups: int,
+    M: int,
+    N: int,
+    K: int,
+    strideBN: int,
+    strideBK: int,
+    trans_b: bool = False,
+    max_m: Optional[int] = None,
+) -> torch.Tensor:
+    # CUDA-graph-capturable variant: derive offsets on-device (no host sync) and
+    # use a static grid bound so the launch shape is fixed across graph replays.
+    cum = size_per_group.cumsum(0, dtype=torch.int32)
+    group_offsets = torch.zeros(num_groups + 1, dtype=torch.int32, device=A.device)
+    group_offsets[1:] = cum
+    # Any single group has at most M rows, so M is a safe static upper bound that
+    # stays constant during capture; surplus m-tiles early-return via the per-group
+    # size check inside the kernel.
+    if max_m is None:
+        max_m = M
+
+    def grid(META):
+        return (
+            triton.cdiv(N, META["BLOCK_N"]),
+            triton.cdiv(max_m, META["BLOCK_M"]),
+            num_groups,
+        )
+
+    _m_grouped_matmul_kernel[grid](
+        A,
+        B,
+        C,
+        group_offsets,
+        N,
+        K,
+        _bucket_max_m(max_m),
         B.stride(0),
         strideBK,
         strideBN,

--- a/mojo_opset/backends/ttx/operators/gemm.py
+++ b/mojo_opset/backends/ttx/operators/gemm.py
@@ -4,6 +4,7 @@ from torch.distributed.tensor import DTensor
 
 from mojo_opset.backends.ttx.kernels import int8_gemm_dequant
 from mojo_opset.backends.ttx.kernels import m_grouped_matmul
+from mojo_opset.backends.ttx.kernels import m_grouped_matmul_capturable
 from mojo_opset.backends.ttx.kernels import prepare_b
 from mojo_opset.backends.ttx.kernels import quant_batch_gemm_reduce_sum_impl
 from mojo_opset.core import MojoQuantGemm
@@ -81,7 +82,12 @@ class TTXGroupGemm(MojoGroupGemm):
         if isinstance(C, DTensor):
             C = C.to_local()
 
-        m_grouped_matmul(input, weight, C, group_list, num_groups, M, N, K, strideBN, strideBK, not self.trans_weight)
+        if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+            m_grouped_matmul_capturable(
+                input, weight, C, group_list, num_groups, M, N, K, strideBN, strideBK, not self.trans_weight
+            )
+        else:
+            m_grouped_matmul(input, weight, C, group_list, num_groups, M, N, K, strideBN, strideBK, not self.trans_weight)
 
         return C
 

--- a/mojo_opset/tests/accuracy/operators/test_gemm.py
+++ b/mojo_opset/tests/accuracy/operators/test_gemm.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import random
 
 import pytest
@@ -12,6 +14,7 @@ from mojo_opset.tests.utils import auto_switch_platform
 from mojo_opset.tests.utils import bypass_not_implemented
 from mojo_opset.tests.utils import get_platform
 from mojo_opset.tests.utils import get_torch_device
+from mojo_opset.utils.acc import check_tol_diff
 
 torch.manual_seed(42)
 
@@ -218,8 +221,7 @@ def generate_quant_group_gemm_data(
     return x1, weight, x1_scale, x2_scale
 
 
-@pytest.mark.parametrize(
-    "input, weight, group_list, trans_weight",
+_group_gemm_cases = (
     [
         (
             torch.randn(size=(8 * 2560, 4096), dtype=dtype),
@@ -276,8 +278,11 @@ def generate_quant_group_gemm_data(
             id=f"trans_weight_uneven_fp={'bf16' if dtype is torch.bfloat16 else 'fp16'}",
         )
         for dtype in [torch.float16, torch.bfloat16]
-    ],
+    ]
 )
+
+
+@pytest.mark.parametrize("input, weight, group_list, trans_weight", _group_gemm_cases)
 @bypass_not_implemented
 @auto_switch_platform()
 def test_group_gemm(input, weight, group_list, trans_weight):
@@ -433,3 +438,78 @@ def test_group_gemm_two_groups_single_call(dtype, trans_weight):
     out = op(x, group_list)
 
     torch.testing.assert_close(out.to(torch.float32), ref.to(torch.float32), atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.skipif(
+    get_platform() != "ilu" or os.environ.get("MOJO_BACKEND", "").strip().lower() != "ttx",
+    reason="CUDA Graph group gemm test is only enabled on ILU platform with TTX backend.",
+)
+@pytest.mark.parametrize("input, weight, group_list, trans_weight", _group_gemm_cases)
+def test_group_gemm_cuda_graph(input, weight, group_list, trans_weight):
+    """CUDA graph variant of test_group_gemm: same cases/tolerances, captured and replayed.
+
+    The capturable path derives group offsets on-device (no host sync) and uses a
+    static grid bound (max_m=M), so replays must pick up in-place edits to the static
+    input/group_list buffers without recompiling or relaunching.
+    """
+    device = get_torch_device()
+
+    input = input.to(device)
+    weight = weight.to(device)
+    group_list = group_list.to(device)
+
+    M, K = input.shape
+    G = weight.shape[0]
+    if trans_weight:
+        N = weight.shape[1]
+        strideBN, strideBK = weight.stride(1), weight.stride(2)
+    else:
+        N = weight.shape[2]
+        strideBK, strideBN = weight.stride(1), weight.stride(2)
+
+    op = MojoGroupGemm(weight=weight, trans_weight=trans_weight)
+    op_ref = MojoGroupGemm._registry.get("torch")(weight=weight.clone(), trans_weight=trans_weight)
+
+    # Same relaxed tolerance as test_group_gemm (bf16 large-K tl.dot accumulation).
+    atol, rtol, ptol = 1, 2**-6, 0.90
+
+    # Warm up the capturable path directly: the operator only dispatches to it
+    # while a stream is capturing, so a normal eager call would compile/autotune
+    # the host-path kernel under a different key=bucket(M) instead.
+    from mojo_opset.backends.ttx.kernels import m_grouped_matmul_capturable
+
+    C_warm = input.new_empty(M, N)
+    m_grouped_matmul_capturable(
+        input, weight, C_warm, group_list, G, M, N, K, strideBN, strideBK, not trans_weight
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    try:
+        with torch.cuda.graph(graph):
+            out = op(input, group_list)
+        torch.cuda.synchronize()
+    except Exception as e:
+        logging.getLogger(__name__).error(f"CUDA graph capture failed: {e}.")
+        torch.cuda.empty_cache()
+        pytest.skip(f"CUDA graph capture unsupported/failed: {e}")
+
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref_output = op_ref(input, group_list)
+    check_tol_diff(out, ref_output, atol=atol, rtol=rtol, ptol=ptol)
+
+    # Replay twice with fresh in-place workloads (sum still == M) to verify the
+    # on-device offset recompute picks up the mutated static buffers.
+    for _ in range(2):
+        group_list.copy_(generate_random_list(G, M).to(device))
+        input.copy_(torch.randn(M, K, dtype=input.dtype, device=device))
+
+        torch.cuda.synchronize()
+        graph.replay()
+        torch.cuda.synchronize()
+
+        ref_output = op_ref(input, group_list)
+        check_tol_diff(out, ref_output, atol=atol, rtol=rtol, ptol=ptol)


### PR DESCRIPTION
Use pinned non-blocking H2D for group_offsets to avoid draining the GPU queue each call, and add small-M autotune tiles (BLOCK_M=16) so large-N MoE shapes pick a bandwidth-friendly config. Drop MAX_M from the autotune key to avoid re-tuning on varying per-group row counts.