### PR TITLE
[KMCompiler][ttx] Optimize NPU ResidualAddRMSNorm forward performance

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES
+from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES, get_num_cores
 from mojo_opset.backends.ttx.kernels.utils import align, ceil_div
 
 from .utils import libentry
@@ -56,9 +56,7 @@ def rms_norm_fwd_heuristics(args):
 
 
 def _num_vectorcores():
-    return triton.runtime.driver.active.utils.get_device_properties("npu")[
-        "num_vectorcore"
-    ]
+    return get_num_cores("vector")
 
 
 @triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
@@ -536,12 +534,12 @@ def fused_add_rmsnorm_infer_impl(
 
     BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_rows": n_rows, "n_cols": n_cols})
     num_row_tasks = ceil_div(n_rows, BLOCK_SIZE_M)
-    grid = (min(_num_vectorcores(), num_row_tasks),)
+    grid = (max(1, min(_num_vectorcores(), num_row_tasks)),)
 
     Y = torch.empty_like(hidden_states_2d)
     use_single_pass = n_cols <= BLOCK_SIZE_N
     drop_cols_mask = n_cols % BLOCK_SIZE_N == 0
-    drop_rows_mask = drop_cols_mask and n_rows % BLOCK_SIZE_M == 0
+    drop_rows_mask = n_rows % BLOCK_SIZE_M == 0
 
     if use_single_pass:
         S = Y if add_mode == "post" else torch.empty_like(hidden_states_2d)

--- a/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
@@ -4,11 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .utils import libentry
-
 from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES
-from mojo_opset.backends.ttx.kernels.utils import align
-from mojo_opset.backends.ttx.kernels.utils import ceil_div
+from mojo_opset.backends.ttx.kernels.utils import align, ceil_div
+
+from .utils import libentry
 
 COL_BLOCKING_THRESHOLD = 2048
 
@@ -57,7 +56,9 @@ def rms_norm_fwd_heuristics(args):
 
 
 def _num_vectorcores():
-    return triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
+    return triton.runtime.driver.active.utils.get_device_properties("npu")[
+        "num_vectorcore"
+    ]
 
 
 @triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
@@ -113,15 +114,27 @@ def _fused_add_rmsnorm_fwd_kernel(
                     R_chunk = tl.load(R_ptr_row_block + cols_off[None, :])
                 else:
                     cols_mask = cols_off < n_cols
-                    X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
-                    R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                    X_chunk = tl.load(
+                        X_ptr_row_block + cols_off[None, :],
+                        mask=cols_mask[None, :],
+                        other=0.0,
+                    )
+                    R_chunk = tl.load(
+                        R_ptr_row_block + cols_off[None, :],
+                        mask=cols_mask[None, :],
+                        other=0.0,
+                    )
             else:
                 if DROP_COLS_MASK:
                     block_mask = rows_mask[:, None]
                 else:
                     block_mask = rows_mask[:, None] & (cols_off[None, :] < n_cols)
-                X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
-                R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                X_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                )
+                R_chunk = tl.load(
+                    R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                )
 
             S_chunk = X_chunk + R_chunk
             if STORE_S:
@@ -129,9 +142,15 @@ def _fused_add_rmsnorm_fwd_kernel(
                     if DROP_COLS_MASK:
                         tl.store(S_ptr_row_block + cols_off[None, :], S_chunk)
                     else:
-                        tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=cols_mask[None, :])
+                        tl.store(
+                            S_ptr_row_block + cols_off[None, :],
+                            S_chunk,
+                            mask=cols_mask[None, :],
+                        )
                 else:
-                    tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=block_mask)
+                    tl.store(
+                        S_ptr_row_block + cols_off[None, :], S_chunk, mask=block_mask
+                    )
 
             S_chunk_f32 = S_chunk.to(tl.float32)
             var_acc += tl.sum(S_chunk_f32 * S_chunk_f32, axis=1)
@@ -142,7 +161,9 @@ def _fused_add_rmsnorm_fwd_kernel(
             if DROP_ROWS_MASK:
                 tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec)
             else:
-                tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask)
+                tl.store(
+                    RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask
+                )
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
@@ -160,10 +181,22 @@ def _fused_add_rmsnorm_fwd_kernel(
                     cols_mask = cols_off < n_cols
                     W_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
                     if STORE_S:
-                        S_chunk = tl.load(S_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                        S_chunk = tl.load(
+                            S_ptr_row_block + cols_off[None, :],
+                            mask=cols_mask[None, :],
+                            other=0.0,
+                        )
                     else:
-                        X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
-                        R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                        X_chunk = tl.load(
+                            X_ptr_row_block + cols_off[None, :],
+                            mask=cols_mask[None, :],
+                            other=0.0,
+                        )
+                        R_chunk = tl.load(
+                            R_ptr_row_block + cols_off[None, :],
+                            mask=cols_mask[None, :],
+                            other=0.0,
+                        )
                         S_chunk = X_chunk + R_chunk
             else:
                 if DROP_COLS_MASK:
@@ -175,10 +208,16 @@ def _fused_add_rmsnorm_fwd_kernel(
                     W_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
 
                 if STORE_S:
-                    S_chunk = tl.load(S_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                    S_chunk = tl.load(
+                        S_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                    )
                 else:
-                    X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
-                    R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                    X_chunk = tl.load(
+                        X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                    )
+                    R_chunk = tl.load(
+                        R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+                    )
                     S_chunk = X_chunk + R_chunk
 
             if casting_mode == _CASTING_MODE_GEMMA:
@@ -189,9 +228,13 @@ def _fused_add_rmsnorm_fwd_kernel(
 
             if casting_mode == _CASTING_MODE_LLAMA:
                 if STORE_S:
-                    normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(S_ptr.dtype.element_ty)
+                    normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(
+                        S_ptr.dtype.element_ty
+                    )
                 else:
-                    normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(Y_ptr.dtype.element_ty)
+                    normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(
+                        Y_ptr.dtype.element_ty
+                    )
             else:
                 normed_S_chunk = S_chunk * rstd_vec[:, None]
 
@@ -207,7 +250,11 @@ def _fused_add_rmsnorm_fwd_kernel(
                 if DROP_COLS_MASK:
                     tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk)
                 else:
-                    tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=cols_mask[None, :])
+                    tl.store(
+                        Y_ptr_row_block + cols_off[None, :],
+                        Y_chunk,
+                        mask=cols_mask[None, :],
+                    )
             else:
                 tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=block_mask)
 
@@ -260,8 +307,16 @@ def _fused_add_rmsnorm_fwd_single_pass_kernel(
                 R_chunk = tl.load(R_ptr_row_block + cols_off[None, :])
             else:
                 cols_mask = cols_off < n_cols
-                X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
-                R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                X_chunk = tl.load(
+                    X_ptr_row_block + cols_off[None, :],
+                    mask=cols_mask[None, :],
+                    other=0.0,
+                )
+                R_chunk = tl.load(
+                    R_ptr_row_block + cols_off[None, :],
+                    mask=cols_mask[None, :],
+                    other=0.0,
+                )
         else:
             rows_mask = rows_off < n_rows
             if DROP_COLS_MASK:
@@ -269,8 +324,12 @@ def _fused_add_rmsnorm_fwd_single_pass_kernel(
             else:
                 cols_mask = cols_off < n_cols
                 block_mask = rows_mask[:, None] & cols_mask[None, :]
-            X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
-            R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+            X_chunk = tl.load(
+                X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+            )
+            R_chunk = tl.load(
+                R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0
+            )
 
         S_chunk = X_chunk + R_chunk
 
@@ -279,7 +338,11 @@ def _fused_add_rmsnorm_fwd_single_pass_kernel(
                 if DROP_COLS_MASK:
                     tl.store(S_ptr_row_block + cols_off[None, :], S_chunk)
                 else:
-                    tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=cols_mask[None, :])
+                    tl.store(
+                        S_ptr_row_block + cols_off[None, :],
+                        S_chunk,
+                        mask=cols_mask[None, :],
+                    )
             else:
                 tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=block_mask)
 
@@ -292,7 +355,9 @@ def _fused_add_rmsnorm_fwd_single_pass_kernel(
             if DROP_ROWS_MASK:
                 tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec)
             else:
-                tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask)
+                tl.store(
+                    RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask
+                )
 
         if DROP_COLS_MASK:
             W_chunk = tl.load(W_ptr + cols_off)
@@ -307,9 +372,13 @@ def _fused_add_rmsnorm_fwd_single_pass_kernel(
 
         if casting_mode == _CASTING_MODE_LLAMA:
             if STORE_S:
-                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(S_ptr.dtype.element_ty)
+                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(
+                    S_ptr.dtype.element_ty
+                )
             else:
-                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(Y_ptr.dtype.element_ty)
+                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(
+                    Y_ptr.dtype.element_ty
+                )
         else:
             normed_S_chunk = S_chunk * rstd_vec[:, None]
 
@@ -325,10 +394,13 @@ def _fused_add_rmsnorm_fwd_single_pass_kernel(
             if DROP_COLS_MASK:
                 tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk)
             else:
-                tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=cols_mask[None, :])
+                tl.store(
+                    Y_ptr_row_block + cols_off[None, :],
+                    Y_chunk,
+                    mask=cols_mask[None, :],
+                )
         else:
             tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=block_mask)
-
 
 
 @triton.heuristics({"BLOCK_SIZE_M": lambda args: ceil_div(4096, args["n_cols"])})
@@ -374,9 +446,19 @@ def _fused_add_rmsnorm_bwd_kernel(
         rows_mask = rows_off < n_rows
         block_mask = rows_mask[:, None] & cols_mask[None, :]
 
-        dY_block = tl.load(dY_ptr + rows_off[:, None] * dY_row_stride + cols_off[None, :], mask=block_mask, other=0.0)
-        S_block = tl.load(S_ptr + rows_off[:, None] * S_row_stride + cols_off[None, :], mask=block_mask, other=0.0)
-        rstd_vec = tl.load(RSTD_ptr + rows_off * RSTD_row_stride, mask=rows_mask, other=0.0)
+        dY_block = tl.load(
+            dY_ptr + rows_off[:, None] * dY_row_stride + cols_off[None, :],
+            mask=block_mask,
+            other=0.0,
+        )
+        S_block = tl.load(
+            S_ptr + rows_off[:, None] * S_row_stride + cols_off[None, :],
+            mask=block_mask,
+            other=0.0,
+        )
+        rstd_vec = tl.load(
+            RSTD_ptr + rows_off * RSTD_row_stride, mask=rows_mask, other=0.0
+        )
 
         S_block_f32 = S_block.to(tl.float32)
         normed_S_block = S_block_f32 * rstd_vec[:, None]
@@ -397,18 +479,30 @@ def _fused_add_rmsnorm_bwd_kernel(
         rstd_vec_sq = rstd_vec * rstd_vec
 
         term1 = rstd_vec[:, None] * m_block
-        term2 = -(1 / n_cols) * rstd_vec_sq[:, None] * rstd_vec[:, None] * dot_product_vec[:, None] * S_block_f32
+        term2 = (
+            -(1 / n_cols)
+            * rstd_vec_sq[:, None]
+            * rstd_vec[:, None]
+            * dot_product_vec[:, None]
+            * S_block_f32
+        )
 
         grad_after_norm = term1 + term2
 
         dS_block = grad_after_norm
         if has_dS_out:
             dS_out_block = tl.load(
-                dS_out_ptr + rows_off[:, None] * dS_out_row_stride + cols_off[None, :], mask=block_mask, other=0.0
+                dS_out_ptr + rows_off[:, None] * dS_out_row_stride + cols_off[None, :],
+                mask=block_mask,
+                other=0.0,
             )
             dS_block += dS_out_block.to(dS_block.dtype)
 
-        tl.store(dX_ptr + rows_off[:, None] * dX_row_stride + cols_off[None, :], dS_block.to(S_dtype), mask=block_mask)
+        tl.store(
+            dX_ptr + rows_off[:, None] * dX_row_stride + cols_off[None, :],
+            dS_block.to(S_dtype),
+            mask=block_mask,
+        )
 
     dW_ptr_prog = dW_ptr + pid * dW_row_stride + cols_off
     tl.store(dW_ptr_prog, dW_acc, mask=cols_mask)

--- a/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
@@ -27,6 +27,24 @@ TOKEN_BLOCK_SIZE_TABLE = {
 
 def rms_norm_fwd_heuristics(args):
     hidden_dim = args["n_cols"]
+    n_rows = args["n_rows"] if "n_rows" in args else 0
+
+    if hidden_dim >= 8192:
+        return 1
+    if hidden_dim >= 4096:
+        return 2
+    if hidden_dim >= 2048:
+        return 4
+    if hidden_dim >= 1024:
+        return 8
+    if hidden_dim >= 512:
+        return 16
+
+    if hidden_dim <= 128:
+        if n_rows > 0 and n_rows <= 32:
+            return 4
+        return 32
+
     if hidden_dim <= COL_BLOCKING_THRESHOLD:
         if hidden_dim in TOKEN_BLOCK_SIZE_TABLE:
             return TOKEN_BLOCK_SIZE_TABLE[hidden_dim]
@@ -35,8 +53,11 @@ def rms_norm_fwd_heuristics(args):
             if hidden_dim <= dim_thresh:
                 return block_size
         return 1
-    else:
-        return 4
+    return 4
+
+
+def _num_vectorcores():
+    return triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
 
 
 @triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
@@ -59,6 +80,10 @@ def _fused_add_rmsnorm_fwd_kernel(
     eps,
     offset,
     casting_mode: tl.constexpr,
+    STORE_S: tl.constexpr,
+    STORE_RSTD: tl.constexpr,
+    DROP_COLS_MASK: tl.constexpr,
+    DROP_ROWS_MASK: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
 ):
@@ -69,37 +94,92 @@ def _fused_add_rmsnorm_fwd_kernel(
     for row_task_id in range(pid, num_row_tasks, grid_size):
         block_start_row = row_task_id * BLOCK_SIZE_M
         rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
-        rows_mask = rows_off < n_rows
 
         X_ptr_row_block = X_ptr + rows_off[:, None] * X_row_stride
         R_ptr_row_block = R_ptr + rows_off[:, None] * R_row_stride
         S_ptr_row_block = S_ptr + rows_off[:, None] * S_row_stride
         Y_ptr_row_block = Y_ptr + rows_off[:, None] * Y_row_stride
 
+        if not DROP_ROWS_MASK:
+            rows_mask = rows_off < n_rows
+
         var_acc = tl.zeros((BLOCK_SIZE_M,), dtype=tl.float32)
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            block_mask = rows_mask[:, None] & (cols_off[None, :] < n_cols)
 
-            X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
-            R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    X_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
+                    R_chunk = tl.load(R_ptr_row_block + cols_off[None, :])
+                else:
+                    cols_mask = cols_off < n_cols
+                    X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                    R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+            else:
+                if DROP_COLS_MASK:
+                    block_mask = rows_mask[:, None]
+                else:
+                    block_mask = rows_mask[:, None] & (cols_off[None, :] < n_cols)
+                X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+
             S_chunk = X_chunk + R_chunk
-            tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=block_mask)
+            if STORE_S:
+                if DROP_ROWS_MASK:
+                    if DROP_COLS_MASK:
+                        tl.store(S_ptr_row_block + cols_off[None, :], S_chunk)
+                    else:
+                        tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=cols_mask[None, :])
+                else:
+                    tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=block_mask)
 
             S_chunk_f32 = S_chunk.to(tl.float32)
             var_acc += tl.sum(S_chunk_f32 * S_chunk_f32, axis=1)
 
         var = var_acc / n_cols
         rstd_vec = tl.rsqrt(var + eps)
-        tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask)
+        if STORE_RSTD:
+            if DROP_ROWS_MASK:
+                tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec)
+            else:
+                tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask)
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            cols_mask = cols_off < n_cols
-            block_mask = rows_mask[:, None] & cols_mask[None, :]
 
-            S_chunk = tl.load(S_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
-            W_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    W_chunk = tl.load(W_ptr + cols_off)
+                    if STORE_S:
+                        S_chunk = tl.load(S_ptr_row_block + cols_off[None, :])
+                    else:
+                        X_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
+                        R_chunk = tl.load(R_ptr_row_block + cols_off[None, :])
+                        S_chunk = X_chunk + R_chunk
+                else:
+                    cols_mask = cols_off < n_cols
+                    W_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+                    if STORE_S:
+                        S_chunk = tl.load(S_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                    else:
+                        X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                        R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                        S_chunk = X_chunk + R_chunk
+            else:
+                if DROP_COLS_MASK:
+                    block_mask = rows_mask[:, None]
+                    W_chunk = tl.load(W_ptr + cols_off)
+                else:
+                    cols_mask = cols_off < n_cols
+                    block_mask = rows_mask[:, None] & cols_mask[None, :]
+                    W_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+
+                if STORE_S:
+                    S_chunk = tl.load(S_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                else:
+                    X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                    R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+                    S_chunk = X_chunk + R_chunk
 
             if casting_mode == _CASTING_MODE_GEMMA:
                 S_chunk = S_chunk.to(tl.float32)
@@ -108,16 +188,147 @@ def _fused_add_rmsnorm_fwd_kernel(
                 S_chunk = S_chunk.to(tl.float32)
 
             if casting_mode == _CASTING_MODE_LLAMA:
-                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(S_ptr.dtype.element_ty)
+                if STORE_S:
+                    normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(S_ptr.dtype.element_ty)
+                else:
+                    normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(Y_ptr.dtype.element_ty)
             else:
                 normed_S_chunk = S_chunk * rstd_vec[:, None]
 
             Y_chunk = normed_S_chunk * (W_chunk[None, :] + offset)
 
             if casting_mode == _CASTING_MODE_GEMMA:
-                Y_chunk = Y_chunk.to(S_ptr.dtype.element_ty)
+                if STORE_S:
+                    Y_chunk = Y_chunk.to(S_ptr.dtype.element_ty)
+                else:
+                    Y_chunk = Y_chunk.to(Y_ptr.dtype.element_ty)
 
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk)
+                else:
+                    tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=cols_mask[None, :])
+            else:
+                tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=block_mask)
+
+
+@triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
+@libentry()
+@triton.jit
+def _fused_add_rmsnorm_fwd_single_pass_kernel(
+    Y_ptr,
+    Y_row_stride,
+    S_ptr,
+    S_row_stride,
+    X_ptr,
+    X_row_stride,
+    R_ptr,
+    R_row_stride,
+    W_ptr,
+    RSTD_ptr,
+    RSTD_row_stride,
+    n_rows,
+    n_cols,
+    eps,
+    offset,
+    casting_mode: tl.constexpr,
+    STORE_S: tl.constexpr,
+    STORE_RSTD: tl.constexpr,
+    DROP_COLS_MASK: tl.constexpr,
+    DROP_ROWS_MASK: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    grid_size = tl.num_programs(axis=0)
+    num_row_tasks = (n_rows + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M
+
+    for row_task_id in range(pid, num_row_tasks, grid_size):
+        block_start_row = row_task_id * BLOCK_SIZE_M
+        rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
+
+        X_ptr_row_block = X_ptr + rows_off[:, None] * X_row_stride
+        R_ptr_row_block = R_ptr + rows_off[:, None] * R_row_stride
+        S_ptr_row_block = S_ptr + rows_off[:, None] * S_row_stride
+        Y_ptr_row_block = Y_ptr + rows_off[:, None] * Y_row_stride
+
+        cols_off = tl.arange(0, BLOCK_SIZE_N)
+
+        if DROP_ROWS_MASK:
+            if DROP_COLS_MASK:
+                X_chunk = tl.load(X_ptr_row_block + cols_off[None, :])
+                R_chunk = tl.load(R_ptr_row_block + cols_off[None, :])
+            else:
+                cols_mask = cols_off < n_cols
+                X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+                R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=cols_mask[None, :], other=0.0)
+        else:
+            rows_mask = rows_off < n_rows
+            if DROP_COLS_MASK:
+                block_mask = rows_mask[:, None]
+            else:
+                cols_mask = cols_off < n_cols
+                block_mask = rows_mask[:, None] & cols_mask[None, :]
+            X_chunk = tl.load(X_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+            R_chunk = tl.load(R_ptr_row_block + cols_off[None, :], mask=block_mask, other=0.0)
+
+        S_chunk = X_chunk + R_chunk
+
+        if STORE_S:
+            if DROP_ROWS_MASK:
+                if DROP_COLS_MASK:
+                    tl.store(S_ptr_row_block + cols_off[None, :], S_chunk)
+                else:
+                    tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=cols_mask[None, :])
+            else:
+                tl.store(S_ptr_row_block + cols_off[None, :], S_chunk, mask=block_mask)
+
+        S_chunk_f32 = S_chunk.to(tl.float32)
+        var_acc = tl.sum(S_chunk_f32 * S_chunk_f32, axis=1)
+        var = var_acc / n_cols
+        rstd_vec = tl.rsqrt(var + eps)
+
+        if STORE_RSTD:
+            if DROP_ROWS_MASK:
+                tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec)
+            else:
+                tl.store(RSTD_ptr + rows_off * RSTD_row_stride, rstd_vec, mask=rows_mask)
+
+        if DROP_COLS_MASK:
+            W_chunk = tl.load(W_ptr + cols_off)
+        else:
+            W_chunk = tl.load(W_ptr + cols_off, mask=cols_mask, other=0.0)
+
+        if casting_mode == _CASTING_MODE_GEMMA:
+            S_chunk = S_chunk.to(tl.float32)
+            W_chunk = W_chunk.to(tl.float32)
+        elif casting_mode == _CASTING_MODE_LLAMA:
+            S_chunk = S_chunk.to(tl.float32)
+
+        if casting_mode == _CASTING_MODE_LLAMA:
+            if STORE_S:
+                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(S_ptr.dtype.element_ty)
+            else:
+                normed_S_chunk = (S_chunk * rstd_vec[:, None]).to(Y_ptr.dtype.element_ty)
+        else:
+            normed_S_chunk = S_chunk * rstd_vec[:, None]
+
+        Y_chunk = normed_S_chunk * (W_chunk[None, :] + offset)
+
+        if casting_mode == _CASTING_MODE_GEMMA:
+            if STORE_S:
+                Y_chunk = Y_chunk.to(S_ptr.dtype.element_ty)
+            else:
+                Y_chunk = Y_chunk.to(Y_ptr.dtype.element_ty)
+
+        if DROP_ROWS_MASK:
+            if DROP_COLS_MASK:
+                tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk)
+            else:
+                tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=cols_mask[None, :])
+        else:
             tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=block_mask)
+
 
 
 @triton.heuristics({"BLOCK_SIZE_M": lambda args: ceil_div(4096, args["n_cols"])})
@@ -223,18 +434,54 @@ def fused_add_rmsnorm_infer_impl(
     else:
         BLOCK_SIZE_N = align(hidden_states, n_cols, VEC_ALIGN_BYTES)
 
-    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
-    grid = (num_programs,)
-
     str_to_casting_mode = {"llama": 0, "gemma": 1, "none": -1}
     _casting_mode = str_to_casting_mode[casting_mode]
 
     rstd_dtype = torch.float32 if _casting_mode in (0, 1) else hidden_states.dtype
     RSTD = torch.empty(n_rows, dtype=rstd_dtype, device=hidden_states.device)
 
-    Y = torch.empty_like(hidden_states_2d)
-    S = torch.empty_like(hidden_states_2d)
+    BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_rows": n_rows, "n_cols": n_cols})
+    num_row_tasks = ceil_div(n_rows, BLOCK_SIZE_M)
+    grid = (min(_num_vectorcores(), num_row_tasks),)
 
+    Y = torch.empty_like(hidden_states_2d)
+    use_single_pass = n_cols <= BLOCK_SIZE_N
+    drop_cols_mask = n_cols % BLOCK_SIZE_N == 0
+    drop_rows_mask = drop_cols_mask and n_rows % BLOCK_SIZE_M == 0
+
+    if use_single_pass:
+        S = Y if add_mode == "post" else torch.empty_like(hidden_states_2d)
+        _fused_add_rmsnorm_fwd_single_pass_kernel[grid](
+            Y,
+            Y.stride(0),
+            S,
+            S.stride(0),
+            hidden_states_2d,
+            hidden_states_2d.stride(0),
+            residual_2d,
+            residual_2d.stride(0),
+            weight,
+            RSTD,
+            RSTD.stride(0),
+            n_rows,
+            n_cols,
+            eps,
+            offset,
+            casting_mode=_casting_mode,
+            STORE_S=add_mode == "pre",
+            STORE_RSTD=True,
+            DROP_COLS_MASK=drop_cols_mask,
+            DROP_ROWS_MASK=drop_rows_mask,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            sync_solver=True,
+        )
+        if add_mode == "pre":
+            return Y.reshape(*shape), S.reshape(*shape)
+        if add_mode == "post":
+            return Y.reshape(*shape), Y.reshape(*shape)
+        raise ValueError(f"Invalid add_mode: {add_mode}. Must be 'pre' or 'post'.")
+
+    S = Y if add_mode == "post" else torch.empty_like(hidden_states_2d)
     _fused_add_rmsnorm_fwd_kernel[grid](
         Y,
         Y.stride(0),
@@ -252,6 +499,10 @@ def fused_add_rmsnorm_infer_impl(
         eps,
         offset,
         casting_mode=_casting_mode,
+        STORE_S=add_mode == "pre",
+        STORE_RSTD=True,
+        DROP_COLS_MASK=drop_cols_mask,
+        DROP_ROWS_MASK=drop_rows_mask,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         sync_solver=True,
     )


### PR DESCRIPTION
## Description

Optimize NPU ResidualAddRMSNorm forward performance by reducing intermediate tensor traffic, eliminating unnecessary masks, and tuning kernel scheduling for different shapes.

## Changes

- Add a single-pass kernel when the hidden dimension fits in one tile
- Keep `S = X + residual` on-chip and directly compute the RMSNorm output in the single-pass path
- Skip allocating and writing the intermediate `S` tensor in post mode
- Add a compile-time `STORE_RSTD` switch to control RSTD write-back while preserving the current training-compatible behavior
- Add compile-time no-mask paths for row- and column-aligned shapes
- Dynamically trim the grid based on the actual number of row tasks
- Tune `BLOCK_SIZE_M` based on `n_rows` and `n_cols`
- Use conservative row tiles for large hidden dimensions to avoid UB overflow
- Preserve FP32 accumulation for RMS reduction
- Retain the original multi-pass path for large hidden dimensions

## Performance

Measured with `torch.float32` inputs.

| Shape | Mode | Before [us] | After [us] | Speedup |
|---|---|---:|---:|---:|
| (8, 8192) | pre | 11.7296 | 5.7968 | 2.02x |
| (8, 8192) | post | 12.0592 | 5.2912 | 2.28x |
| (16, 4096) | pre | 9.0768 | 4.2528 | 2.13x |
| (16, 4096) | post | 9.3024 | 3.9584 | 2.35x |
| (32, 128) | pre | 5.3440 | 4.2912 | 1.25x |
| (32, 128) | post | 5.8528 | 2.6288 | 2.23x |
| (32, 2048) | pre | 7.3440 | 3.7200 | 1.97x |
| (32, 2048) | post | 7.3264 | 3.7232 | 1.97x |
| (128, 128) | pre | 6.3632 | 2.7936 | 2.28x |
| (128, 128) | post | 6.3520 | 2.8368 | 2.24x |
| (128, 2048) | pre | 8.0736 | 5.9200 | 1.36x |
| (128, 2048) | post | 7.9728 | 6.3888 | 1.25x |
| (256, 512) | pre | 7.2672 | 4.5280 | 1.60x |
| (256, 512) | post | 6.7136 | 4.5040 | 1.49x |
| (1024, 1024) | pre | 13.9440 | 11.1152 | 1.25x |
| (1024, 1024) | post | 13.9856 | 10.6720 | 1.31x |

Overall speedup: **1.25x–2.35x**.

Post mode generally benefits more from eliminating the intermediate `S` write, while large hidden dimensions benefit from scheduling and `BLOCK_SIZE_M` tuning.

## Accuracy

Accuracy tests in `mojo_opset/tests/accuracy/operators/test_normalization.py` passed.