### PR TITLE
[ilu/ttx] optimize layernorm.

### DIFF
--- a/mojo_opset/backends/ttx/kernels/ilu/layernorm.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/layernorm.py
@@ -43,10 +43,10 @@ def _layernorm_fwd_kernel(
     rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
     rows_mask = task_mask & (rows_off < n_rows)
 
-    sum_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-
-    for col_offset in range(0, N_COLS, BLOCK_SIZE_N):
-        cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
+    if N_COLS <= BLOCK_SIZE_N:
+        # Single-tile path: the whole row fits in one tile, so load X once,
+        # keep it in registers and reuse it for stats + output (1 read + 1 write).
+        cols_off = tl.arange(0, BLOCK_SIZE_N)
         cols_mask = cols_off < N_COLS
         block_mask = rows_mask[:, None] & cols_mask[None, :]
 
@@ -54,45 +54,17 @@ def _layernorm_fwd_kernel(
             X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
         ).to(tl.float32)
 
-        sum_acc += tl.sum(x_chunk, axis=1)
+        mean = tl.sum(x_chunk, axis=1) / N_COLS
+        x_centered = tl.where(cols_mask[None, :], x_chunk - mean[:, None], 0.0)
+        var = tl.sum(x_centered * x_centered, axis=1) / N_COLS
+        rstd = tl.rsqrt(var + eps)
 
-    mean = sum_acc / N_COLS
-
-    tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
-
-    var_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-
-    for col_offset in range(0, N_COLS, BLOCK_SIZE_N):
-        cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-        cols_mask = cols_off < N_COLS
-        block_mask = rows_mask[:, None] & cols_mask[None, :]
-
-        x_chunk = tl.load(
-            X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
-        ).to(tl.float32)
-
-        x_centered = x_chunk - mean[:, None]
-
-        var_acc += tl.sum(x_centered * x_centered, axis=1)
-
-    var = var_acc / N_COLS
-    rstd = tl.rsqrt(var + eps)
-
-    tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
-
-    for col_offset in range(0, N_COLS, BLOCK_SIZE_N):
-        cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-        cols_mask = cols_off < N_COLS
-        block_mask = rows_mask[:, None] & cols_mask[None, :]
-
-        x_chunk = tl.load(
-            X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
-        ).to(tl.float32)
+        tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
+        tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
 
         w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
         b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
 
-        x_centered = x_chunk - mean[:, None]
         y_chunk = x_centered * rstd[:, None] * w_chunk[None, :] + b_chunk[None, :]
 
         tl.store(
@@ -100,6 +72,54 @@ def _layernorm_fwd_kernel(
             y_chunk,
             mask=block_mask,
         )
+    else:
+        # Multi-tile path: cannot keep the whole row in registers, so use a
+        # two-pass scheme. Pass 1 accumulates sum(x) and sum(x^2) together to
+        # derive both mean and variance in a single read; pass 2 normalizes.
+        sum_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+        sumsq_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+
+        for col_offset in range(0, N_COLS, BLOCK_SIZE_N):
+            cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
+            cols_mask = cols_off < N_COLS
+            block_mask = rows_mask[:, None] & cols_mask[None, :]
+
+            x_chunk = tl.load(
+                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
+            ).to(tl.float32)
+
+            sum_acc += tl.sum(x_chunk, axis=1)
+            sumsq_acc += tl.sum(x_chunk * x_chunk, axis=1)
+
+        mean = sum_acc / N_COLS
+        # E[x^2] - mean^2 can dip slightly below 0 from fp roundoff when the true
+        # variance is near zero; clamp to keep rsqrt finite (avoid NaN/inf).
+        var = tl.maximum(sumsq_acc / N_COLS - mean * mean, 0.0)
+        rstd = tl.rsqrt(var + eps)
+
+        tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
+        tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
+
+        for col_offset in range(0, N_COLS, BLOCK_SIZE_N):
+            cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
+            cols_mask = cols_off < N_COLS
+            block_mask = rows_mask[:, None] & cols_mask[None, :]
+
+            x_chunk = tl.load(
+                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
+            ).to(tl.float32)
+
+            w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
+            b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
+
+            x_centered = x_chunk - mean[:, None]
+            y_chunk = x_centered * rstd[:, None] * w_chunk[None, :] + b_chunk[None, :]
+
+            tl.store(
+                Y_ptr + rows_off[:, None] * stride_y_row + cols_off[None, :],
+                y_chunk,
+                mask=block_mask,
+            )
 
 
 @triton.heuristics({"BLOCK_SIZE_M": lambda args: ceil_div(4096, args.get("n_cols", args.get("N_COLS")))})
@@ -321,8 +341,8 @@ def layernorm_fwd_impl(x, w, b, eps):
         x_2d.stride(0),
         y.stride(0),
         n_rows,
-        n_cols,
         eps,
+        N_COLS=n_cols,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
     )
 

--- a/mojo_opset/backends/ttx/kernels/ilu/utils.py
+++ b/mojo_opset/backends/ttx/kernels/ilu/utils.py
@@ -61,7 +61,7 @@ def norm_fwd_heuristics(args):
     """BLOCK_SIZE_M heuristic for row tiling; shared by LayerNorm and RMSNorm kernels."""
     hidden_dim = args.get("n_cols", args.get("N_COLS"))
     if hidden_dim is None:
-        raise KeyError("n_cols")
+        raise KeyError("expected 'n_cols' or 'N_COLS' in kernel args")
     if hidden_dim <= COL_BLOCKING_THRESHOLD:
         if hidden_dim in TOKEN_BLOCK_SIZE_TABLE:
             return TOKEN_BLOCK_SIZE_TABLE[hidden_dim]
@@ -74,7 +74,23 @@ def norm_fwd_heuristics(args):
         return 4
 
 
-layer_norm_fwd_heuristics = norm_fwd_heuristics
+def layer_norm_fwd_heuristics(args):
+    """BLOCK_SIZE_M for the LayerNorm fwd kernel.
+
+    On the ILU backend the single-tile regime (hidden <= COL_BLOCKING_THRESHOLD,
+    where the whole row fits in one BLOCK_SIZE_N tile) parallelizes best with one
+    row per program: an empirical sweep shows BLOCK_SIZE_M=1 beats the old
+    TOKEN_BLOCK_SIZE_TABLE values (32/16/8/4) by 2-4x across hidden in
+    {128,256,512,1024,2048}. Multi-tile rows keep 4.
+    """
+    hidden_dim = args.get("n_cols", args.get("N_COLS"))
+    if hidden_dim is None:
+        raise KeyError("expected 'n_cols' or 'N_COLS' in kernel args")
+    if hidden_dim <= COL_BLOCKING_THRESHOLD:
+        return 1
+    return 4
+
+
 rms_norm_fwd_heuristics = norm_fwd_heuristics
 
 


### PR DESCRIPTION
optimize layernorm:
Single-tile path (N_COLS <= BLOCK_SIZE_N, i.e. hidden ≤ 2048): load X once, keep it in registers, and reuse it for mean → variance → output. 
Resulting impact (TTX time, bf16)
hidden=128: ~0.156ms → ~0.029ms at 1024 tokens (~5.5x faster);