### PR TITLE
[bugfix] remove unsupported overflow_mode from tl.cast

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/quant.py
+++ b/mojo_opset/backends/ttx/kernels/npu/quant.py
@@ -151,6 +151,6 @@ def scale_dynamic_quant_kernel(
                 scaled_vals = input_vals
             quant_vals = scaled_vals / current_quant_scale[:, None]
             quant_vals = tl.where(quant_vals < 0, quant_vals - 0.5, quant_vals + 0.5)
-            quant_vals_int8 = tl.cast(quant_vals, dtype=tl.int8, overflow_mode="saturate")
+            quant_vals_int8 = tl.cast(quant_vals, dtype=tl.int8)
 
             tl.store(output_ptr, quant_vals_int8, mask=block_mask)


### PR DESCRIPTION
tl.cast does not support the overflow_mode parameter.