### PR TITLE
[bug fix] Fix test judgement criteria, data‑type error and restore‑value bug

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/convolution.py
+++ b/mojo_opset/backends/ttx/kernels/npu/convolution.py
@@ -11,7 +11,13 @@ from mojo_opset.backends.ttx.kernels.npu.utils import get_num_cores
 from mojo_opset.backends.ttx.kernels.utils import input_guard
 from mojo_opset.backends.ttx.kernels.utils import prepare_chunk_indices
 
-
+@triton.autotune(
+    configs=[
+        triton.Config({"BD": BD})
+        for BD in [128, 256, 4096]
+    ],
+    key=["T", "D"],
+)
 @triton.heuristics(
     {
         "HAS_WEIGHT": lambda args: args["weight"] is not None,
@@ -44,8 +50,8 @@ def causal_conv1d_fwd_kernel(
     USE_INITIAL_STATE: tl.constexpr,
     IS_VARLEN: tl.constexpr,
     NUM_CHKS: tl.int32,
-    NUM_BLKS_D: tl.int32,
 ):
+    NUM_BLKS_D = triton.cdiv(D, BD)
     pid = tl.program_id(0)
     num_programs = tl.num_programs(0)
 
@@ -406,9 +412,6 @@ def causal_conv1d_fwd_impl(
 
     BT = min(32, triton.next_power_of_2(triton.cdiv(max(16, B * T), NUM_CORES)))
 
-    BD = 256
-    assert D % BD == 0, "D must be divisible by BD."
-    NUM_BLKS_D = triton.cdiv(D, BD)
 
     if cu_seqlens is not None:
         chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
@@ -436,10 +439,8 @@ def causal_conv1d_fwd_impl(
         D=D,
         W=W,
         BT=BT,
-        BD=BD,
         ACTIVATION=activation,
         NUM_CHKS=NUM_CHKS,
-        NUM_BLKS_D=NUM_BLKS_D,
     )
 
     final_state = None

--- a/mojo_opset/backends/ttx/kernels/npu/mrope.py
+++ b/mojo_opset/backends/ttx/kernels/npu/mrope.py
@@ -103,14 +103,17 @@ def _triton_mrope_kernel(
     first_q_mask = (tl.arange(0, pad_n_qh)[:, None] < n_qh) & (tl.arange(0, pad_hd // 2)[None, :] < half_rd)
     first_k_mask = (tl.arange(0, pad_n_kh)[:, None] < n_kh) & (tl.arange(0, pad_hd // 2)[None, :] < half_rd)
 
-    q_tile_1 = tl.load(q_ptr + first_half_q_offsets, mask=first_q_mask)
-    k_tile_1 = tl.load(k_ptr + first_half_k_offsets, mask=first_k_mask)
+    safe_q_off1 = tl.where(first_q_mask, first_half_q_offsets, 0)
+    safe_k_off1 = tl.where(first_k_mask, first_half_k_offsets, 0)
 
-    second_half_q_offsets = first_half_q_offsets + half_rd
-    second_half_k_offsets = first_half_k_offsets + half_rd
+    q_tile_1 = tl.load(q_ptr + safe_q_off1, mask=first_q_mask)
+    k_tile_1 = tl.load(k_ptr + safe_k_off1, mask=first_k_mask)
 
-    q_tile_2 = tl.load(q_ptr + second_half_q_offsets, mask=first_q_mask)
-    k_tile_2 = tl.load(k_ptr + second_half_k_offsets, mask=first_k_mask)
+    safe_q_off2 = safe_q_off1 + half_rd
+    safe_k_off2 = safe_k_off1 + half_rd
+
+    q_tile_2 = tl.load(q_ptr + safe_q_off2, mask=first_q_mask)
+    k_tile_2 = tl.load(k_ptr + safe_k_off2, mask=first_k_mask)
 
     cos_row = cos_row.to(q_tile_1.dtype)
     sin_row = sin_row.to(q_tile_1.dtype)
@@ -118,14 +121,14 @@ def _triton_mrope_kernel(
     new_q_tile_1 = q_tile_1 * cos_row - q_tile_2 * sin_row
     new_q_tile_2 = q_tile_2 * cos_row + q_tile_1 * sin_row
 
-    tl.store(q_ptr + first_half_q_offsets, new_q_tile_1, mask=first_q_mask)
-    tl.store(q_ptr + second_half_q_offsets, new_q_tile_2, mask=first_q_mask)
+    tl.store(q_ptr + safe_q_off1, new_q_tile_1, mask=first_q_mask)
+    tl.store(q_ptr + safe_q_off2, new_q_tile_2, mask=first_q_mask)
 
     new_k_tile_1 = k_tile_1 * cos_row - k_tile_2 * sin_row
     new_k_tile_2 = k_tile_2 * cos_row + k_tile_1 * sin_row
 
-    tl.store(k_ptr + first_half_k_offsets, new_k_tile_1, mask=first_k_mask)
-    tl.store(k_ptr + second_half_k_offsets, new_k_tile_2, mask=first_k_mask)
+    tl.store(k_ptr + safe_k_off1, new_k_tile_1, mask=first_k_mask)
+    tl.store(k_ptr + safe_k_off2, new_k_tile_2, mask=first_k_mask)
 
 
 def mrope_fwd_impl(

--- a/mojo_opset/backends/ttx/kernels/npu/rope.py
+++ b/mojo_opset/backends/ttx/kernels/npu/rope.py
@@ -189,6 +189,7 @@ def _rot_pos_embed_kernel(
         triton.Config({"TOKEN_BLOCK_SIZE": 32}),
     ],
     key=["n_qh", "n_kh"],
+    restore_value=["q_ptr", "k_ptr"],
 )
 @triton.jit(do_not_specialize=["seq_len"])
 def _rope_inplace_kernel(

--- a/mojo_opset/backends/ttx/kernels/npu/sample.py
+++ b/mojo_opset/backends/ttx/kernels/npu/sample.py
@@ -952,9 +952,8 @@ def _join_prob_reject_sampler_kernel(
     target_probs = tl.load(batch_target_probs_ptr + spec_offset * vocab_size + draft_token_ids)
 
     ratio = target_probs / draft_probs
-
+    ratio = tl.clamp(ratio, 0, 1)
     cum_probs = tl.cumprod(ratio, axis=0)
-    cum_probs = tl.clamp(cum_probs, 0, 1)
     cum_rands = tl.cumprod(uniform_rand, axis=0)
 
     tl.store(batch_cum_probs_ptr + spec_offset, cum_probs)

--- a/mojo_opset/backends/ttx/kernels/npu/sdpa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/sdpa.py
@@ -169,10 +169,12 @@ def get_autotune_config():
 
 @triton.autotune(
     configs=[
+        triton.Config({"BLOCK_M": 256, "BLOCK_N": 512}),
         triton.Config({"BLOCK_M": 256, "BLOCK_N": 256}),
         triton.Config({"BLOCK_M": 256, "BLOCK_N": 128}),
         triton.Config({"BLOCK_M": 128, "BLOCK_N": 128}),
         triton.Config({"BLOCK_M": 128, "BLOCK_N": 256}),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 512}),
     ],
     key=["BSZ", "Q_HEAD_NUM", "SEQ", "HEAD_DIM"],
 )

--- a/mojo_opset/backends/ttx/kernels/npu/sdpa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/sdpa.py
@@ -167,10 +167,15 @@ def get_autotune_config():
     return configs
 
 
-# @triton.autotune(
-#     configs=get_autotune_config(),
-#     key=["BSZ", "Q_HEAD_NUM", "SEQ", "HEAD_DIM"],  # 加入 shape 相关的关键参数
-# )
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 256, "BLOCK_N": 256}),
+        triton.Config({"BLOCK_M": 256, "BLOCK_N": 128}),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 128}),
+        triton.Config({"BLOCK_M": 128, "BLOCK_N": 256}),
+    ],
+    key=["BSZ", "Q_HEAD_NUM", "SEQ", "HEAD_DIM"],
+)
 @triton.jit
 def _sdpa_infer_kernel(
     Q,
@@ -841,8 +846,6 @@ def sdpa_infer_impl(
         KV_HEAD_NUM=kv_head_num,
         SEQ=seq_length,
         HEAD_DIM=head_dim,
-        BLOCK_M=128,
-        BLOCK_N=512,
         enable_ubuf_saving=True,
         enable_hivm_auto_cv_balance=True,
         multibuffer=True,  # 控制开double_buffer

--- a/mojo_opset/tests/accuracy/operators/test_sampling.py
+++ b/mojo_opset/tests/accuracy/operators/test_sampling.py
@@ -39,9 +39,30 @@ def test_topp_sampling(shape, topk, topp, min_tokens_to_keep):
     top_p_sampling_ref = MojoTopPSampling._registry.get("torch")(
         top_p=topp, min_tokens_to_keep=min_tokens_to_keep, rand_top_k=topk
     )
-
-    top_p_sampling.forward_diff_with(top_p_sampling_ref, logits)
-
+    perf(lambda: top_p_sampling(logits))
+    perf(lambda: top_p_sampling_ref(logits))
+    # 两个实现采用不同采样策略（torch.multinomial 逆CDF vs 类Gumbel-max），
+    # 单次采样的 token 不可逐个比对。改为对同一 logits 大量重复采样，
+    # 比较返回概率 out_probs 的统计均值和标准差：
+    # - 均值收敛到 sum(p_i^2)，反映采样分布的一阶特征；
+    # - 标准差反映分布的离散程度。
+    # 两者均应收敛到同一理论值（采样噪声 ~ O(1/sqrt(N))）。
+    num_samples = 200
+    ref_probs_list = []
+    npu_probs_list = []
+    for _ in range(num_samples):
+        ref_p, _ = top_p_sampling_ref(logits.clone())
+        npu_p, _ = top_p_sampling(logits.clone())
+        ref_probs_list.append(ref_p.float())
+        npu_probs_list.append(npu_p.float())
+    ref_all = torch.cat(ref_probs_list, dim=1)
+    npu_all = torch.cat(npu_probs_list, dim=1)
+    ref_mean = ref_all.mean(dim=1, keepdim=True)
+    npu_mean = npu_all.mean(dim=1, keepdim=True)
+    ref_std = ref_all.std(dim=1, keepdim=True)
+    npu_std = npu_all.std(dim=1, keepdim=True)
+    torch.testing.assert_close(npu_mean, ref_mean, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(npu_std, ref_std, atol=1e-2, rtol=1e-2)
 
 @pytest.mark.parametrize(
     "shape, topk, topp, min_tokens_to_keep",
@@ -52,15 +73,19 @@ def test_topp_filter(shape, topk, topp, min_tokens_to_keep):
     logits = torch.randn(shape, dtype=torch.float32)
     top_p_filter = MojoTopPFilter()
     top_p_filter_ref = MojoTopPFilter._registry.get("torch")()
+    ref_probs, ref_idx = top_p_filter_ref(logits.clone(), topp, min_tokens_to_keep, topk)
+    npu_probs, npu_idx = top_p_filter(logits.clone(), topp, min_tokens_to_keep, topk)
 
-    top_p_filter.forward_diff_with(
-        top_p_filter_ref,
-        logits=logits,
-        top_p=topp,
-        min_tokens_to_keep=min_tokens_to_keep,
-        rand_top_k=topk,
+    torch.testing.assert_close(
+        npu_probs.float(), ref_probs.float(), atol=1e-2, rtol=1e-2
     )
 
+    ref_idx_sorted, _ = ref_idx.sort(dim=-1)
+    npu_idx_sorted, _ = npu_idx.sort(dim=-1)
+    assert torch.equal(ref_idx_sorted, npu_idx_sorted), (
+        f"Selected token indices do not match! "
+        f"Expected: {ref_idx_sorted}, Got: {npu_idx_sorted}"
+    )
 
 @pytest.mark.parametrize(
     "batch_size, vocab_size, spec_step",

--- a/mojo_opset/tests/accuracy/operators/test_sampling.py
+++ b/mojo_opset/tests/accuracy/operators/test_sampling.py
@@ -39,8 +39,6 @@ def test_topp_sampling(shape, topk, topp, min_tokens_to_keep):
     top_p_sampling_ref = MojoTopPSampling._registry.get("torch")(
         top_p=topp, min_tokens_to_keep=min_tokens_to_keep, rand_top_k=topk
     )
-    perf(lambda: top_p_sampling(logits))
-    perf(lambda: top_p_sampling_ref(logits))
     # 两个实现采用不同采样策略（torch.multinomial 逆CDF vs 类Gumbel-max），
     # 单次采样的 token 不可逐个比对。改为对同一 logits 大量重复采样，
     # 比较返回概率 out_probs 的统计均值和标准差：

--- a/mojo_opset/tests/perf/test_gemm_dequant.py
+++ b/mojo_opset/tests/perf/test_gemm_dequant.py
@@ -4,6 +4,7 @@ import torch
 from mojo_opset import MojoQuantGemm
 from mojo_opset.tests.utils import auto_switch_platform
 from mojo_opset.tests.utils import bypass_not_implemented
+from mojo_opset.utils.platform import get_torch_device
 
 
 def _make_gemm_dequant_perf_data(m, k, n, trans_weight):
@@ -45,12 +46,13 @@ def _make_gemm_dequant_perf_data(m, k, n, trans_weight):
 @auto_switch_platform(set_perf=True)
 @bypass_not_implemented
 def test_quant_gemm_perf(x_i8, w_i8, x_scale, w_scale, output_dtype, trans_weight):
+    device = get_torch_device()
     op = MojoQuantGemm(
         in_features=x_i8.shape[1],
         out_features=w_scale.numel(),
         output_dtype=output_dtype,
         trans_weight=trans_weight,
-    )
+    ).to(device)
     op.load_state_dict(
         {
             "weight": w_i8,

--- a/mojo_opset/tests/perf/test_linear.py
+++ b/mojo_opset/tests/perf/test_linear.py
@@ -62,7 +62,7 @@ def generate_quant_group_gemm_reduce_sum_perf_data(b: int, m: int, k: int, n: in
 @auto_switch_platform(set_perf=True)
 @bypass_not_implemented
 def test_quant_batch_gemm_reduce_sum_perf(x1, weight, x1_scale, x2_scale):
-    op = MojoQuantBatchGemmReduceSum(trans_weight=False, weight=weight)
+    op = MojoQuantBatchGemmReduceSum._registry.get("torch")(trans_weight=False, weight=weight)
 
     def run():
         op(x1, x1_scale, x2_scale)

--- a/mojo_opset/tests/perf/test_linear.py
+++ b/mojo_opset/tests/perf/test_linear.py
@@ -62,7 +62,7 @@ def generate_quant_group_gemm_reduce_sum_perf_data(b: int, m: int, k: int, n: in
 @auto_switch_platform(set_perf=True)
 @bypass_not_implemented
 def test_quant_batch_gemm_reduce_sum_perf(x1, weight, x1_scale, x2_scale):
-    op = MojoQuantBatchGemmReduceSum._registry.get("torch")(trans_weight=False, weight=weight)
+    op = MojoQuantBatchGemmReduceSum(trans_weight=False, weight=weight)
 
     def run():
         op(x1, x1_scale, x2_scale)

--- a/mojo_opset/tests/perf/test_store_lowrank.py
+++ b/mojo_opset/tests/perf/test_store_lowrank.py
@@ -40,7 +40,7 @@ def test_store_lowrank(shape_label_cache, shape_key_lr, kv_len):
     label_cache = torch.zeros(size=shape_label_cache, dtype=torch.bfloat16,device=device)
     key_lr = torch.randn(size=(slot_mapping.shape[0], *shape_key_lr), dtype=torch.bfloat16,device=device)
     block_idxs = (slot_mapping // 512).to(torch.int32)
-    token_idxs = (slot_mapping % 512).to(torch.int32)   
+    token_idxs = (slot_mapping % 512).to(torch.int32)
     token_num = slot_mapping.shape[0]
 
     store_lowrank = MojoStoreLowrank()


### PR DESCRIPTION
1. Correct the judgment criteria for test_topp_filter and test_topp_sampling.
2. Fix the data type error in test_store_lowrank.py.
3. Resolve the restore‑value bug inside _rope_inplace_kernel.