### PR TITLE
[KMCompiler][ttx]Optimize rms_norm for small cols

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/rmsnorm.py
@@ -82,13 +82,10 @@ def _rmsnorm_infer_small_cols_kernel(
         rrms = tl.where(row_mask, rrms, 0.0)
 
         y = x * rrms[:, None] * w[None, :]
-        tl.store(
-            y_ptrs,
-            y.to(Y_ptr.dtype.element_ty),
-            mask=block_mask,
-        )
+        tl.store(y_ptrs, y.to(Y_ptr.dtype.element_ty), mask=block_mask)
 
 
+@triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
 @libentry()
 @triton.jit
 def _rmsnorm_infer_kernel(
@@ -168,7 +165,6 @@ def rmsnorm_infer_impl(
     dim = shape[-1]
     X_2d = x.reshape(-1, dim)
     n_rows, n_cols = X_2d.shape
-    work_items = n_rows * n_cols
 
     y = torch.empty_like(X_2d)
 
@@ -178,21 +174,22 @@ def rmsnorm_infer_impl(
         BLOCK_SIZE_N = align(x, n_cols, VEC_ALIGN_BYTES)
 
     num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
-    # BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_cols": n_cols})
-    # BLOCK_SIZE_M 同时看 hidden dim 和总 work size
-    if work_items <= 4096:
-        BLOCK_SIZE_M = 1
-    elif work_items <= 16384:
-        BLOCK_SIZE_M = 2 if n_cols >= 1024 else 4
-    elif work_items <= 65536:
-        BLOCK_SIZE_M = 4 if n_cols >= 1024 else 8
-    else:
-        BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_cols": n_cols})
-    num_row_tasks = ceil_div(n_rows, BLOCK_SIZE_M)
-
-    grid = (min(num_programs, num_row_tasks),)
 
     if n_cols <= COL_BLOCKING_THRESHOLD:
+        work_items = n_rows * n_cols
+        # BLOCK_SIZE_M 同时看 hidden dim 和总 work size
+        if work_items <= 4096:
+            BLOCK_SIZE_M = 1
+        elif work_items <= 16384:
+            BLOCK_SIZE_M = 2 if n_cols >= 1024 else 4
+        elif work_items <= 65536:
+            BLOCK_SIZE_M = 4 if n_cols >= 1024 else 8
+        else:
+            heur_m = rms_norm_fwd_heuristics({"n_cols": n_cols})
+            BLOCK_SIZE_M = 1 << (heur_m.bit_length() - 1)
+        num_row_tasks = ceil_div(n_rows, BLOCK_SIZE_M)
+        grid = (min(num_programs, num_row_tasks),)
+
         _rmsnorm_infer_small_cols_kernel[grid](
             x,
             y,
@@ -202,10 +199,12 @@ def rmsnorm_infer_impl(
             n_rows=n_rows,
             n_cols=n_cols,
             eps=eps,
-            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_N=triton.next_power_of_2(n_cols),
             BLOCK_SIZE_M=BLOCK_SIZE_M,
         )
     else:
+        grid = (num_programs,)
+
         _rmsnorm_infer_kernel[grid](
             x,
             y,
@@ -216,7 +215,6 @@ def rmsnorm_infer_impl(
             n_cols=n_cols,
             eps=eps,
             BLOCK_SIZE_N=BLOCK_SIZE_N,
-            BLOCK_SIZE_M=BLOCK_SIZE_M,
         )
 
     return y.reshape(*shape)

--- a/mojo_opset/backends/ttx/kernels/npu/rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/rmsnorm.py
@@ -42,7 +42,53 @@ def rms_norm_fwd_heuristics(args):
         return 4
 
 
-@triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
+@libentry()
+@triton.jit
+def _rmsnorm_infer_small_cols_kernel(
+    X_ptr,
+    Y_ptr,
+    W_ptr,
+    stride_x_row,
+    stride_y_row,
+    n_rows,
+    n_cols,
+    eps,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    grid_size = tl.num_programs(axis=0)
+
+    num_row_tasks = (n_rows + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M
+
+    for row_task_id in range(pid, num_row_tasks, grid_size):
+        block_start_row = row_task_id * BLOCK_SIZE_M
+
+        current_row_offsets = block_start_row + tl.arange(0, BLOCK_SIZE_M)
+        col_offsets = tl.arange(0, BLOCK_SIZE_N)
+        row_mask = current_row_offsets < n_rows
+        col_mask = col_offsets < n_cols
+        block_mask = row_mask[:, None] & col_mask[None, :]
+
+        x_ptrs = X_ptr + (current_row_offsets[:, None] * stride_x_row + col_offsets[None, :])
+        y_ptrs = Y_ptr + (current_row_offsets[:, None] * stride_y_row + col_offsets[None, :])
+
+        x = tl.load(x_ptrs, mask=block_mask, other=0.0).to(tl.float32)
+        w = tl.load(W_ptr + col_offsets, mask=col_mask, other=0.0).to(tl.float32)
+
+        ss_acc = tl.sum(x * x, axis=1)
+        mean_square = ss_acc / n_cols
+        rrms = tl.rsqrt(mean_square + eps)
+        rrms = tl.where(row_mask, rrms, 0.0)
+
+        y = x * rrms[:, None] * w[None, :]
+        tl.store(
+            y_ptrs,
+            y.to(Y_ptr.dtype.element_ty),
+            mask=block_mask,
+        )
+
+
 @libentry()
 @triton.jit
 def _rmsnorm_infer_kernel(
@@ -122,6 +168,7 @@ def rmsnorm_infer_impl(
     dim = shape[-1]
     X_2d = x.reshape(-1, dim)
     n_rows, n_cols = X_2d.shape
+    work_items = n_rows * n_cols
 
     y = torch.empty_like(X_2d)
 
@@ -131,20 +178,46 @@ def rmsnorm_infer_impl(
         BLOCK_SIZE_N = align(x, n_cols, VEC_ALIGN_BYTES)
 
     num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
+    # BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_cols": n_cols})
+    # BLOCK_SIZE_M 同时看 hidden dim 和总 work size
+    if work_items <= 4096:
+        BLOCK_SIZE_M = 1
+    elif work_items <= 16384:
+        BLOCK_SIZE_M = 2 if n_cols >= 1024 else 4
+    elif work_items <= 65536:
+        BLOCK_SIZE_M = 4 if n_cols >= 1024 else 8
+    else:
+        BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_cols": n_cols})
+    num_row_tasks = ceil_div(n_rows, BLOCK_SIZE_M)
 
-    grid = (num_programs,)
+    grid = (min(num_programs, num_row_tasks),)
 
-    _rmsnorm_infer_kernel[grid](
-        x,
-        y,
-        w,
-        X_2d.stride(0),
-        y.stride(0),
-        n_rows=n_rows,
-        n_cols=n_cols,
-        eps=eps,
-        BLOCK_SIZE_N=BLOCK_SIZE_N,
-    )
+    if n_cols <= COL_BLOCKING_THRESHOLD:
+        _rmsnorm_infer_small_cols_kernel[grid](
+            x,
+            y,
+            w,
+            X_2d.stride(0),
+            y.stride(0),
+            n_rows=n_rows,
+            n_cols=n_cols,
+            eps=eps,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+        )
+    else:
+        _rmsnorm_infer_kernel[grid](
+            x,
+            y,
+            w,
+            X_2d.stride(0),
+            y.stride(0),
+            n_rows=n_rows,
+            n_cols=n_cols,
+            eps=eps,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
+        )
 
     return y.reshape(*shape)
 


### PR DESCRIPTION
## Description
The rms_norm operator has been optimized for the Ascend platform.

## Changes
1. Added _rmsnorm_infer_small_cols_kernel for n_cols <= 2048.

2. Updated the BLOCK_SIZE_M selection logic for inference.

## Performance

Using Ascend 910B and Triton 3.2.x of FlagTree，cann-8.5.0 :

| shape          | Dtype   | befor  | after  | speedup|
| -------------- | ------- | ------- | ------- | ------ |
| (1, 8, 128)    | float32 | 4.1424  | 2.1648  | 1.91   |
| (4, 32, 256)   | float32 | 5.3104  | 3.1248  | 1.70   |
| (8, 256, 2048) | float32 | 25.9360 | 25.3568 | 1.02   |
| (8, 256, 4096) | float32 | 38.6848 | 38.6608 | 1.00   |
| (1, 16, 4096)  | float32 | 6.6352  | 4.68    | 1.42   |
| (4, 32, 2048)  | float32 | 5.944   | 5.4448  | 1.09   |

## Accuracy test

```
platform linux -- Python 3.11.13, pytest-8.3.2, pluggy-1.6.0
rootdir: /data/baai_user_home/jstar/mojo-work/mojo_opset
configfile: pytest.ini
plugins: xdist-3.6.1, anyio-4.10.0
collected 10 items

test_normalization.py::test_rmsnorm[1e-05-dtype0-shape0] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype0-shape1] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype0-shape2] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype0-shape3] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype0-shape4] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype1-shape0] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype1-shape1] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype1-shape2] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype1-shape3] PASSED
test_normalization.py::test_rmsnorm[1e-05-dtype1-shape4] PASSED

============================ 10 passed in 24.16s ==========================
```