### PR TITLE
fix(ttx/npu): zero-initialize NF4 embedding output for OOB tokens

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/over_encoding/embedding.py
+++ b/mojo_opset/backends/ttx/kernels/npu/over_encoding/embedding.py
@@ -290,7 +290,13 @@ def embedding_nf4_dequant_impl(
     else:
         codebook = codebook.to(device=LUT_qweight.device, dtype=torch.float16)
 
-    output = torch.empty(
+    # `torch.zeros` (not `torch.empty`) so that rows corresponding to out-of-vocab
+    # tokens — for which the kernel's `token_mask` is False and `tl.store` is
+    # masked out — deterministically read back as zero. Using `torch.empty` here
+    # leaves those rows holding whatever bytes the allocator hands us; on some
+    # runners those bytes happen to be close to zero (test passes), on others
+    # they aren't (test fails with large mismatches at exactly one row).
+    output = torch.zeros(
         (input_flat.numel(), embedding_dim),
         dtype=output_dtype,
         device=input.device,


### PR DESCRIPTION
`embedding_nf4_dequant_impl` used torch.empty to allocate the output tensor. When an input id was out of vocabulary (>= vocab_size or < 0), the kernel's token_mask went False and `tl.store` was masked out — so the corresponding output row was never written. The row silently kept whatever bytes torch.empty had handed us from the allocator.

On some runners those bytes happened to be near zero (test passed), on others they weren't (test failed with Max absolute difference of several thousand at exactly one row). This made
`test_embedding_nf4_dequant_impl` flake in a way that only reproduced on specific CI hosts.

Switch to torch.zeros so OOB rows deterministically read back as zero — matching the contract the reference implementation exercises via `expected = torch.zeros(...); expected[valid_mask] = ...`.

Non-OOB behavior is unchanged: the kernel overwrites the zeros with the real dequantized values.