### PR TITLE
MojoFusedNormRoPESageQuantStore: fused RoPE + KV-Quant with Key per-token Quant operator

### DIFF
--- a/.github/workflows/iluvatar_accuracy_ci.yml
+++ b/.github/workflows/iluvatar_accuracy_ci.yml
@@ -70,7 +70,7 @@ jobs:
             python3 -m build .
             pip install dist/*.whl --force-reinstall --no-deps
             pip3 uninstall -y ixformer
-            curl -O -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260610-cp310-cp310-linux_x86_64.whl
+            curl -O -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.4.2.1.20260623-cp310-cp310-linux_x86_64.whl
             pip3 install ixformer*.whl
           "
 

--- a/.github/workflows/iluvatar_accuracy_ci.yml
+++ b/.github/workflows/iluvatar_accuracy_ci.yml
@@ -70,7 +70,7 @@ jobs:
             python3 -m build .
             pip install dist/*.whl --force-reinstall --no-deps
             pip3 uninstall -y ixformer
-            curl -O -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260601-cp310-cp310-linux_x86_64.whl
+            curl -O -u "${DEEPSPARK_USER}:${DEEPSPARK_PASS}" http://files.deepspark.org.cn:880/upload/ixformer-0.7.0+corex.4.5.0.rc.5.20260616-cp310-cp310-linux_x86_64.whl
             pip3 install ixformer*.whl
           "
 

--- a/mojo_opset/backends/ixformer/operators/compute_with_comm.py
+++ b/mojo_opset/backends/ixformer/operators/compute_with_comm.py
@@ -2,7 +2,11 @@ import torch
 import torch.distributed as dist
 
 from ixformer import functions as ixf_f
-from ixformer.distributed import symmetric_memory as symm
+# from ixformer.distributed import symmetric_memory as symm
+try:
+    from ixformer.distributed import symmetric_memory as symm
+except ImportError:
+    symm = None 
 
 from mojo_opset.core.operators.compute_with_comm import (
     MojoAllGatherQuantGemm,

--- a/mojo_opset/backends/ixformer/operators/fused_norm_rope_sage_quant_store.py
+++ b/mojo_opset/backends/ixformer/operators/fused_norm_rope_sage_quant_store.py
@@ -86,7 +86,7 @@ class IxformerFusedNormRoPESageQuantStore(MojoFusedNormRoPESageQuantStore):
           - ``key_quant``   : [T, nkv, head_dim] static per-channel int8 key
           - ``value_quant`` : [T, nkv, head_dim] static per-channel int8 value
           - ``key_pt_int8`` : [T, nkv, head_dim] per-token int8 key
-          - ``key_pt_scale``: [T, nkv, 1] per-token bf16 scale
+          - ``key_pt_scale``: [T, nkv, 1] per-token float32 scale
         """
         head_size = self.head_dim
         if cu_q_lens is None:

--- a/mojo_opset/backends/ixformer/operators/fused_norm_rope_sage_quant_store.py
+++ b/mojo_opset/backends/ixformer/operators/fused_norm_rope_sage_quant_store.py
@@ -1,0 +1,208 @@
+import torch
+
+from ixformer import functions as ixf_f
+from mojo_opset.experimental import MojoFusedNormRoPESageQuantStore
+
+
+class IxformerFusedNormRoPESageQuantStore(MojoFusedNormRoPESageQuantStore):
+    """Ixformer backend for SAGE-aware fused QK-Norm + RoPE + KV-Quant + Store.
+
+      - SWA stream: ``rms_norm_qk_rotary_embedding_quant_kv_and_store``.
+
+      - Full stream: when SAGE is off, the same
+        ``rms_norm_qk_rotary_embedding_quant_kv_and_store``; when SAGE is on, the
+        ``rms_norm_sage_qk_rotary_embedding`` kernel, which performs the exact
+        same norm + rope + static K/V quant + paged store and additionally
+        produces the per-token dynamic-int8 view of the key and its per-token
+        scale, storing both into their own paged caches
+        (``sage_full_k_pt_cache`` / ``sage_full_k_pt_scale_cache``) inline,
+        exactly like ``key_cache`` / ``value_cache`` — all in one fused kernel —
+        and also returns ``(output_q, key_quant, value_quant, key_pt_int8,
+        key_pt_scale)``.
+    """
+
+    supported_platforms_list = ["ilu"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.head_dim != 128:
+            raise NotImplementedError(
+                f"ixformer fused kernel only supports head_dim=128, got {self.head_dim}"
+            )
+        if not (self.use_query_norm and self.use_key_norm):
+            raise NotImplementedError(
+                f"ixformer fused kernel only supports use_query_norm and use_key_norm, got {self.use_query_norm} and {self.use_key_norm}"
+            )
+
+        self.register_load_state_dict_post_hook(self._convert_norm_weight_to_bf16)
+
+    @staticmethod
+    def _convert_norm_weight_to_bf16(module, incompatible_keys):
+        if module.qk_norm is not None:
+            module.qk_norm.weight = torch.nn.Parameter(
+                module.qk_norm.weight.data.to(torch.bfloat16)
+            )
+        
+
+    def _run_stream_update_kv(
+        self, query, key, value, weight_q, weight_k,
+        scale_k, scale_v, cos, sin, rotary_dim,
+        key_cache, value_cache, block_table, cu_q_lens, context_kv_lens, eps,
+    ):
+        head_size = self.head_dim
+        if cu_q_lens is None:
+            batch_size = context_kv_lens.shape[0]
+            cu_q_lens = torch.arange(
+                batch_size + 1, dtype=torch.int32, device=query.device
+            )
+        output_q, key_quant, value_quant = (
+            ixf_f.rms_norm_qk_rotary_embedding_quant_kv_and_store(
+                cos, sin,
+                query, key, value,
+                weight_q, weight_k,
+                head_size,
+                scale_k, scale_v,
+                key_cache, value_cache,
+                block_table, cu_q_lens, context_kv_lens,
+                eps=eps, is_neox_style=True, rotary_dim=rotary_dim,
+            )
+        )
+        return output_q, key_quant, value_quant
+
+    def _run_sage_stream_update_kv(
+        self, query, key, value, weight_q, weight_k,
+        scale_k, scale_v, cos, sin, rotary_dim,
+        key_cache, value_cache, block_table, cu_q_lens, context_kv_lens, eps,
+        key_pt_cache, key_pt_scale_cache,
+    ):
+        """Full + SAGE: same all-in-one fused norm + rope + static int8 K/V quant
+        + paged store as ``_run_stream_update_kv``, additionally producing the
+        per-token dynamic-int8 key and its per-token scale and storing both into
+        their own paged "Bypass" caches (``key_pt_cache`` / ``key_pt_scale_cache``),
+        exactly like ``key_cache`` / ``value_cache`` — all in a single fused kernel.
+
+        Returns ``(output_q, key_quant, value_quant, key_pt_int8, key_pt_scale)``:
+          - ``output_q``    : [T, nh_q, head_dim] post-norm+rope query (bf16)
+          - ``key_quant``   : [T, nkv, head_dim] static per-channel int8 key
+          - ``value_quant`` : [T, nkv, head_dim] static per-channel int8 value
+          - ``key_pt_int8`` : [T, nkv, head_dim] per-token int8 key
+          - ``key_pt_scale``: [T, nkv, 1] per-token bf16 scale
+        """
+        head_size = self.head_dim
+        if cu_q_lens is None:
+            batch_size = context_kv_lens.shape[0]
+            cu_q_lens = torch.arange(
+                batch_size + 1, dtype=torch.int32, device=query.device
+            )
+        output_q, key_quant, value_quant, key_pt_int8, key_pt_scale = (
+            ixf_f.rms_norm_sage_qk_rotary_embedding(
+                cos, sin,
+                query, key, value,
+                weight_q, weight_k,
+                head_size,
+                scale_k, scale_v,
+                key_cache, value_cache,
+                key_pt_cache, key_pt_scale_cache,
+                block_table, cu_q_lens, context_kv_lens,
+                eps=eps, is_neox_style=True, rotary_dim=rotary_dim,
+                quant_dtype=torch.int8,
+            )
+        )
+        return output_q, key_quant, value_quant, key_pt_int8, key_pt_scale
+
+    def _run_stream_no_update(
+        self, query, key, weight_q, weight_k,
+        cos, sin, rotary_dim, eps,
+    ):
+        head_size = self.head_dim
+        output_q, _ = ixf_f.rms_norm_qk_rotary_embedding(
+            cos, sin,
+            query, key,
+            weight_q, weight_k,
+            head_size,
+            eps=eps, is_neox_style=True, rotary_dim=rotary_dim,
+        )
+        return output_q
+
+    def forward(
+        self,
+        swa_query, swa_key, swa_value,
+        full_query, full_key, full_value,
+        cos, sin,
+        full_key_cache, full_value_cache,
+        swa_key_cache, swa_value_cache,
+        block_tables, cu_q_lens, context_kv_lens,
+        block_tables_sparse, cu_q_lens_sparse, context_kv_lens_sparse,
+        sage_full_k_pt_cache=None,
+        sage_full_k_pt_scale_cache=None,
+        update_kv=True,
+    ):
+
+        eps = self.qk_norm.variance_epsilon if self.qk_norm is not None else 1e-5
+        rotary_dim = cos.shape[-1]
+
+        w = self.qk_norm.weight
+        swa_wq = w[0]
+        swa_wk = w[1]
+        full_wq = w[2]
+        full_wk = w[3]
+
+        swa_ks = self.swa_k_quantize.scale
+        swa_vs = self.swa_v_quantize.scale
+        full_ks = self.full_k_quantize.scale
+        full_vs = self.full_v_quantize.scale
+
+        # --- YOCO reuse layer: Q norm+rope only, no K/V touch ---
+        if not update_kv:
+            swa_q_out = self._run_stream_no_update(
+                swa_query, swa_key, swa_wq, swa_wk,
+                cos, sin, rotary_dim, eps,
+            )
+            full_q_out = self._run_stream_no_update(
+                full_query, full_key, full_wq, full_wk,
+                cos, sin, rotary_dim, eps,
+            )
+            return (
+                swa_q_out, full_q_out,
+                None, None, None, None, None, None, None, None,
+                None, None,
+            )
+
+        # --- SWA stream: all-in-one fused norm+rope+static-quant+store ---
+        swa_q_out, swa_key_q, swa_val_q = self._run_stream_update_kv(
+            swa_query, swa_key, swa_value, swa_wq, swa_wk,
+            swa_ks, swa_vs,
+            cos, sin, rotary_dim,
+            swa_key_cache, swa_value_cache,
+            block_tables_sparse, cu_q_lens_sparse, context_kv_lens_sparse, eps,
+        )
+
+        # --- Full stream: all-in-one fused kernel (+ per-token int8 K for SAGE) ---
+        if self.enable_sage:
+            (full_q_out, full_key_q, full_val_q,
+             full_key_pt_int8, full_key_pt_scale) = self._run_sage_stream_update_kv(
+                full_query, full_key, full_value, full_wq, full_wk,
+                full_ks, full_vs,
+                cos, sin, rotary_dim,
+                full_key_cache, full_value_cache,
+                block_tables, cu_q_lens, context_kv_lens, eps,
+                sage_full_k_pt_cache, sage_full_k_pt_scale_cache,
+            )
+        else:
+            full_q_out, full_key_q, full_val_q = self._run_stream_update_kv(
+                full_query, full_key, full_value, full_wq, full_wk,
+                full_ks, full_vs,
+                cos, sin, rotary_dim,
+                full_key_cache, full_value_cache,
+                block_tables, cu_q_lens, context_kv_lens, eps,
+            )
+            full_key_pt_int8, full_key_pt_scale = None, None
+
+        return (
+            swa_q_out, full_q_out,
+            full_key_q, full_ks,
+            swa_key_q, swa_ks,
+            full_val_q, full_vs,
+            swa_val_q, swa_vs,
+            full_key_pt_int8, full_key_pt_scale,
+        )

--- a/mojo_opset/backends/ixformer/operators/kv_cache.py
+++ b/mojo_opset/backends/ixformer/operators/kv_cache.py
@@ -4,6 +4,7 @@ import torch
 from ixformer import functions as ixf_f
 
 from mojo_opset.core import MojoStorePagedKVCache
+from mojo_opset.core import MojoStorePagedSingleCache
 from mojo_opset.core.operators.kv_cache import assert_paged_kv_store_contract
 
 class IxformerStorePagedKVCache(MojoStorePagedKVCache):
@@ -78,3 +79,61 @@ class IxformerStorePagedKVCache(MojoStorePagedKVCache):
             context_kv_lens,
         )
         return key_cache, value_cache
+
+
+class IxformerStorePagedSingleCache(MojoStorePagedSingleCache):
+    supported_platforms_list = ["ilu"]
+
+    def forward(
+        self,
+        states: torch.Tensor,
+        cache: torch.Tensor,
+        block_table: Optional[torch.Tensor] = None,
+        cu_q_lens: Optional[torch.Tensor] = None,
+        context_kv_lens: Optional[torch.Tensor] = None,
+        *,
+        chunk_metadata: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Store new tokens of a single attribute (key OR value) into one ixformer
+        block-based paged cache.
+
+        Args:
+            states (torch.Tensor): New tokens with shape (token_num, kv_head_num, head_dim).
+            cache (torch.Tensor): Paged cache with shape
+                (num_blocks, kv_head_num, block_size, head_dim), updated in-place.
+            block_table (torch.Tensor | None): Logical-to-physical block mapping with
+                shape (batch_size, max_blocks_per_sequence).
+            cu_q_lens (torch.Tensor | None): Cumulative query lengths for prefill with
+                shape (batch_size + 1,). None indicates decode mode.
+            context_kv_lens (torch.Tensor | None): Existing KV lengths before storing the
+                current tokens, shape (batch_size,). Padding entries use -1.
+            chunk_metadata (torch.Tensor | None): Optional precomputed store plan with shape
+                (num_chunks, 4) and per-row (src_token_start, dst_block_id, dst_block_offset, chunk_len).
+
+        Returns:
+            torch.Tensor: Updated cache.
+        """
+        if states.dim() != 3:
+            raise ValueError("states must be (token_num, kv_head_num, head_dim).")
+        if cache.dim() != 4:
+            raise ValueError("cache must be (num_blocks, kv_head_num, block_size, head_dim).")
+        if cache.dtype != states.dtype:
+            raise ValueError("IxformerStorePagedSingleCache requires states and cache to have the same dtype.")
+
+        if chunk_metadata is not None:
+            raise NotImplementedError("IxformerStorePagedSingleCache does not support the chunk_metadata path.")
+        if block_table is None or context_kv_lens is None:
+            raise ValueError("block_table and context_kv_lens are required when chunk_metadata is not provided.")
+
+        ixf_f.paged_store_kv_cache_with_block_table(
+            states,
+            states,
+            cache,
+            cache,
+            block_table,
+            cu_q_lens,
+            context_kv_lens,
+            store_mode=1,
+        )
+        return cache

--- a/mojo_opset/core/__init__.py
+++ b/mojo_opset/core/__init__.py
@@ -26,6 +26,7 @@ from .operators.attention import MojoSWA
 
 """ kvcache """
 from .operators.kv_cache import MojoStorePagedKVCache
+from .operators.kv_cache import MojoStorePagedSingleCache
 
 """ gemm """
 from .operators.gemm import MojoGemm
@@ -125,6 +126,7 @@ __all__ = [
     "MojoSWA",
 
     "MojoStorePagedKVCache",
+    "MojoStorePagedSingleCache",
 
     "MojoGemm",
     "MojoQuantGemm",

--- a/mojo_opset/core/operators/kv_cache.py
+++ b/mojo_opset/core/operators/kv_cache.py
@@ -169,3 +169,69 @@ class MojoStorePagedKVCache(MojoOperator):
             )
 
         return key_cache, value_cache
+
+
+class MojoStorePagedSingleCache(MojoOperator):
+    def __init__(
+        self,
+    ):
+        super().__init__()
+
+    def forward(
+        self,
+        states: torch.Tensor,
+        cache: torch.Tensor,
+        block_table: Optional[torch.Tensor] = None,
+        cu_q_lens: Optional[torch.Tensor] = None,
+        context_kv_lens: Optional[torch.Tensor] = None,
+        *,
+        chunk_metadata: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """
+        Copy new tokens of a single attribute (key OR value) into one paged cache.
+
+        Mirrors :class:`MojoStorePagedKVCache` but operates on a single tensor/cache
+        pair, for cases where only one of K/V needs to be written (e.g. SAGE prefill
+        only stores V into the static cache while K lives in a separate cache).
+
+        Args:
+            states (torch.Tensor): Shape (token_num, kv_head_num, head_dim) — new tokens.
+            cache (torch.Tensor): Shape (total_phys_blocks, kv_heads, block_size, head_dim) — paged cache.
+            block_table (torch.Tensor | None): Logical-to-physical block mapping.
+            cu_q_lens (torch.Tensor | None): Cumulative query lengths. ``None`` indicates decode mode.
+            context_kv_lens (torch.Tensor | None): KV lengths before storing current tokens.
+            chunk_metadata (torch.Tensor | None): Optimized precomputed store plan with shape ``(num_chunks, 4)``
+                and per-row ``(src_token_start, dst_block_id, dst_block_offset, chunk_len)``.
+
+        Returns:
+            torch.Tensor: Updated ``cache`` after in-place writes.
+        """
+        assert len(states.shape) == 3, "states must be (token_num, kv_head_num, head_dim), please check."
+
+        if chunk_metadata is None:
+            assert block_table is not None, "block_table is required when chunk_metadata is not provided."
+            assert context_kv_lens is not None, "context_kv_lens is required when chunk_metadata is not provided."
+            chunk_metadata = build_paged_kv_chunk_metadata(
+                block_table,
+                cu_q_lens,
+                context_kv_lens,
+                cache.shape[2],
+            )
+        else:
+            assert block_table is None and cu_q_lens is None and context_kv_lens is None, (
+                "chunk_metadata path should not be mixed with block_table/cu_q_lens/context_kv_lens."
+            )
+
+        assert_paged_kv_store_contract(chunk_metadata)
+
+        if chunk_metadata.shape[0] == 0:
+            return cache
+
+        for src_token_start, dst_block_id, dst_block_offset, chunk_len in chunk_metadata.tolist():
+            src_end = src_token_start + chunk_len
+            dst_end = dst_block_offset + chunk_len
+            cache[dst_block_id, :, dst_block_offset:dst_end, :] = states[src_token_start:src_end].permute(
+                1, 0, 2
+            )
+
+        return cache

--- a/mojo_opset/experimental/__init__.py
+++ b/mojo_opset/experimental/__init__.py
@@ -34,6 +34,7 @@ from .operators.normalization import MojoGroupLayerNorm
 from .operators.position_embedding import MojoGridRoPE
 from .operators.position_embedding import MojoRelativeEmbedding
 from .operators.fused_norm_rope_quant_store import MojoFusedNormRoPEQuantStore
+from .operators.fused_norm_rope_sage_quant_store import MojoFusedNormRoPESageQuantStore
 from .operators.store_lowrank import MojoStoreLowrank
 
 __all__ = [
@@ -68,5 +69,6 @@ __all__ = [
     "MojoGridRoPE",
     "MojoStoreLowrank",
     "MojoFusedNormRoPEQuantStore",
+    "MojoFusedNormRoPESageQuantStore",
     "MojoIndexer",
 ]

--- a/mojo_opset/experimental/operators/__init__.py
+++ b/mojo_opset/experimental/operators/__init__.py
@@ -24,6 +24,7 @@ from .normalization import MojoGroupLayerNorm
 from .position_embedding import MojoGridRoPE
 from .position_embedding import MojoRelativeEmbedding
 from .fused_norm_rope_quant_store import MojoFusedNormRoPEQuantStore
+from .fused_norm_rope_sage_quant_store import MojoFusedNormRoPESageQuantStore
 from .store_lowrank import MojoStoreLowrank
 
 __all__ = [
@@ -54,4 +55,5 @@ __all__ = [
     "MojoStoreLowrank",
     "MojoQuantBatchGemmReduceSum",
     "MojoFusedNormRoPEQuantStore",
+    "MojoFusedNormRoPESageQuantStore",
 ]

--- a/mojo_opset/experimental/operators/fused_norm_rope_sage_quant_store.py
+++ b/mojo_opset/experimental/operators/fused_norm_rope_sage_quant_store.py
@@ -136,7 +136,7 @@ class MojoFusedNormRoPESageQuantStore(MojoOperator):
             cu_q_lens_sparse: [B+1] cumulative query lengths for SWA
             context_kv_lens_sparse: [B] existing KV lengths for SWA
             sage_full_k_pt_cache: paged cache for the SAGE per-token int8 K
-            sage_full_k_pt_scale_cache: paged cache for the SAGE per-token (bf16) scale.
+            sage_full_k_pt_scale_cache: paged cache for the SAGE per-token float32 scale.
             update_kv: if True, run full pipeline (norm+rope+quant+store);
                        if False, only compute Q norm+rope (skip K/V entirely)
 
@@ -212,7 +212,7 @@ class MojoFusedNormRoPESageQuantStore(MojoOperator):
 
         # --- 4b. Store the SAGE per-token K snapshot + scale into the paged
         # "Bypass" caches, just like the main K/V store above. The int8 K and
-        # the (bf16) scale go into two separate caches, each dispatched with the
+        # the float32 scale go into two separate caches, each dispatched with the
         # tensor acting as both "key" and "value". This mirrors the model-side
         # Bypass cache write so the operator owns the snapshot store internally
         # while still returning the per-token K + scale to the caller.
@@ -223,14 +223,13 @@ class MojoFusedNormRoPESageQuantStore(MojoOperator):
             and sage_full_k_pt_cache is not None
             and sage_full_k_pt_scale_cache is not None
         ):
-            full_key_pt_scale_bf16 = full_key_pt_scale.to(torch.bfloat16)
             self.store_sage_full_kpt_cache(
                 full_key_pt_int8, full_key_pt_int8,
                 sage_full_k_pt_cache, sage_full_k_pt_cache,
                 block_tables, cu_q_lens, context_kv_lens,
             )
             self.store_sage_full_kpt_scale_cache(
-                full_key_pt_scale_bf16, full_key_pt_scale_bf16,
+                full_key_pt_scale, full_key_pt_scale,
                 sage_full_k_pt_scale_cache, sage_full_k_pt_scale_cache,
                 block_tables, cu_q_lens, context_kv_lens,
             )

--- a/mojo_opset/experimental/operators/fused_norm_rope_sage_quant_store.py
+++ b/mojo_opset/experimental/operators/fused_norm_rope_sage_quant_store.py
@@ -1,0 +1,257 @@
+from typing import Optional, Tuple
+
+import torch
+
+from ...core.operator import MojoOperator
+from ...core.operators.normalization import MojoGroupRMSNorm
+from ...core.operators.position_embedding import MojoApplyRoPE
+from ...core.operators.quantize import MojoStaticQuant, MojoDynamicQuant
+from ...core.operators.kv_cache import MojoStorePagedKVCache
+
+__all__ = ["MojoFusedNormRoPESageQuantStore"]
+
+
+class MojoFusedNormRoPESageQuantStore(MojoOperator):
+    """Fused QK-Norm + RoPE + KV-StaticQuant + (optional SAGE per-token K) + PagedKVStore.
+
+    Combines GroupRMSNorm (on Q and K), RoPE (on Q and K), StaticQuant (on K
+    and V), the paged KV cache store, and -- when ``enable_sage`` is set -- an
+    additional per-token (dynamic) int8 quantization of the post-norm+rope full
+    key. The per-token int8 key and its per-token scale are returned directly to
+    the caller (exactly like the static ``full_key_q`` / ``full_k_scale``
+    outputs); this operator does not own a separate "Bypass" cache store.
+
+    When ``update_kv=False`` (YOCO reuse layer), only Q norm+rope is computed —
+    the K/V quant, the SAGE per-token quant and the stores are all skipped.
+
+    Sub-operations are composed from existing Mojo core operators:
+      - ``MojoGroupRMSNorm``: per-head QK norm
+      - ``MojoApplyRoPE``: rotary position embedding
+      - ``MojoStaticQuant``: static per-channel int8 quantization (main cache)
+      - ``MojoDynamicQuant``: dynamic per-token int8 quantization (SAGE K)
+      - ``MojoStorePagedKVCache``: paged KV cache store
+    """
+
+    def __init__(
+        self,
+        num_heads_swa_q: int,
+        num_heads_swa_k: int,
+        num_heads_full_q: int,
+        num_heads_full_k: int,
+        head_dim: int,
+        norm_eps: float = 1e-5,
+        use_query_norm: bool = True,
+        use_key_norm: bool = True,
+        quant_dtype: torch.dtype = torch.int8,
+        enable_sage: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.num_heads_swa_q = num_heads_swa_q
+        self.num_heads_swa_k = num_heads_swa_k
+        self.num_heads_full_q = num_heads_full_q
+        self.num_heads_full_k = num_heads_full_k
+        self.head_dim = head_dim
+        self.use_query_norm = use_query_norm
+        self.use_key_norm = use_key_norm
+        self.enable_sage = enable_sage
+
+        num_norm_groups = (2 if use_query_norm else 0) + (2 if use_key_norm else 0)
+        if num_norm_groups > 0:
+            self.qk_norm = MojoGroupRMSNorm._registry.get(self._backend)(num_norm_groups, head_dim, eps=norm_eps)
+        else:
+            self.qk_norm = None
+
+        self.apply_rope = MojoApplyRoPE._registry.get(self._backend)()
+
+        self.full_k_quantize = MojoStaticQuant._registry.get(self._backend)((num_heads_full_k, head_dim), quant_dtype=quant_dtype)
+        self.full_v_quantize = MojoStaticQuant._registry.get(self._backend)((num_heads_full_k, head_dim), quant_dtype=quant_dtype)
+        self.swa_k_quantize = MojoStaticQuant._registry.get(self._backend)((num_heads_swa_k, head_dim), quant_dtype=quant_dtype)
+        self.swa_v_quantize = MojoStaticQuant._registry.get(self._backend)((num_heads_swa_k, head_dim), quant_dtype=quant_dtype)
+
+        # SAGE: dynamic per-token int8 quant of the full key (over head_dim).
+        if self.enable_sage:
+            self.sage_full_k_quantize = MojoDynamicQuant._registry.get(self._backend)(quant_dtype=quant_dtype)
+            # Mirrors the model-side "Bypass" cache: the int8 K and the (bf16)
+            # scale are written into two separate paged caches.
+            self.store_sage_full_kpt_cache = MojoStorePagedKVCache._registry.get(self._backend)()
+            self.store_sage_full_kpt_scale_cache = MojoStorePagedKVCache._registry.get(self._backend)()
+        else:
+            self.sage_full_k_quantize = None
+            self.store_sage_full_kpt_cache = None
+            self.store_sage_full_kpt_scale_cache = None
+
+        self.store_full_kvcache = MojoStorePagedKVCache._registry.get(self._backend)()
+        self.store_swa_kvcache = MojoStorePagedKVCache._registry.get(self._backend)()
+
+    def forward(
+        self,
+        swa_query: torch.Tensor,
+        swa_key: torch.Tensor,
+        swa_value: torch.Tensor,
+        full_query: torch.Tensor,
+        full_key: torch.Tensor,
+        full_value: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        full_key_cache: torch.Tensor,
+        full_value_cache: torch.Tensor,
+        swa_key_cache: torch.Tensor,
+        swa_value_cache: torch.Tensor,
+        block_tables: torch.Tensor,
+        cu_q_lens: Optional[torch.Tensor],
+        context_kv_lens: torch.Tensor,
+        block_tables_sparse: torch.Tensor,
+        cu_q_lens_sparse: Optional[torch.Tensor],
+        context_kv_lens_sparse: torch.Tensor,
+        sage_full_k_pt_cache: Optional[torch.Tensor] = None,
+        sage_full_k_pt_scale_cache: Optional[torch.Tensor] = None,
+        update_kv: bool = True,
+    ) -> Tuple[
+        torch.Tensor, torch.Tensor,
+        Optional[torch.Tensor], Optional[torch.Tensor],
+        Optional[torch.Tensor], Optional[torch.Tensor],
+        Optional[torch.Tensor], Optional[torch.Tensor],
+        Optional[torch.Tensor], Optional[torch.Tensor],
+        Optional[torch.Tensor], Optional[torch.Tensor],
+    ]:
+        """
+        Args:
+            swa_query: [T, swa_nh_q, head_dim] pre-norm SWA query
+            swa_key: [T, swa_nkv, head_dim] pre-norm SWA key
+            swa_value: [T, swa_nkv, head_dim] SWA value (no norm/rope)
+            full_query: [T, full_nh_q, head_dim] pre-norm full query
+            full_key: [T, full_nkv, head_dim] pre-norm full key
+            full_value: [T, full_nkv, head_dim] full value (no norm/rope)
+            cos: [T, rope_dim] RoPE cosine
+            sin: [T, rope_dim] RoPE sine
+            full_key_cache: paged KV cache for full attention keys
+            full_value_cache: paged KV cache for full attention values
+            swa_key_cache: paged KV cache for SWA keys
+            swa_value_cache: paged KV cache for SWA values
+            block_tables: [B, max_blocks] block table for full attn
+            cu_q_lens: [B+1] cumulative query lengths (None for decode)
+            context_kv_lens: [B] existing KV lengths before store
+            block_tables_sparse: [B, max_blocks] block table for SWA
+            cu_q_lens_sparse: [B+1] cumulative query lengths for SWA
+            context_kv_lens_sparse: [B] existing KV lengths for SWA
+            sage_full_k_pt_cache: paged cache for the SAGE per-token int8 K
+            sage_full_k_pt_scale_cache: paged cache for the SAGE per-token (bf16) scale.
+            update_kv: if True, run full pipeline (norm+rope+quant+store);
+                       if False, only compute Q norm+rope (skip K/V entirely)
+
+        Returns:
+            Tuple of:
+              - swa_query_out: [T, swa_nh_q, head_dim] post-norm+rope
+              - full_query_out: [T, full_nh_q, head_dim] post-norm+rope
+              - full_key_out: [T, full_nkv, head_dim] int8 (None if update_kv=False)
+              - full_k_scale: [full_nkv, head_dim] (None if update_kv=False)
+              - swa_key_out: [T, swa_nkv, head_dim] int8 (None if update_kv=False)
+              - swa_k_scale: [swa_nkv, head_dim] (None if update_kv=False)
+              - full_value_out: [T, full_nkv, head_dim] int8 (None if update_kv=False)
+              - full_v_scale: [full_nkv, head_dim] (None if update_kv=False)
+              - swa_value_out: [T, swa_nkv, head_dim] int8 (None if update_kv=False)
+              - swa_v_scale: [swa_nkv, head_dim] (None if update_kv=False)
+              - full_key_pt_int8: [T, full_nkv, head_dim] per-token int8 key
+                  (None if update_kv=False or SAGE disabled)
+              - full_key_pt_scale: [T, full_nkv, 1] per-token scale
+                  (None if update_kv=False or SAGE disabled)
+        """
+        # --- 1. GroupRMSNorm on Q and/or K ---
+        if self.use_query_norm and self.use_key_norm:
+            swa_query, swa_key, full_query, full_key = self.qk_norm(
+                [swa_query, swa_key, full_query, full_key]
+            )
+        elif self.use_query_norm:
+            swa_query, full_query = self.qk_norm([swa_query, full_query])
+        elif self.use_key_norm:
+            swa_key, full_key = self.qk_norm([swa_key, full_key])
+
+        # --- 2. RoPE on Q (always) and K (only if update_kv) ---
+        if update_kv:
+            swa_query, swa_key = self.apply_rope(swa_query, swa_key, cos, sin, head_first=False)
+            full_query, full_key = self.apply_rope(full_query, full_key, cos, sin, head_first=False)
+        else:
+            # Only Q needs rope; pass Q as both q and k, discard second output
+            swa_query, _ = self.apply_rope(swa_query, swa_query, cos, sin, head_first=False)
+            full_query, _ = self.apply_rope(full_query, full_query, cos, sin, head_first=False)
+            return (
+                swa_query, full_query,
+                None, None, None, None, None, None, None, None,
+                None, None,
+            )
+
+        # --- 3a. SAGE per-token dynamic int8 K snapshot (BEFORE static quant) ---
+        full_key_pt_int8 = None
+        full_key_pt_scale = None
+        if self.enable_sage:
+            k_t, k_h, k_d = full_key.shape
+            full_key_pt_int8, full_key_pt_scale = self.sage_full_k_quantize(
+                full_key.reshape(-1, k_d)
+            )
+            full_key_pt_int8 = full_key_pt_int8.view(k_t, k_h, k_d)
+            full_key_pt_scale = full_key_pt_scale.view(k_t, k_h, 1)
+
+        # --- 3b. StaticQuant on K and V ---
+        full_key_q, full_k_scale = self.full_k_quantize(full_key)
+        full_val_q, full_v_scale = self.full_v_quantize(full_value)
+        swa_key_q, swa_k_scale = self.swa_k_quantize(swa_key)
+        swa_val_q, swa_v_scale = self.swa_v_quantize(swa_value)
+
+        # --- 4. Store to paged KV cache ---
+        self.store_full_kvcache(
+            full_key_q, full_val_q,
+            full_key_cache, full_value_cache,
+            block_tables, cu_q_lens, context_kv_lens,
+        )
+        self.store_swa_kvcache(
+            swa_key_q, swa_val_q,
+            swa_key_cache, swa_value_cache,
+            block_tables_sparse, cu_q_lens_sparse, context_kv_lens_sparse,
+        )
+
+        # --- 4b. Store the SAGE per-token K snapshot + scale into the paged
+        # "Bypass" caches, just like the main K/V store above. The int8 K and
+        # the (bf16) scale go into two separate caches, each dispatched with the
+        # tensor acting as both "key" and "value". This mirrors the model-side
+        # Bypass cache write so the operator owns the snapshot store internally
+        # while still returning the per-token K + scale to the caller.
+        if (
+            self.enable_sage
+            and full_key_pt_int8 is not None
+            and cu_q_lens is not None
+            and sage_full_k_pt_cache is not None
+            and sage_full_k_pt_scale_cache is not None
+        ):
+            full_key_pt_scale_bf16 = full_key_pt_scale.to(torch.bfloat16)
+            self.store_sage_full_kpt_cache(
+                full_key_pt_int8, full_key_pt_int8,
+                sage_full_k_pt_cache, sage_full_k_pt_cache,
+                block_tables, cu_q_lens, context_kv_lens,
+            )
+            self.store_sage_full_kpt_scale_cache(
+                full_key_pt_scale_bf16, full_key_pt_scale_bf16,
+                sage_full_k_pt_scale_cache, sage_full_k_pt_scale_cache,
+                block_tables, cu_q_lens, context_kv_lens,
+            )
+
+        return (
+            swa_query, full_query,
+            full_key_q, full_k_scale,
+            swa_key_q, swa_k_scale,
+            full_val_q, full_v_scale,
+            swa_val_q, swa_v_scale,
+            full_key_pt_int8, full_key_pt_scale,
+        )
+
+    def extra_repr(self) -> str:
+        return (
+            f"num_heads_swa_q={self.num_heads_swa_q}, "
+            f"num_heads_swa_k={self.num_heads_swa_k}, "
+            f"num_heads_full_q={self.num_heads_full_q}, "
+            f"num_heads_full_k={self.num_heads_full_k}, "
+            f"head_dim={self.head_dim}, "
+            f"use_query_norm={self.use_query_norm}, "
+            f"use_key_norm={self.use_key_norm}, "
+            f"enable_sage={self.enable_sage}"
+        )

--- a/mojo_opset/tests/accuracy/operators/test_fused_norm_rope_sage_quant_store.py
+++ b/mojo_opset/tests/accuracy/operators/test_fused_norm_rope_sage_quant_store.py
@@ -1,0 +1,317 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from mojo_opset.experimental import MojoFusedNormRoPESageQuantStore
+from mojo_opset.tests.utils import assert_deterministic
+from mojo_opset.tests.utils import bypass_not_implemented
+from mojo_opset.tests.utils import get_torch_device
+
+torch.manual_seed(42)
+
+CONFIGS = [
+    # (num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim)
+    (8, 2, 32, 4, 128, 128),
+    (8, 2, 32, 4, 128, 64),
+    (16, 4, 48, 8, 96, 96),
+    (4, 1, 16, 2, 128, 128),
+    (8, 2, 32, 4, 64, 64),
+    (32, 8, 64, 16, 128, 128),
+    (4, 2, 8, 4, 96, 48),
+]
+
+SEQ_CONFIGS = [
+    # (batch_size, q_lens_list, context_kv_lens_list)
+    (1, [1], [0]),
+    (1, [1], [15]),
+    (1, [1], [127]),
+    (1, [1], [1023]),
+    (2, [1, 1], [0, 7]),
+    (4, [1, 1, 1, 1], [0, 15, 31, 63]),
+    (1, [32], [0]),
+    (1, [64], [0]),
+    (1, [128], [0]),
+    (1, [256], [0]),
+    (2, [16, 8], [5, 10]),
+    (2, [64, 32], [0, 128]),
+    (3, [1, 1, 1], [10, 20, 30]),
+    (1, [512], [0]),
+    (2, [128, 128], [64, 64]),
+]
+
+BLOCK_SIZE = 128
+
+
+def _build_kv_case(batch_size, kv_heads, head_dim, block_size, context_kv_lens_val, q_lens_val, device):
+    context_kv_lens = torch.tensor(context_kv_lens_val, dtype=torch.int32, device=device)
+    q_lens = torch.tensor(q_lens_val, dtype=torch.int32, device=device)
+
+    is_decode = all(q == 1 for q in q_lens_val)
+    cu_q_lens = (
+        torch.cat([
+            torch.zeros(1, dtype=torch.int32, device=device),
+            torch.cumsum(q_lens, dim=0, dtype=torch.int32),
+        ])
+        if not is_decode
+        else None
+    )
+
+    total_tokens = int(q_lens.sum().item()) if not is_decode else batch_size
+
+    max_kv_len = int(torch.clamp(context_kv_lens + q_lens, min=0).max().item())
+    max_blocks_per_seq = (max_kv_len + block_size - 1) // block_size + 2
+    total_blocks_needed = sum(
+        max(0, ckv + ql + block_size - 1) // block_size
+        for ckv, ql in zip(context_kv_lens_val, q_lens_val)
+    )
+    total_phys_blocks = total_blocks_needed + 10
+
+    cache_shape = (total_phys_blocks, kv_heads, block_size, head_dim)
+    k_cache = torch.zeros(cache_shape, dtype=torch.int8, device=device)
+    v_cache = torch.zeros(cache_shape, dtype=torch.int8, device=device)
+
+    block_table = torch.full((batch_size, max_blocks_per_seq), -1, dtype=torch.int32, device=device)
+    next_block = 0
+    for b in range(batch_size):
+        needed = max(0, context_kv_lens_val[b] + q_lens_val[b] + block_size - 1) // block_size
+        if needed > 0:
+            block_table[b, :needed] = torch.arange(next_block, next_block + needed, dtype=torch.int32, device=device)
+        next_block += needed
+
+    return {
+        "total_tokens": total_tokens,
+        "cu_q_lens": cu_q_lens,
+        "context_kv_lens": context_kv_lens,
+        "k_cache": k_cache,
+        "v_cache": v_cache,
+        "block_table": block_table,
+    }
+
+
+def _build_inputs(cfg, seq_cfg, device):
+    num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim = cfg
+    batch_size, q_lens_val, context_kv_lens_val = seq_cfg
+
+    full_kv_case = _build_kv_case(batch_size, num_heads_full_k, head_dim, BLOCK_SIZE, context_kv_lens_val, q_lens_val, device)
+    swa_kv_case = _build_kv_case(batch_size, num_heads_swa_k, head_dim, BLOCK_SIZE, context_kv_lens_val, q_lens_val, device)
+
+    T = full_kv_case["total_tokens"]
+    inputs = {
+        "swa_query": torch.randn(T, num_heads_swa_q, head_dim, dtype=torch.bfloat16, device=device),
+        "swa_key": torch.randn(T, num_heads_swa_k, head_dim, dtype=torch.bfloat16, device=device),
+        "swa_value": torch.randn(T, num_heads_swa_k, head_dim, dtype=torch.bfloat16, device=device),
+        "full_query": torch.randn(T, num_heads_full_q, head_dim, dtype=torch.bfloat16, device=device),
+        "full_key": torch.randn(T, num_heads_full_k, head_dim, dtype=torch.bfloat16, device=device),
+        "full_value": torch.randn(T, num_heads_full_k, head_dim, dtype=torch.bfloat16, device=device),
+        "cos": torch.randn(T, rope_dim, dtype=torch.bfloat16, device=device),
+        "sin": torch.randn(T, rope_dim, dtype=torch.bfloat16, device=device),
+    }
+    return inputs, full_kv_case, swa_kv_case, T
+
+
+def _forward_args(inputs, full_kv_case, swa_kv_case):
+    return (
+        inputs["swa_query"], inputs["swa_key"], inputs["swa_value"],
+        inputs["full_query"], inputs["full_key"], inputs["full_value"],
+        inputs["cos"], inputs["sin"],
+        full_kv_case["k_cache"].clone(), full_kv_case["v_cache"].clone(),
+        swa_kv_case["k_cache"].clone(), swa_kv_case["v_cache"].clone(),
+        full_kv_case["block_table"], full_kv_case["cu_q_lens"], full_kv_case["context_kv_lens"],
+        swa_kv_case["block_table"], swa_kv_case["cu_q_lens"], swa_kv_case["context_kv_lens"],
+    )
+
+
+@pytest.mark.parametrize("num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim", CONFIGS)
+@pytest.mark.parametrize("batch_size, q_lens_val, context_kv_lens_val", SEQ_CONFIGS)
+@pytest.mark.parametrize("update_kv", [True, False])
+@bypass_not_implemented
+def test_diff_vs_torch_no_sage(
+    num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim,
+    batch_size, q_lens_val, context_kv_lens_val,
+    update_kv,
+):
+    """forward_diff_with: dedicated backend vs torch reference (enable_sage=False)."""
+    torch.manual_seed(42)
+    device = get_torch_device()
+    cfg = (num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim)
+    seq_cfg = (batch_size, q_lens_val, context_kv_lens_val)
+
+    op = MojoFusedNormRoPESageQuantStore(
+        num_heads_swa_q=num_heads_swa_q,
+        num_heads_swa_k=num_heads_swa_k,
+        num_heads_full_q=num_heads_full_q,
+        num_heads_full_k=num_heads_full_k,
+        head_dim=head_dim,
+        norm_eps=1e-5,
+        use_query_norm=True,
+        use_key_norm=True,
+        quant_dtype=torch.int8,
+        enable_sage=False,
+    ).to(device)
+
+    op_ref = MojoFusedNormRoPESageQuantStore._registry.get("torch")(
+        num_heads_swa_q=num_heads_swa_q,
+        num_heads_swa_k=num_heads_swa_k,
+        num_heads_full_q=num_heads_full_q,
+        num_heads_full_k=num_heads_full_k,
+        head_dim=head_dim,
+        norm_eps=1e-5,
+        use_query_norm=True,
+        use_key_norm=True,
+        quant_dtype=torch.int8,
+        enable_sage=False,
+    ).to(device)
+
+    for p in op_ref.parameters():
+        nn.init.normal_(p, mean=1.0, std=0.1)
+    op.load_state_dict(op_ref.state_dict())
+
+    full_kv_case = _build_kv_case(batch_size, num_heads_full_k, head_dim, BLOCK_SIZE, context_kv_lens_val, q_lens_val, device)
+    swa_kv_case = _build_kv_case(batch_size, num_heads_swa_k, head_dim, BLOCK_SIZE, context_kv_lens_val, q_lens_val, device)
+
+    T = full_kv_case["total_tokens"]
+    swa_query = torch.randn(T, num_heads_swa_q, head_dim, dtype=torch.bfloat16, device=device)
+    swa_key = torch.randn(T, num_heads_swa_k, head_dim, dtype=torch.bfloat16, device=device)
+    swa_value = torch.randn(T, num_heads_swa_k, head_dim, dtype=torch.bfloat16, device=device)
+    full_query = torch.randn(T, num_heads_full_q, head_dim, dtype=torch.bfloat16, device=device)
+    full_key = torch.randn(T, num_heads_full_k, head_dim, dtype=torch.bfloat16, device=device)
+    full_value = torch.randn(T, num_heads_full_k, head_dim, dtype=torch.bfloat16, device=device)
+
+    cos = torch.randn(T, rope_dim, dtype=torch.bfloat16, device=device)
+    sin = torch.randn(T, rope_dim, dtype=torch.bfloat16, device=device)
+
+    op.forward_diff_with(
+        op_ref,
+        swa_query, swa_key, swa_value,
+        full_query, full_key, full_value,
+        cos, sin,
+        full_kv_case["k_cache"].clone(), full_kv_case["v_cache"].clone(),
+        swa_kv_case["k_cache"].clone(), swa_kv_case["v_cache"].clone(),
+        full_kv_case["block_table"], full_kv_case["cu_q_lens"], full_kv_case["context_kv_lens"],
+        swa_kv_case["block_table"], swa_kv_case["cu_q_lens"], swa_kv_case["context_kv_lens"],
+        update_kv=update_kv,
+        atol=1, rtol=0.05, ptol=0.999,
+    )
+
+@pytest.mark.parametrize("num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim", CONFIGS)
+@pytest.mark.parametrize("batch_size, q_lens_val, context_kv_lens_val", SEQ_CONFIGS)
+@pytest.mark.parametrize("enable_sage", [True, False])
+@pytest.mark.parametrize("update_kv", [True, False])
+def test_torch_reference_logic(
+    num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim,
+    batch_size, q_lens_val, context_kv_lens_val,
+    enable_sage, update_kv,
+):
+    """Validate the torch reference: tuple shape/dtype + SAGE/static quant math."""
+    torch.manual_seed(42)
+    device = "cpu" if get_torch_device() == "meta" else get_torch_device()
+    cfg = (num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim)
+    seq_cfg = (batch_size, q_lens_val, context_kv_lens_val)
+
+    # The session fixture sets the default device to ``meta`` on hosts without
+    # an accelerator; scope a concrete device so the pure-torch math runs.
+    with torch.device(device):
+        op = MojoFusedNormRoPESageQuantStore._registry.get("torch")(
+            num_heads_swa_q=num_heads_swa_q,
+            num_heads_swa_k=num_heads_swa_k,
+            num_heads_full_q=num_heads_full_q,
+            num_heads_full_k=num_heads_full_k,
+            head_dim=head_dim,
+            norm_eps=1e-5,
+            use_query_norm=True,
+            use_key_norm=True,
+            quant_dtype=torch.int8,
+            enable_sage=enable_sage,
+        )
+        for p in op.parameters():
+            nn.init.normal_(p, mean=1.0, std=0.1)
+
+        inputs, full_kv_case, swa_kv_case, T = _build_inputs(cfg, seq_cfg, device)
+        out = op(*_forward_args(inputs, full_kv_case, swa_kv_case), update_kv=update_kv)
+
+    # --- contract: always a 12-tuple, query outputs present ---
+    assert len(out) == 12
+    (swa_q_out, full_q_out,
+     full_key_q, full_k_scale,
+     swa_key_q, swa_k_scale,
+     full_val_q, full_v_scale,
+     swa_val_q, swa_v_scale,
+     full_key_pt_int8, full_key_pt_scale) = out
+
+    assert swa_q_out.shape == (T, num_heads_swa_q, head_dim)
+    assert full_q_out.shape == (T, num_heads_full_q, head_dim)
+    assert swa_q_out.dtype == torch.bfloat16
+    assert full_q_out.dtype == torch.bfloat16
+
+    if not update_kv:
+        # YOCO reuse layer: everything except the queries is None.
+        for t in out[2:]:
+            assert t is None
+        return
+
+    # --- static per-channel int8 K/V quant ---
+    assert full_key_q.shape == (T, num_heads_full_k, head_dim)
+    assert full_key_q.dtype == torch.int8
+    assert full_k_scale.shape == (num_heads_full_k, head_dim)
+    assert full_val_q.shape == (T, num_heads_full_k, head_dim)
+    assert full_val_q.dtype == torch.int8
+    assert swa_key_q.shape == (T, num_heads_swa_k, head_dim)
+    assert swa_key_q.dtype == torch.int8
+    assert swa_k_scale.shape == (num_heads_swa_k, head_dim)
+    assert swa_val_q.shape == (T, num_heads_swa_k, head_dim)
+    assert swa_val_q.dtype == torch.int8
+
+    # --- recompute the post-norm+rope full key (the SAGE/static quant source) ---
+    swa_q_n, swa_k_n, full_q_n, full_k_n = op.qk_norm([
+        inputs["swa_query"], inputs["swa_key"], inputs["full_query"], inputs["full_key"],
+    ])
+    _, ref_full_key = op.apply_rope(full_q_n, full_k_n, inputs["cos"], inputs["sin"], head_first=False)
+    ref_full_key = ref_full_key.float()
+
+    # static dequant should reconstruct the key within one quant step (per channel).
+    static_deq = full_key_q.float() * full_k_scale.float()
+    allowed_static = full_k_scale.float().abs().unsqueeze(0)  # (1, kh, hd)
+    assert torch.all((static_deq - ref_full_key).abs() <= allowed_static + 1e-2)
+
+    # --- SAGE per-token int8 key + per-token scale ---
+    if enable_sage:
+        assert full_key_pt_int8.shape == (T, num_heads_full_k, head_dim)
+        assert full_key_pt_int8.dtype == torch.int8
+        assert full_key_pt_scale.shape == (T, num_heads_full_k, 1)
+
+        # per-token scale = amax over head_dim / 127 (matching MojoDynamicQuant).
+        expected_scale = ref_full_key.abs().amax(dim=-1, keepdim=True).clamp(min=1e-12) / 127.0
+        expected_scale = torch.where(expected_scale < 1e-6, torch.ones_like(expected_scale), expected_scale)
+        torch.testing.assert_close(full_key_pt_scale.float(), expected_scale, atol=1e-3, rtol=1e-2)
+
+        # per-token dequant should reconstruct the key within one quant step.
+        pt_deq = full_key_pt_int8.float() * full_key_pt_scale.float()
+        allowed_pt = full_key_pt_scale.float().abs()  # (T, kh, 1) -> broadcast over hd
+        assert torch.all((pt_deq - ref_full_key).abs() <= allowed_pt + 1e-2)
+    else:
+        assert full_key_pt_int8 is None
+        assert full_key_pt_scale is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Determinism of the torch reference.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("enable_sage", [True, False])
+def test_torch_reference_deterministic(enable_sage):
+    device = "cpu" if get_torch_device() == "meta" else get_torch_device()
+    cfg = (8, 2, 32, 4, 128, 128)
+    seq_cfg = (2, [16, 8], [5, 10])
+
+    with torch.device(device):
+        op = MojoFusedNormRoPESageQuantStore._registry.get("torch")(
+            num_heads_swa_q=8, num_heads_swa_k=2, num_heads_full_q=32, num_heads_full_k=4,
+            head_dim=128, norm_eps=1e-5, use_query_norm=True, use_key_norm=True,
+            quant_dtype=torch.int8, enable_sage=enable_sage,
+        )
+        for p in op.parameters():
+            nn.init.normal_(p, mean=1.0, std=0.1)
+
+        inputs, full_kv_case, swa_kv_case, _ = _build_inputs(cfg, seq_cfg, device)
+        args = _forward_args(inputs, full_kv_case, swa_kv_case)
+
+        assert_deterministic(lambda: op(*args, update_kv=True))

--- a/mojo_opset/tests/accuracy/operators/test_fused_norm_rope_sage_quant_store.py
+++ b/mojo_opset/tests/accuracy/operators/test_fused_norm_rope_sage_quant_store.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 
 from mojo_opset.experimental import MojoFusedNormRoPESageQuantStore
+from mojo_opset.tests.utils import assert_close
 from mojo_opset.tests.utils import assert_deterministic
 from mojo_opset.tests.utils import bypass_not_implemented
 from mojo_opset.tests.utils import get_torch_device
@@ -121,6 +122,18 @@ def _forward_args(inputs, full_kv_case, swa_kv_case):
     )
 
 
+def _build_sage_caches(full_kv_case):
+    key_cache = full_kv_case["k_cache"]
+    key_pt_cache = torch.zeros_like(key_cache)
+    key_pt_scale_cache = torch.zeros(
+        key_cache.shape[:-1] + (1,), dtype=torch.float32, device=key_cache.device
+    )
+    return key_pt_cache, key_pt_scale_cache
+
+
+SAGE_CONFIGS = [cfg for cfg in CONFIGS if cfg[4] == 128]
+
+
 @pytest.mark.parametrize("num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim", CONFIGS)
 @pytest.mark.parametrize("batch_size, q_lens_val, context_kv_lens_val", SEQ_CONFIGS)
 @pytest.mark.parametrize("update_kv", [True, False])
@@ -192,6 +205,115 @@ def test_diff_vs_torch_no_sage(
         update_kv=update_kv,
         atol=1, rtol=0.05, ptol=0.999,
     )
+
+
+@pytest.mark.parametrize("num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim", SAGE_CONFIGS)
+@pytest.mark.parametrize("batch_size, q_lens_val, context_kv_lens_val", SEQ_CONFIGS)
+@pytest.mark.parametrize("update_kv", [True, False])
+@bypass_not_implemented
+def test_diff_vs_torch_with_sage(
+    num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim,
+    batch_size, q_lens_val, context_kv_lens_val,
+    update_kv,
+):
+    """Dedicated ixformer SAGE path matches torch reference, including SAGE caches."""
+    torch.manual_seed(42)
+    device = get_torch_device()
+    cfg = (num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim)
+    seq_cfg = (batch_size, q_lens_val, context_kv_lens_val)
+
+    op = MojoFusedNormRoPESageQuantStore(
+        num_heads_swa_q=num_heads_swa_q,
+        num_heads_swa_k=num_heads_swa_k,
+        num_heads_full_q=num_heads_full_q,
+        num_heads_full_k=num_heads_full_k,
+        head_dim=head_dim,
+        norm_eps=1e-5,
+        use_query_norm=True,
+        use_key_norm=True,
+        quant_dtype=torch.int8,
+        enable_sage=True,
+    ).to(device)
+    op_ref = MojoFusedNormRoPESageQuantStore._registry.get("torch")(
+        num_heads_swa_q=num_heads_swa_q,
+        num_heads_swa_k=num_heads_swa_k,
+        num_heads_full_q=num_heads_full_q,
+        num_heads_full_k=num_heads_full_k,
+        head_dim=head_dim,
+        norm_eps=1e-5,
+        use_query_norm=True,
+        use_key_norm=True,
+        quant_dtype=torch.int8,
+        enable_sage=True,
+    ).to(device)
+
+    for p in op_ref.parameters():
+        nn.init.normal_(p, mean=1.0, std=0.1)
+    op.load_state_dict(op_ref.state_dict())
+
+    inputs, full_kv_case, swa_kv_case, T = _build_inputs(cfg, seq_cfg, device)
+    fused_kpt_cache, fused_scale_cache = _build_sage_caches(full_kv_case)
+    ref_kpt_cache, ref_scale_cache = _build_sage_caches(full_kv_case)
+
+    fused_out = op(
+        *_forward_args(inputs, full_kv_case, swa_kv_case),
+        sage_full_k_pt_cache=fused_kpt_cache,
+        sage_full_k_pt_scale_cache=fused_scale_cache,
+        update_kv=update_kv,
+    )
+    ref_out = op_ref(
+        *_forward_args(inputs, full_kv_case, swa_kv_case),
+        sage_full_k_pt_cache=ref_kpt_cache,
+        sage_full_k_pt_scale_cache=ref_scale_cache,
+        update_kv=update_kv,
+    )
+
+    assert len(fused_out) == len(ref_out) == 12
+    output_names = (
+        "swa_q", "full_q", "full_key", "full_k_scale",
+        "swa_key", "swa_k_scale", "full_value", "full_v_scale",
+        "swa_value", "swa_v_scale", "full_key_pt", "full_key_pt_scale",
+    )
+    for name, fused, ref in zip(output_names, fused_out, ref_out):
+        if fused is None or ref is None:
+            assert fused is ref, name
+        elif fused.dtype == torch.int8:
+            diff = (fused.to(torch.int32) - ref.to(torch.int32)).abs().float()
+            assert (diff <= 1).float().mean().item() >= 0.99, name
+        elif name.endswith("scale"):
+            torch.testing.assert_close(
+                fused.float(), ref.float(), atol=1e-3, rtol=1e-2
+            )
+        else:
+            assert_close(fused, ref)
+
+    full_key_pt_int8, full_key_pt_scale = fused_out[-2], fused_out[-1]
+    if not update_kv:
+        assert full_key_pt_int8 is None
+        assert full_key_pt_scale is None
+        assert not bool((fused_kpt_cache != 0).any().item())
+        assert not bool((fused_scale_cache != 0).any().item())
+        return
+
+    assert full_key_pt_int8.shape == (T, num_heads_full_k, head_dim)
+    assert full_key_pt_int8.dtype == torch.int8
+    assert full_key_pt_scale.shape == (T, num_heads_full_k, 1)
+    assert full_key_pt_scale.dtype == torch.float32
+
+    kpt_written = ref_kpt_cache != 0
+    if bool(kpt_written.any().item()):
+        diff = (fused_kpt_cache.to(torch.int32) - ref_kpt_cache.to(torch.int32)).abs().float()[kpt_written]
+        assert (diff <= 1).float().mean().item() >= 0.99
+
+    scale_written = ref_scale_cache != 0
+    if bool(scale_written.any().item()):
+        torch.testing.assert_close(
+            fused_scale_cache[scale_written],
+            ref_scale_cache[scale_written],
+            atol=1e-2,
+            rtol=5e-2,
+        )
+
 
 @pytest.mark.parametrize("num_heads_swa_q, num_heads_swa_k, num_heads_full_q, num_heads_full_k, head_dim, rope_dim", CONFIGS)
 @pytest.mark.parametrize("batch_size, q_lens_val, context_kv_lens_val", SEQ_CONFIGS)

--- a/mojo_opset/tests/accuracy/operators/test_kv_cache.py
+++ b/mojo_opset/tests/accuracy/operators/test_kv_cache.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 from mojo_opset import MojoStorePagedKVCache
+from mojo_opset import MojoStorePagedSingleCache
 from mojo_opset.experimental import MojoStorePagedMLAKVCache
 from mojo_opset.tests.utils import assert_close
 from mojo_opset.tests.utils import auto_switch_platform
@@ -418,6 +419,152 @@ def test_store_paged_kv_chunk_metadata_perf_and_accuracy():
         f"chunk-metadata kernel should outperform legacy sequence-chunk kernel on bucket-padded sparse batches. "
         f"new={new_latency_ms:.3f} ms, legacy={legacy_latency_ms:.3f} ms"
     )
+
+
+# ===========================================================================
+# MojoStorePagedSingleCache
+# ===========================================================================
+
+@pytest.mark.parametrize(
+    "batch_size, kv_heads, head_dim, block_size, context_kv_lens_val, q_lens_val",
+    [
+        (2, 2, 128, 128, [0, 0], [130, 33]),
+        (2, 2, 128, 128, [32, 35], [1, 1]),
+        (2, 2, 128, 128, [15, 40], [788, 126]),
+        (2, 2, 128, 512, [255, 511], [300, 257]),
+        (2, 2, 128, 2048, [1023, 2047], [900, 1025]),
+        (1, 1, 128, 128, [0], [5]),
+        (1, 1, 128, 128, [5], [1]),
+        (1, 1, 128, 2048, [2046], [2]),
+        (3, 2, 128, 128, [32, -1, 35], [1, 1, 1]),
+        (3, 2, 128, 128, [0, -1, 5], [4, 0, 2]),
+        (3, 2, 128, 512, [510, -1, 700], [4, 1, 300]),
+        (8, 2, 128, 128, [224, 542, 34, 41, 54, 57, 65, 0], [432, 84, 977, 93, 23, 89, 31, 555]),
+        (8, 2, 128, 128, [772, 974, 3232, 43, 77, 7633, 888, 1], [1, 1, 1, 1, 1, 1, 1, 1]),
+    ],
+)
+@bypass_not_implemented
+def test_store_paged_single_cache(batch_size, kv_heads, head_dim, block_size, context_kv_lens_val, q_lens_val):
+    case = _build_store_paged_kv_case(
+        batch_size,
+        kv_heads,
+        head_dim,
+        block_size,
+        context_kv_lens_val,
+        q_lens_val,
+        device=get_torch_device(),
+    )
+
+    store_single_ref = MojoStorePagedSingleCache._registry.get("torch")()
+    store_single = MojoStorePagedSingleCache()
+    if type(store_single_ref) is type(store_single):
+        raise NotImplementedError("both operands resolve to the same implementation, skipping comparison.")
+
+    cache_ref = store_single_ref(
+        case["key_states"],
+        case["k_cache"].clone(),
+        chunk_metadata=case["chunk_metadata"],
+    )
+    cache = store_single(
+        case["key_states"],
+        case["k_cache"].clone(),
+        chunk_metadata=case["chunk_metadata"],
+    )
+
+    assert_close(cache, cache_ref)
+
+
+@pytest.mark.parametrize(
+    "batch_size, kv_heads, head_dim, block_size, context_kv_lens_val, q_lens_val",
+    [
+        (1, 2, 128, 16, [0], [3]),
+        (1, 2, 128, 128, [127], [1]),
+        (2, 4, 128, 32, [5, 33], [7, 19]),
+        (2, 4, 128, 256, [255, 511], [1, 1]),
+        (3, 8, 128, 128, [17, -1, 63], [1, 1, 1]),
+        (4, 16, 128, 128, [0, 3, 127, 255], [9, 17, 33, 65]),
+        (4, 16, 128, 512, [511, 1025, 7, 63], [1, 1, 1, 1]),
+        (6, 24, 128, 128, [31, 511, 1023, 7, 95, 1535], [129, 257, 513, 5, 17, 65]),
+    ],
+)
+@bypass_not_implemented
+def test_store_paged_single_cache_without_chunk_metadata(
+    batch_size,
+    kv_heads,
+    head_dim,
+    block_size,
+    context_kv_lens_val,
+    q_lens_val,
+):
+    case = _build_store_paged_kv_case(
+        batch_size,
+        kv_heads,
+        head_dim,
+        block_size,
+        context_kv_lens_val,
+        q_lens_val,
+        device=get_torch_device(),
+    )
+
+    store_single_ref = MojoStorePagedSingleCache._registry.get("torch")()
+    store_single = MojoStorePagedSingleCache()
+    if type(store_single_ref) is type(store_single):
+        raise NotImplementedError("both operands resolve to the same implementation, skipping comparison.")
+
+    cache_ref = store_single_ref(
+        case["key_states"],
+        case["k_cache"].clone(),
+        case["block_table"],
+        case["cu_q_lens"],
+        case["context_kv_lens"],
+    )
+    cache = store_single(
+        case["key_states"],
+        case["k_cache"].clone(),
+        case["block_table"],
+        case["cu_q_lens"],
+        case["context_kv_lens"],
+    )
+
+    assert_close(cache, cache_ref)
+
+
+@bypass_not_implemented
+def test_store_paged_single_cache_matches_full_kv_store():
+    batch_size = 4
+    kv_heads = 2
+    head_dim = 128
+    block_size = 128
+    context_kv_lens_val = [224, 0, 34, 41]
+    q_lens_val = [432, 84, 977, 93]
+
+    case = _build_store_paged_kv_case(
+        batch_size,
+        kv_heads,
+        head_dim,
+        block_size,
+        context_kv_lens_val,
+        q_lens_val,
+        device=get_torch_device(),
+    )
+
+    store_kv_ref = MojoStorePagedKVCache._registry.get("torch")()
+    store_single_ref = MojoStorePagedSingleCache._registry.get("torch")()
+
+    k_cache_ref, _ = store_kv_ref(
+        case["key_states"],
+        case["value_states"],
+        case["k_cache"].clone(),
+        case["v_cache"].clone(),
+        chunk_metadata=case["chunk_metadata"],
+    )
+    cache_single = store_single_ref(
+        case["key_states"],
+        case["k_cache"].clone(),
+        chunk_metadata=case["chunk_metadata"],
+    )
+
+    assert_close(cache_single, k_cache_ref)
 
 
 # ===========================================================================

--- a/mojo_opset/tests/accuracy/operators/test_kv_cache.py
+++ b/mojo_opset/tests/accuracy/operators/test_kv_cache.py
@@ -22,6 +22,7 @@ def _build_store_paged_kv_case(
     q_lens_val,
     *,
     device,
+    dtype=torch.bfloat16,
 ):
     context_kv_lens = torch.tensor(context_kv_lens_val, dtype=torch.int32, device=device)
     q_lens = torch.tensor(q_lens_val, dtype=torch.int32, device=device)
@@ -36,8 +37,8 @@ def _build_store_paged_kv_case(
     )
 
     total_tokens = int(q_lens.sum().item()) if not is_decode else batch_size
-    key_states = torch.randn((total_tokens, kv_heads, head_dim), dtype=torch.bfloat16, device=device)
-    value_states = torch.randn((total_tokens, kv_heads, head_dim), dtype=torch.bfloat16, device=device)
+    key_states = torch.randn((total_tokens, kv_heads, head_dim), dtype=dtype, device=device)
+    value_states = torch.randn((total_tokens, kv_heads, head_dim), dtype=dtype, device=device)
 
     max_kv_len = torch.clamp(context_kv_lens + q_lens, min=0).max().item()
     max_blocks_per_seq = (max_kv_len + block_size - 1) // block_size + 2
@@ -48,8 +49,8 @@ def _build_store_paged_kv_case(
     total_phys_blocks = total_blocks_needed + 10
 
     cache_shape = (total_phys_blocks, kv_heads, block_size, head_dim)
-    k_cache = torch.zeros(cache_shape, dtype=torch.bfloat16, device=device)
-    v_cache = torch.zeros(cache_shape, dtype=torch.bfloat16, device=device)
+    k_cache = torch.zeros(cache_shape, dtype=dtype, device=device)
+    v_cache = torch.zeros(cache_shape, dtype=dtype, device=device)
 
     block_table = torch.full((batch_size, max_blocks_per_seq), -1, dtype=torch.int32, device=device)
     next_block = 0
@@ -526,6 +527,61 @@ def test_store_paged_single_cache_without_chunk_metadata(
         case["context_kv_lens"],
     )
 
+    assert_close(cache, cache_ref)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "batch_size, kv_heads, head_dim, block_size, context_kv_lens_val, q_lens_val",
+    [
+        (1, 2, 128, 128, [127], [1]),
+        (2, 4, 128, 32, [5, 33], [7, 19]),
+        (3, 8, 128, 128, [17, -1, 63], [1, 1, 1]),
+        (4, 16, 128, 128, [0, 3, 127, 255], [9, 17, 33, 65]),
+    ],
+)
+@bypass_not_implemented
+def test_store_paged_single_cache_dtypes(
+    dtype,
+    batch_size,
+    kv_heads,
+    head_dim,
+    block_size,
+    context_kv_lens_val,
+    q_lens_val,
+):
+    case = _build_store_paged_kv_case(
+        batch_size,
+        kv_heads,
+        head_dim,
+        block_size,
+        context_kv_lens_val,
+        q_lens_val,
+        device=get_torch_device(),
+        dtype=dtype,
+    )
+
+    store_single_ref = MojoStorePagedSingleCache._registry.get("torch")()
+    store_single = MojoStorePagedSingleCache()
+    if type(store_single_ref) is type(store_single):
+        raise NotImplementedError("both operands resolve to the same implementation, skipping comparison.")
+
+    cache_ref = store_single_ref(
+        case["key_states"],
+        case["k_cache"].clone(),
+        case["block_table"],
+        case["cu_q_lens"],
+        case["context_kv_lens"],
+    )
+    cache = store_single(
+        case["key_states"],
+        case["k_cache"].clone(),
+        case["block_table"],
+        case["cu_q_lens"],
+        case["context_kv_lens"],
+    )
+
+    assert cache.dtype == dtype
     assert_close(cache, cache_ref)
 
 

--- a/mojo_opset/utils/platform.py
+++ b/mojo_opset/utils/platform.py
@@ -101,7 +101,14 @@ def get_impl_by_platform():
 
             for _, module_name, _ in pkgutil.iter_modules([api_dir_path]):
                 full_module_name = f"{api_package_name}.{module_name}"
-                module = importlib.import_module(full_module_name)
+                try:
+                    module = importlib.import_module(full_module_name)
+                except ImportError as e:
+                    logger.warning(
+                        f"Skip backend module '{full_module_name}' due to import error: {e}. "
+                        f"Other operators in this backend are unaffected."
+                    )
+                    continue
 
                 for name, op in inspect.getmembers(module, inspect.isclass):
                     if (
@@ -113,7 +120,7 @@ def get_impl_by_platform():
                         logger.debug(f"Found supported operator '{name}' in {full_module_name}")
                         import_op_map[name] = op
 
-    except (ImportError, IndexError):
+    except IndexError:
         import traceback
 
         logger.error(f"Failed to discover operators: {traceback.format_exc()}")


### PR DESCRIPTION
Adds MojoFusedNormRoPESageQuantStore, fusing QK-Norm, RoPE, int8 K/V quant, and paged store into one op, with optional SAGE per-token int8 key + scale stored inline via the ixformer rms_norm_sage_qk_rotary_embedding kernel.