### PR TITLE
Profiler tensor shape to MojoOperator

### DIFF
--- a/mojo_opset/core/operator.py
+++ b/mojo_opset/core/operator.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 
 from abc import ABC
@@ -67,9 +68,49 @@ class MojoOperator(ABC, torch.nn.Module):
         ABC.__init__(self)
         self.tensor_factory_kwargs = get_tensor_factory_kwargs(**kwargs)
 
+    def _call_impl(self, *args, **kwargs):
+        if torch.autograd._profiler_enabled():
+            sig = self._get_forward_signature_repr()
+            shape_repr = self._build_mojo_shape_repr(args, kwargs)
+            name = f"{type(self).__name__}{sig}[{shape_repr}]"
+            with torch.profiler.record_function(name):
+                return super()._call_impl(*args, **kwargs)
+        return super()._call_impl(*args, **kwargs)
+
     @abstractmethod
     def forward(self, *args, **kwargs) -> Tuple[Any]:
         raise NotImplementedError
+
+    @classmethod
+    def _get_forward_signature_repr(cls) -> str:
+        cached = cls.__dict__.get("_forward_signature_repr_cache")
+        if cached is not None:
+            return cached
+        try:
+            sig = inspect.signature(cls.forward)
+            params = [p for p in sig.parameters.values() if p.name != "self"]
+            sig_no_self = sig.replace(parameters=params)
+            repr_str = str(sig_no_self)
+        except (TypeError, ValueError):
+            repr_str = "(...)"
+        cls._forward_signature_repr_cache = repr_str
+        return repr_str
+
+    @staticmethod
+    def _format_tensor_meta(t: torch.Tensor) -> str:
+        dtype_str = str(t.dtype).replace("torch.", "")
+        shape = ",".join(str(s) for s in t.shape)
+        return f"({shape}){dtype_str}"
+
+    def _build_mojo_shape_repr(self, args, kwargs) -> str:
+        parts = []
+        for a in args:
+            if isinstance(a, torch.Tensor):
+                parts.append(self._format_tensor_meta(a))
+        for k, v in kwargs.items():
+            if isinstance(v, torch.Tensor):
+                parts.append(f"{k}={self._format_tensor_meta(v)}")
+        return ",".join(parts)
 
     def forward_diff_with(
         self,


### PR DESCRIPTION
Wrap MojoOperator._call_impl in torch.profiler.record_function so each forward shows up in traces as ClassName(sig)[shapes], with a per-class cached signature and tensor args rendered as (shape)dtype (bf16/fp16/fp32/i32/...).
<img width="1728" height="1117" alt="截屏2026-06-02 16 45 33" src="https://github.com/user-attachments/assets/4b5280b7-b143-498d-803e-7eec626f8085" />

