### PR TITLE
[KMCompiler][ttx] Optimize Layernorm performance

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/layernorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/layernorm.py
@@ -2,7 +2,7 @@ import torch
 import triton
 import triton.language as tl
 from triton.language.math import rsqrt
-from .utils import libentry
+from .utils import get_num_cores, libentry
 
 from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES
 from mojo_opset.backends.ttx.kernels.utils import align, ceil_div, torch_to_triton_dtype
@@ -147,36 +147,31 @@ def _layernorm_fwd_kernel(
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
 
+            if DROP_COLS_MASK:
+                w_chunk = tl.load(W_ptr + cols_off)
+                b_chunk = tl.load(B_ptr + cols_off)
+            else:
+                cols_mask = cols_off < n_cols
+                w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+                b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0)
+
             if DROP_ROWS_MASK:
                 if DROP_COLS_MASK:
                     x_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
-                    w_chunk = tl.load(W_ptr + cols_off)
-                    b_chunk = tl.load(B_ptr + cols_off)
                 else:
-                    cols_mask = cols_off < n_cols
                     x_chunk = tl.load(
                         X_ptr_row_block + cols_off[None, :],
                         mask=cols_mask[None, :],
                         other=0.0,
                     )
-                    w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
-                    b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0)
             else:
                 if DROP_COLS_MASK:
                     block_mask = rows_mask[:, None]
-                    x_chunk = tl.load(
-                        X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
-                    )
-                    w_chunk = tl.load(W_ptr + cols_off)
-                    b_chunk = tl.load(B_ptr + cols_off)
                 else:
-                    cols_mask = cols_off < n_cols
                     block_mask = rows_mask[:, None] & cols_mask[None, :]
-                    x_chunk = tl.load(
-                        X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
-                    )
-                    w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
-                    b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0)
+                x_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                )
 
             x_chunk = x_chunk.to(tl.float32)
             w_chunk = w_chunk.to(tl.float32)
@@ -495,10 +490,8 @@ def _layernorm_fwd_grid(n_rows: int, n_cols: int, x_dtype: torch.dtype) -> tuple
         {"n_rows": n_rows, "n_cols": n_cols, "x_dtype": x_dtype}
     )
     num_row_tasks = ceil_div(n_rows, block_m)
-    num_vectorcores = triton.runtime.driver.active.utils.get_device_properties("npu")[
-        "num_vectorcore"
-    ]
-    return (min(num_vectorcores, num_row_tasks),)
+    num_vectorcores = get_num_cores("vector")
+    return (max(1, min(num_vectorcores, num_row_tasks)),)
 
 
 def _launch_layernorm_fwd_kernel(
@@ -518,7 +511,7 @@ def _launch_layernorm_fwd_kernel(
         {"n_rows": n_rows, "n_cols": n_cols, "x_dtype": x_2d.dtype}
     )
     drop_cols_mask = n_cols % block_size_n == 0
-    drop_rows_mask = drop_cols_mask and n_rows % block_size_m == 0
+    drop_rows_mask = n_rows % block_size_m == 0
     use_single_pass = n_cols <= block_size_n
     grid = _layernorm_fwd_grid(n_rows, n_cols, x_2d.dtype)
 
@@ -629,9 +622,7 @@ def layernorm_bwd_impl(dy, x_2d, w, b, mean, rstd):
     else:
         BLOCK_SIZE_N = align(x_2d, n_cols, VEC_ALIGN_BYTES)
 
-    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")[
-        "num_vectorcore"
-    ]
+    num_programs = get_num_cores("vector")
     grid = (num_programs,)
 
     dx = torch.empty_like(dy_2d)

--- a/mojo_opset/backends/ttx/kernels/npu/layernorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/layernorm.py
@@ -1,14 +1,11 @@
 import torch
 import triton
 import triton.language as tl
-
 from triton.language.math import rsqrt
 from .utils import libentry
 
 from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES
-from mojo_opset.backends.ttx.kernels.utils import align
-from mojo_opset.backends.ttx.kernels.utils import ceil_div
-from mojo_opset.backends.ttx.kernels.utils import torch_to_triton_dtype
+from mojo_opset.backends.ttx.kernels.utils import align, ceil_div, torch_to_triton_dtype
 
 COL_BLOCKING_THRESHOLD = 2048
 
@@ -50,6 +47,8 @@ def _layernorm_fwd_kernel(
     n_rows,
     n_cols,
     eps,
+    DROP_COLS_MASK: tl.constexpr,
+    DROP_ROWS_MASK: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
 ):
@@ -61,49 +60,216 @@ def _layernorm_fwd_kernel(
     for row_task_id in range(pid, num_row_tasks, num_programs):
         block_start_row = row_task_id * BLOCK_SIZE_M
         rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
-        rows_mask = rows_off < n_rows
 
-        # Stage 1: compute mean and rstd in one pass over X
-        sum_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-        sum_sq_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+        if not DROP_ROWS_MASK:
+            rows_mask = rows_off < n_rows
+
+        mean_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+        var_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+
+        X_ptr_row_block = X_ptr + rows_off[:, None] * stride_x_row
+        Y_ptr_row_block = Y_ptr + rows_off[:, None] * stride_y_row
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            cols_mask = cols_off < n_cols
-            block_mask = rows_mask[:, None] & cols_mask[None, :]
 
-            x_chunk = tl.load(
-                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
-            ).to(tl.float32)
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    x_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
+                else:
+                    cols_mask = cols_off < n_cols
+                    x_chunk = tl.load(
+                        X_ptr_row_block + cols_off[None, :],
+                        mask=cols_mask[None, :],
+                        other=0.0,
+                    )
+            else:
+                if DROP_COLS_MASK:
+                    block_mask = rows_mask[:, None]
+                else:
+                    cols_mask = cols_off < n_cols
+                    block_mask = rows_mask[:, None] & cols_mask[None, :]
+                x_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                )
 
-            sum_acc += tl.sum(x_chunk, axis=1)
-            sum_sq_acc += tl.sum(x_chunk * x_chunk, axis=1)
+            x_chunk = x_chunk.to(tl.float32)
+            mean_acc += tl.sum(x_chunk, axis=1)
+            var_acc += tl.sum(x_chunk * x_chunk, axis=1)
 
-        mean = sum_acc / n_cols
-        var = sum_sq_acc / n_cols - mean * mean
+        mean = mean_acc / n_cols
+        var = var_acc / n_cols - mean * mean
+        var = tl.maximum(var, 0.0)
         rstd = rsqrt(var + eps)
 
-        tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
-        tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
+        if DROP_ROWS_MASK:
+            tl.store(Mean_ptr + rows_off, mean)
+            tl.store(RSTD_ptr + rows_off, rstd)
+        else:
+            tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
+            tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
 
-        # Stage 2: normalize and write output
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            cols_mask = cols_off < n_cols
-            block_mask = rows_mask[:, None] & cols_mask[None, :]
 
-            x_chunk = tl.load(
-                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
-            ).to(tl.float32)
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    x_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
+                    w_chunk = tl.load(W_ptr + cols_off)
+                    b_chunk = tl.load(B_ptr + cols_off)
+                else:
+                    cols_mask = cols_off < n_cols
+                    x_chunk = tl.load(
+                        X_ptr_row_block + cols_off[None, :],
+                        mask=cols_mask[None, :],
+                        other=0.0,
+                    )
+                    w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+                    b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0)
+            else:
+                if DROP_COLS_MASK:
+                    block_mask = rows_mask[:, None]
+                    x_chunk = tl.load(
+                        X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                    )
+                    w_chunk = tl.load(W_ptr + cols_off)
+                    b_chunk = tl.load(B_ptr + cols_off)
+                else:
+                    cols_mask = cols_off < n_cols
+                    block_mask = rows_mask[:, None] & cols_mask[None, :]
+                    x_chunk = tl.load(
+                        X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                    )
+                    w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+                    b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0)
 
-            w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
-            b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
+            x_chunk = x_chunk.to(tl.float32)
+            w_chunk = w_chunk.to(tl.float32)
+            b_chunk = b_chunk.to(tl.float32)
+            y_chunk = (x_chunk - mean[:, None]) * rstd[:, None] * w_chunk[
+                None, :
+            ] + b_chunk[None, :]
 
-            x_centered = x_chunk - mean[:, None]
-            y_chunk = x_centered * rstd[:, None] * w_chunk[None, :] + b_chunk[None, :]
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    tl.store(
+                        Y_ptr_row_block + cols_off[None, :],
+                        y_chunk.to(Y_ptr.dtype.element_ty),
+                    )
+                else:
+                    tl.store(
+                        Y_ptr_row_block + cols_off[None, :],
+                        y_chunk.to(Y_ptr.dtype.element_ty),
+                        mask=cols_mask[None, :],
+                    )
+            else:
+                tl.store(
+                    Y_ptr_row_block + cols_off[None, :],
+                    y_chunk.to(Y_ptr.dtype.element_ty),
+                    mask=block_mask,
+                )
 
+
+@triton.heuristics({"BLOCK_SIZE_M": layer_norm_fwd_heuristics})
+@libentry()
+@triton.jit
+def _layernorm_fwd_single_pass_kernel(
+    X_ptr,
+    Y_ptr,
+    W_ptr,
+    B_ptr,
+    Mean_ptr,
+    RSTD_ptr,
+    stride_x_row,
+    stride_y_row,
+    n_rows,
+    n_cols,
+    eps,
+    DROP_COLS_MASK: tl.constexpr,
+    DROP_ROWS_MASK: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+
+    num_row_tasks = (n_rows + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M
+    cols_off = tl.arange(0, BLOCK_SIZE_N)
+
+    for row_task_id in range(pid, num_row_tasks, num_programs):
+        block_start_row = row_task_id * BLOCK_SIZE_M
+        rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
+
+        X_ptr_row_block = X_ptr + rows_off[:, None] * stride_x_row
+        Y_ptr_row_block = Y_ptr + rows_off[:, None] * stride_y_row
+
+        if DROP_ROWS_MASK:
+            if DROP_COLS_MASK:
+                x_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
+            else:
+                cols_mask = cols_off < n_cols
+                x_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :],
+                    mask=cols_mask[None, :],
+                    other=0.0,
+                )
+        else:
+            rows_mask = rows_off < n_rows
+            if DROP_COLS_MASK:
+                block_mask = rows_mask[:, None]
+                x_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                )
+            else:
+                cols_mask = cols_off < n_cols
+                block_mask = rows_mask[:, None] & cols_mask[None, :]
+                x_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                )
+
+        x_chunk = x_chunk.to(tl.float32)
+        mean = tl.sum(x_chunk, axis=1) / n_cols
+        var = tl.sum(x_chunk * x_chunk, axis=1) / n_cols - mean * mean
+        var = tl.maximum(var, 0.0)
+        rstd = rsqrt(var + eps)
+
+        if DROP_ROWS_MASK:
+            tl.store(Mean_ptr + rows_off, mean)
+            tl.store(RSTD_ptr + rows_off, rstd)
+        else:
+            tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
+            tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
+
+        if DROP_COLS_MASK:
+            w_chunk = tl.load(W_ptr + cols_off).to(tl.float32)
+            b_chunk = tl.load(B_ptr + cols_off).to(tl.float32)
+        else:
+            w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(
+                tl.float32
+            )
+            b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0).to(
+                tl.float32
+            )
+
+        y_chunk = (x_chunk - mean[:, None]) * rstd[:, None] * w_chunk[
+            None, :
+        ] + b_chunk[None, :]
+
+        if DROP_ROWS_MASK:
+            if DROP_COLS_MASK:
+                tl.store(
+                    Y_ptr_row_block + cols_off[None, :],
+                    y_chunk.to(Y_ptr.dtype.element_ty),
+                )
+            else:
+                tl.store(
+                    Y_ptr_row_block + cols_off[None, :],
+                    y_chunk.to(Y_ptr.dtype.element_ty),
+                    mask=cols_mask[None, :],
+                )
+        else:
             tl.store(
-                Y_ptr + rows_off[:, None] * stride_y_row + cols_off[None, :],
+                Y_ptr_row_block + cols_off[None, :],
                 y_chunk.to(Y_ptr.dtype.element_ty),
                 mask=block_mask,
             )
@@ -152,13 +318,17 @@ def _layernorm_bwd_kernel(
         mean = tl.load(Mean_ptr + rows_off, mask=rows_mask, other=0.0).to(tl.float32)
         rstd = tl.load(RSTD_ptr + rows_off, mask=rows_mask, other=0.0).to(tl.float32)
 
-        dy = tl.load(DY_ptr + rows_off[:, None] * stride_dy_row + cols_off[None, :], mask=block_mask, other=0.0).to(
-            tl.float32
-        )
+        dy = tl.load(
+            DY_ptr + rows_off[:, None] * stride_dy_row + cols_off[None, :],
+            mask=block_mask,
+            other=0.0,
+        ).to(tl.float32)
 
-        x = tl.load(X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0).to(
-            tl.float32
-        )
+        x = tl.load(
+            X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :],
+            mask=block_mask,
+            other=0.0,
+        ).to(tl.float32)
 
         x_hat = (x - mean[:, None]) * rstd[:, None]
 
@@ -170,7 +340,11 @@ def _layernorm_bwd_kernel(
         c2 = tl.sum(wdy, axis=1) / n_cols
         dx = (wdy - (x_hat * c1[:, None] + c2[:, None])) * rstd[:, None]
 
-        tl.store(DX_ptr + rows_off[:, None] * stride_dx_row + cols_off[None, :], dx.to(X_dtype), mask=block_mask)
+        tl.store(
+            DX_ptr + rows_off[:, None] * stride_dx_row + cols_off[None, :],
+            dx.to(X_dtype),
+            mask=block_mask,
+        )
 
     tl.atomic_add(DW_ptr + cols_off, dW_acc, mask=cols_mask)
     tl.atomic_add(DB_ptr + cols_off, dB_acc, mask=cols_mask)
@@ -217,13 +391,17 @@ def _layernorm_bwd_large_cols_kernel(
             cols_mask = cols_off < n_cols
             block_mask = rows_mask[:, None] & cols_mask[None, :]
 
-            dy = tl.load(DY_ptr + rows_off[:, None] * stride_dy_row + cols_off[None, :], mask=block_mask, other=0.0).to(
-                tl.float32
-            )
+            dy = tl.load(
+                DY_ptr + rows_off[:, None] * stride_dy_row + cols_off[None, :],
+                mask=block_mask,
+                other=0.0,
+            ).to(tl.float32)
 
-            x = tl.load(X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0).to(
-                tl.float32
-            )
+            x = tl.load(
+                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :],
+                mask=block_mask,
+                other=0.0,
+            ).to(tl.float32)
 
             w = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
 
@@ -241,13 +419,17 @@ def _layernorm_bwd_large_cols_kernel(
             cols_mask = cols_off < n_cols
             block_mask = rows_mask[:, None] & cols_mask[None, :]
 
-            dy = tl.load(DY_ptr + rows_off[:, None] * stride_dy_row + cols_off[None, :], mask=block_mask, other=0.0).to(
-                tl.float32
-            )
+            dy = tl.load(
+                DY_ptr + rows_off[:, None] * stride_dy_row + cols_off[None, :],
+                mask=block_mask,
+                other=0.0,
+            ).to(tl.float32)
 
-            x = tl.load(X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0).to(
-                tl.float32
-            )
+            x = tl.load(
+                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :],
+                mask=block_mask,
+                other=0.0,
+            ).to(tl.float32)
 
             w = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
 
@@ -259,10 +441,69 @@ def _layernorm_bwd_large_cols_kernel(
 
             dx = (wdy - (x_hat * c1[:, None] + c2[:, None])) * rstd[:, None]
 
-            tl.store(DX_ptr + rows_off[:, None] * stride_dx_row + cols_off[None, :], dx.to(X_dtype), mask=block_mask)
+            tl.store(
+                DX_ptr + rows_off[:, None] * stride_dx_row + cols_off[None, :],
+                dx.to(X_dtype),
+                mask=block_mask,
+            )
 
             tl.atomic_add(DW_ptr + cols_off, dW_chunk, mask=cols_mask)
             tl.atomic_add(DB_ptr + cols_off, dB_chunk, mask=cols_mask)
+
+
+def _layernorm_fwd_grid(n_rows: int, n_cols: int) -> tuple[int]:
+    block_m = layer_norm_fwd_heuristics({"n_cols": n_cols})
+    num_row_tasks = ceil_div(n_rows, block_m)
+    num_vectorcores = triton.runtime.driver.active.utils.get_device_properties("npu")[
+        "num_vectorcore"
+    ]
+    return (min(num_vectorcores, num_row_tasks),)
+
+
+def _launch_layernorm_fwd_kernel(
+    x_2d, y, weight, bias, mean, rstd, n_rows, n_cols, eps, block_size_n
+):
+    block_size_m = layer_norm_fwd_heuristics({"n_cols": n_cols})
+    drop_cols_mask = n_cols % block_size_n == 0
+    drop_rows_mask = drop_cols_mask and n_rows % block_size_m == 0
+    use_single_pass = n_cols <= block_size_n
+    grid = _layernorm_fwd_grid(n_rows, n_cols)
+
+    if use_single_pass:
+        _layernorm_fwd_single_pass_kernel[grid](
+            x_2d,
+            y,
+            weight,
+            bias,
+            mean,
+            rstd,
+            x_2d.stride(0),
+            y.stride(0),
+            n_rows,
+            n_cols,
+            eps,
+            DROP_COLS_MASK=drop_cols_mask,
+            DROP_ROWS_MASK=drop_rows_mask,
+            BLOCK_SIZE_N=block_size_n,
+        )
+        return
+
+    _layernorm_fwd_kernel[grid](
+        x_2d,
+        y,
+        weight,
+        bias,
+        mean,
+        rstd,
+        x_2d.stride(0),
+        y.stride(0),
+        n_rows,
+        n_cols,
+        eps,
+        DROP_COLS_MASK=drop_cols_mask,
+        DROP_ROWS_MASK=drop_rows_mask,
+        BLOCK_SIZE_N=block_size_n,
+    )
 
 
 def layernorm_infer_impl(
@@ -281,26 +522,12 @@ def layernorm_infer_impl(
     else:
         BLOCK_SIZE_N = align(hidden_states, n_cols, VEC_ALIGN_BYTES)
 
-    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
-    grid = (num_programs,)
-
     y = torch.empty_like(x_2d)
-    mean = torch.empty(n_rows, dtype=hidden_states.dtype, device=hidden_states.device)
-    rstd = torch.empty(n_rows, dtype=hidden_states.dtype, device=hidden_states.device)
+    mean = torch.empty(n_rows, dtype=torch.float32, device=hidden_states.device)
+    rstd = torch.empty(n_rows, dtype=torch.float32, device=hidden_states.device)
 
-    _layernorm_fwd_kernel[grid](
-        x_2d,
-        y,
-        weight,
-        bias,
-        mean,
-        rstd,
-        x_2d.stride(0),
-        y.stride(0),
-        n_rows,
-        n_cols,
-        eps,
-        BLOCK_SIZE_N=BLOCK_SIZE_N,
+    _launch_layernorm_fwd_kernel(
+        x_2d, y, weight, bias, mean, rstd, n_rows, n_cols, eps, BLOCK_SIZE_N
     )
 
     return y.reshape(*shape)
@@ -317,26 +544,12 @@ def layernorm_fwd_impl(x, w, b, eps):
     else:
         BLOCK_SIZE_N = align(x, n_cols, VEC_ALIGN_BYTES)
 
-    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
-    grid = (num_programs,)
-
     y = torch.empty_like(x_2d)
-    mean = torch.empty(n_rows, dtype=x.dtype, device=x.device)
-    rstd = torch.empty(n_rows, dtype=x.dtype, device=x.device)
+    mean = torch.empty(n_rows, dtype=torch.float32, device=x.device)
+    rstd = torch.empty(n_rows, dtype=torch.float32, device=x.device)
 
-    _layernorm_fwd_kernel[grid](
-        x_2d,
-        y,
-        w,
-        b,
-        mean,
-        rstd,
-        x_2d.stride(0),
-        y.stride(0),
-        n_rows,
-        n_cols,
-        eps,
-        BLOCK_SIZE_N=BLOCK_SIZE_N,
+    _launch_layernorm_fwd_kernel(
+        x_2d, y, w, b, mean, rstd, n_rows, n_cols, eps, BLOCK_SIZE_N
     )
 
     return y.reshape(*shape), x_2d, mean, rstd
@@ -353,7 +566,9 @@ def layernorm_bwd_impl(dy, x_2d, w, b, mean, rstd):
     else:
         BLOCK_SIZE_N = align(x_2d, n_cols, VEC_ALIGN_BYTES)
 
-    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
+    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")[
+        "num_vectorcore"
+    ]
     grid = (num_programs,)
 
     dx = torch.empty_like(dy_2d)

--- a/mojo_opset/backends/ttx/kernels/npu/layernorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/layernorm.py
@@ -20,6 +20,40 @@ TOKEN_BLOCK_SIZE_TABLE = {
 
 def layer_norm_fwd_heuristics(args):
     hidden_dim = args["n_cols"]
+    n_rows = args["n_rows"] if "n_rows" in args else 0
+    x_dtype = args["x_dtype"] if "x_dtype" in args else args["X_ptr"].dtype
+
+    if hidden_dim > 8192:
+        if x_dtype != torch.float32:
+            return 4
+        return 8
+
+    if hidden_dim >= 8192:
+        if n_rows <= 16:
+            return 1
+        if x_dtype != torch.float32:
+            return 4
+        return 8
+
+    if hidden_dim >= 4096:
+        if n_rows <= 16:
+            return 1
+        return 4
+
+    if hidden_dim >= 2048:
+        return 4
+
+    if hidden_dim >= 1024:
+        return 8
+
+    if hidden_dim >= 512:
+        return 12
+
+    if hidden_dim <= 128:
+        if n_rows >= 256:
+            return 32
+        return 16
+
     if hidden_dim <= COL_BLOCKING_THRESHOLD:
         if hidden_dim in TOKEN_BLOCK_SIZE_TABLE:
             return TOKEN_BLOCK_SIZE_TABLE[hidden_dim]
@@ -28,8 +62,7 @@ def layer_norm_fwd_heuristics(args):
             if hidden_dim <= dim_thresh:
                 return block_size
         return 1
-    else:
-        return 4
+    return 4
 
 
 @triton.heuristics({"BLOCK_SIZE_M": layer_norm_fwd_heuristics})
@@ -49,6 +82,7 @@ def _layernorm_fwd_kernel(
     eps,
     DROP_COLS_MASK: tl.constexpr,
     DROP_ROWS_MASK: tl.constexpr,
+    STORE_STATS: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
 ):
@@ -102,12 +136,13 @@ def _layernorm_fwd_kernel(
         var = tl.maximum(var, 0.0)
         rstd = rsqrt(var + eps)
 
-        if DROP_ROWS_MASK:
-            tl.store(Mean_ptr + rows_off, mean)
-            tl.store(RSTD_ptr + rows_off, rstd)
-        else:
-            tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
-            tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
+        if STORE_STATS:
+            if DROP_ROWS_MASK:
+                tl.store(Mean_ptr + rows_off, mean)
+                tl.store(RSTD_ptr + rows_off, rstd)
+            else:
+                tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
+                tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
@@ -187,6 +222,7 @@ def _layernorm_fwd_single_pass_kernel(
     eps,
     DROP_COLS_MASK: tl.constexpr,
     DROP_ROWS_MASK: tl.constexpr,
+    STORE_STATS: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
 ):
@@ -229,16 +265,21 @@ def _layernorm_fwd_single_pass_kernel(
 
         x_chunk = x_chunk.to(tl.float32)
         mean = tl.sum(x_chunk, axis=1) / n_cols
-        var = tl.sum(x_chunk * x_chunk, axis=1) / n_cols - mean * mean
-        var = tl.maximum(var, 0.0)
+        x_centered = x_chunk - mean[:, None]
+        if DROP_COLS_MASK:
+            var = tl.sum(x_centered * x_centered, axis=1) / n_cols
+        else:
+            x_centered_for_var = tl.where(cols_mask[None, :], x_centered, 0.0)
+            var = tl.sum(x_centered_for_var * x_centered_for_var, axis=1) / n_cols
         rstd = rsqrt(var + eps)
 
-        if DROP_ROWS_MASK:
-            tl.store(Mean_ptr + rows_off, mean)
-            tl.store(RSTD_ptr + rows_off, rstd)
-        else:
-            tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
-            tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
+        if STORE_STATS:
+            if DROP_ROWS_MASK:
+                tl.store(Mean_ptr + rows_off, mean)
+                tl.store(RSTD_ptr + rows_off, rstd)
+            else:
+                tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
+                tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
 
         if DROP_COLS_MASK:
             w_chunk = tl.load(W_ptr + cols_off).to(tl.float32)
@@ -251,9 +292,7 @@ def _layernorm_fwd_single_pass_kernel(
                 tl.float32
             )
 
-        y_chunk = (x_chunk - mean[:, None]) * rstd[:, None] * w_chunk[
-            None, :
-        ] + b_chunk[None, :]
+        y_chunk = x_centered * rstd[:, None] * w_chunk[None, :] + b_chunk[None, :]
 
         if DROP_ROWS_MASK:
             if DROP_COLS_MASK:
@@ -451,8 +490,10 @@ def _layernorm_bwd_large_cols_kernel(
             tl.atomic_add(DB_ptr + cols_off, dB_chunk, mask=cols_mask)
 
 
-def _layernorm_fwd_grid(n_rows: int, n_cols: int) -> tuple[int]:
-    block_m = layer_norm_fwd_heuristics({"n_cols": n_cols})
+def _layernorm_fwd_grid(n_rows: int, n_cols: int, x_dtype: torch.dtype) -> tuple[int]:
+    block_m = layer_norm_fwd_heuristics(
+        {"n_rows": n_rows, "n_cols": n_cols, "x_dtype": x_dtype}
+    )
     num_row_tasks = ceil_div(n_rows, block_m)
     num_vectorcores = triton.runtime.driver.active.utils.get_device_properties("npu")[
         "num_vectorcore"
@@ -461,13 +502,25 @@ def _layernorm_fwd_grid(n_rows: int, n_cols: int) -> tuple[int]:
 
 
 def _launch_layernorm_fwd_kernel(
-    x_2d, y, weight, bias, mean, rstd, n_rows, n_cols, eps, block_size_n
+    x_2d,
+    y,
+    weight,
+    bias,
+    mean,
+    rstd,
+    n_rows,
+    n_cols,
+    eps,
+    block_size_n,
+    store_stats: bool,
 ):
-    block_size_m = layer_norm_fwd_heuristics({"n_cols": n_cols})
+    block_size_m = layer_norm_fwd_heuristics(
+        {"n_rows": n_rows, "n_cols": n_cols, "x_dtype": x_2d.dtype}
+    )
     drop_cols_mask = n_cols % block_size_n == 0
     drop_rows_mask = drop_cols_mask and n_rows % block_size_m == 0
     use_single_pass = n_cols <= block_size_n
-    grid = _layernorm_fwd_grid(n_rows, n_cols)
+    grid = _layernorm_fwd_grid(n_rows, n_cols, x_2d.dtype)
 
     if use_single_pass:
         _layernorm_fwd_single_pass_kernel[grid](
@@ -484,6 +537,7 @@ def _launch_layernorm_fwd_kernel(
             eps,
             DROP_COLS_MASK=drop_cols_mask,
             DROP_ROWS_MASK=drop_rows_mask,
+            STORE_STATS=store_stats,
             BLOCK_SIZE_N=block_size_n,
         )
         return
@@ -502,6 +556,7 @@ def _launch_layernorm_fwd_kernel(
         eps,
         DROP_COLS_MASK=drop_cols_mask,
         DROP_ROWS_MASK=drop_rows_mask,
+        STORE_STATS=store_stats,
         BLOCK_SIZE_N=block_size_n,
     )
 
@@ -523,11 +578,19 @@ def layernorm_infer_impl(
         BLOCK_SIZE_N = align(hidden_states, n_cols, VEC_ALIGN_BYTES)
 
     y = torch.empty_like(x_2d)
-    mean = torch.empty(n_rows, dtype=torch.float32, device=hidden_states.device)
-    rstd = torch.empty(n_rows, dtype=torch.float32, device=hidden_states.device)
 
     _launch_layernorm_fwd_kernel(
-        x_2d, y, weight, bias, mean, rstd, n_rows, n_cols, eps, BLOCK_SIZE_N
+        x_2d,
+        y,
+        weight,
+        bias,
+        y,
+        y,
+        n_rows,
+        n_cols,
+        eps,
+        BLOCK_SIZE_N,
+        store_stats=False,
     )
 
     return y.reshape(*shape)
@@ -549,7 +612,7 @@ def layernorm_fwd_impl(x, w, b, eps):
     rstd = torch.empty(n_rows, dtype=torch.float32, device=x.device)
 
     _launch_layernorm_fwd_kernel(
-        x_2d, y, w, b, mean, rstd, n_rows, n_cols, eps, BLOCK_SIZE_N
+        x_2d, y, w, b, mean, rstd, n_rows, n_cols, eps, BLOCK_SIZE_N, store_stats=True
     )
 
     return y.reshape(*shape), x_2d, mean, rstd

--- a/mojo_opset/backends/ttx/kernels/npu/layernorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/layernorm.py
@@ -63,7 +63,9 @@ def _layernorm_fwd_kernel(
         rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
         rows_mask = rows_off < n_rows
 
+        # Stage 1: compute mean and rstd in one pass over X
         sum_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
+        sum_sq_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
@@ -75,34 +77,16 @@ def _layernorm_fwd_kernel(
             ).to(tl.float32)
 
             sum_acc += tl.sum(x_chunk, axis=1)
+            sum_sq_acc += tl.sum(x_chunk * x_chunk, axis=1)
 
         mean = sum_acc / n_cols
-
-        tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
-
-        var_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
-
-        for col_offset in range(0, n_cols, BLOCK_SIZE_N):
-            cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            cols_mask = cols_off < n_cols
-            block_mask = rows_mask[:, None] & cols_mask[None, :]
-
-            x_chunk = tl.load(
-                X_ptr + rows_off[:, None] * stride_x_row + cols_off[None, :], mask=block_mask, other=0.0
-            ).to(tl.float32)
-
-            w_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
-            b_chunk = tl.load(B_ptr + cols_off, mask=cols_mask, other=0.0).to(tl.float32)
-
-            x_centered = x_chunk - mean[:, None]
-
-            var_acc += tl.sum(x_centered * x_centered, axis=1)
-
-        var = var_acc / n_cols
+        var = sum_sq_acc / n_cols - mean * mean
         rstd = rsqrt(var + eps)
 
+        tl.store(Mean_ptr + rows_off, mean, mask=rows_mask)
         tl.store(RSTD_ptr + rows_off, rstd, mask=rows_mask)
 
+        # Stage 2: normalize and write output
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
             cols_mask = cols_off < n_cols


### PR DESCRIPTION
## Description

Optimize NPU LayerNorm forward performance by reducing input reads, eliminating unnecessary masks and statistic writes, and tuning kernel scheduling for different shapes and dtypes.

## Changes

- Merge mean and variance statistics into one input pass using `Var(x) = E[x^2] - E[x]^2`
- Dynamically trim the grid based on the actual number of row tasks
- Add no-mask paths for tile-aligned shapes
- Add a single-pass kernel when the hidden dimension fits in one tile
- Use centered variance and reuse `x_centered` in the single-pass path
- Skip `Mean/RSTD` allocation and writes during inference
- Tune `BLOCK_SIZE_M` based on `n_rows`, `n_cols`, and dtype
- Use conservative fp16/bf16 tiles to avoid UB overflow

## Performance

Measured with `torch.float32` inputs.

| Shape | Before [us] | After [us] | Speedup |
|---|---:|---:|---:|
| (8, 8192) | 11.9520 | 4.7712 | 2.51x |
| (16, 4096) | 8.2624 | 3.9824 | 2.07x |
| (32, 64) | 4.0880 | 2.2608 | 1.81x |
| (32, 128) | 4.1568 | 2.3184 | 1.79x |
| (32, 2048) | 6.4656 | 3.8000 | 1.70x |
| (128, 128) | 5.1024 | 2.7152 | 1.88x |
| (128, 2048) | 6.7168 | 5.9072 | 1.14x |
| (256, 128) | 5.4800 | 3.2048 | 1.71x |
| (256, 512) | 6.3760 | 4.7824 | 1.33x |
| (256, 12800) | 35.9152 | 24.5744 | 1.46x |
| (1024, 1024) | 14.3488 | 10.5536 | 1.36x |

Overall speedup: **1.14x–2.51x**.

## Accuracy

Accuracy tests in `mojo_opset/tests/accuracy/operators/test_normalization.py` passed.