### PR TITLE
Optimize SWA/GQA L1 cache aggregation

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/flash_attention.py
+++ b/mojo_opset/backends/ttx/kernels/npu/flash_attention.py
@@ -53,7 +53,6 @@ def _build_lpt_task_schedule(
             cost = max(1, triton.cdiv(kv_cache_len + q_block_end, block_size_n))
             for q_head_id in range(num_q_heads):
                 kv_head_id = q_head_id // (num_q_heads // 4)
-                # weighted_tasks.append((cost, seq_no, b_id, q_block_id, q_head_id))
                 weighted_tasks.append((b_id, kv_head_id, q_block_id, cost, q_head_id, seq_no))
                 seq_no += 1
 
@@ -70,14 +69,11 @@ def _build_lpt_task_schedule(
     task_q_head = []
     core_task_offsets = [0]
     for tasks in per_core_tasks:
-        # tasks.sort()
         for b_id, q_head_id, q_block_id in tasks:
-            # task_b.append(b_id * 1024 * 12 + q_block_id * 12 + q_head_id)
             task_b.append(b_id)
             task_q_block.append(q_block_id)
             task_q_head.append(q_head_id)
         core_task_offsets.append(len(task_b))
-    # print(max(task_b), max(task_q_block), max(task_q_head))
 
     device = cu_q_lens.device
     return (

--- a/mojo_opset/backends/ttx/kernels/npu/flash_attention.py
+++ b/mojo_opset/backends/ttx/kernels/npu/flash_attention.py
@@ -479,7 +479,7 @@ def paged_prefill_page_aggregation_kernel(
 
             # Load (transposed) K block
             k = tl.zeros((PAGE_AGGREGATION_NUM * BLOCK_SIZE_N, BLOCK_SIZE_D), dtype=key_cache_ptr.dtype.element_ty)
-            for page_iter in range(PAGE_AGGREGATION_NUM):
+            for page_iter in tl.extra.cann.extension.parallel(0, PAGE_AGGREGATION_NUM):
                 kv_block_start = (kv_block_id + page_iter) * BLOCK_SIZE_N
                 kv_block_end = min(kv_block_start + BLOCK_SIZE_N, kv_seq_len)
                 kv_block_len = max(kv_block_end - kv_block_start, 0)
@@ -526,7 +526,7 @@ def paged_prefill_page_aggregation_kernel(
             acc = acc * alpha[:, None]
             # Load corresponding V block
             v = tl.zeros((PAGE_AGGREGATION_NUM * BLOCK_SIZE_N, BLOCK_SIZE_D), dtype=value_cache_ptr.dtype.element_ty)
-            for page_iter in range(PAGE_AGGREGATION_NUM):
+            for page_iter in tl.extra.cann.extension.parallel(0, PAGE_AGGREGATION_NUM):
                 kv_block_start = (kv_block_id + page_iter) * BLOCK_SIZE_N
                 kv_block_end = min(kv_block_start + BLOCK_SIZE_N, kv_seq_len)
                 kv_block_len = max(kv_block_end - kv_block_start, 0)

--- a/mojo_opset/backends/ttx/kernels/npu/flash_attention.py
+++ b/mojo_opset/backends/ttx/kernels/npu/flash_attention.py
@@ -19,9 +19,11 @@ def _build_lpt_task_schedule(
         cu_q_lens: torch.Tensor,
         seqlens_kv: Optional[torch.Tensor],
         num_q_heads: int,
+        num_kv_heads: int,
         block_size_m: int,
         block_size_n: int,
         cube_num: int,
+        gqa_interleave: bool,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
     """Build a shape-aware static schedule for the 1D Triton grid.
 
@@ -52,7 +54,10 @@ def _build_lpt_task_schedule(
             q_block_end = min((q_block_id + 1) * block_size_m, q_seq_len)
             cost = max(1, triton.cdiv(kv_cache_len + q_block_end, block_size_n))
             for q_head_id in range(num_q_heads):
-                kv_head_id = q_head_id // (num_q_heads // 4)
+                if gqa_interleave:
+                    kv_head_id = q_head_id % num_kv_heads
+                else:
+                    kv_head_id = q_head_id // (num_q_heads // num_kv_heads)
                 weighted_tasks.append((b_id, kv_head_id, q_block_id, cost, q_head_id, seq_no))
                 seq_no += 1
 
@@ -599,9 +604,11 @@ def paged_attention_prefill_impl(
         cu_q_lens,
         seqlens_kv,
         num_q_heads,
+        num_kv_heads,
         CHUNK_SIZE,
         BLOCK_SIZE_N,
         cube_num,
+        gqa_interleave,
     )
 
     if not (page_size < 128 and 128 % page_size == 0):

--- a/mojo_opset/backends/ttx/kernels/npu/swa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/swa.py
@@ -1017,7 +1017,7 @@ def _swa_paged_prefill_aggregation_kernel(
                     mask = tl.full((BLOCK_M, BLOCK_N), 1,  dtype=tl.int1)
 
                 k = tl.zeros((PAGE_AGGREGATION_NUM * BLOCK_N, BLOCK_D), dtype=k_ptr.dtype.element_ty)
-                for page_iter in range(PAGE_AGGREGATION_NUM):
+                for page_iter in tl.extra.cann.extension.parallel(0, PAGE_AGGREGATION_NUM):
                     kv_block_start = (kv_block_id + page_iter) * BLOCK_N
                     kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
                     kv_block_len = max(kv_block_end - kv_block_start, 0)
@@ -1054,7 +1054,7 @@ def _swa_paged_prefill_aggregation_kernel(
                 l_i = l_i * alpha + l_ij
                 acc = acc * alpha[:, None]
                 v = tl.zeros((PAGE_AGGREGATION_NUM * BLOCK_N, BLOCK_D), dtype=v_ptr.dtype.element_ty)
-                for page_iter in range(PAGE_AGGREGATION_NUM):
+                for page_iter in tl.extra.cann.extension.parallel(0, PAGE_AGGREGATION_NUM):
                     kv_block_start = (kv_block_id + page_iter) * BLOCK_N
                     kv_block_end = min(kv_block_start + BLOCK_N, kv_seq_len)
                     kv_block_len = max(kv_block_end - kv_block_start, 0)

--- a/mojo_opset/tests/perf/test_attention.py
+++ b/mojo_opset/tests/perf/test_attention.py
@@ -389,7 +389,7 @@ def test_paged_prefill_gqa(
     # trigger NPU thermal throttling (frequency down-shifting). Insert a short
     # sleep before each execution on NPU to let the device cool down and avoid
     # frequency throttling skewing the benchmark results.
-    need_sleep = "M_BF16_128K_FULL" in request.node.callspec.id and get_platform() == "npu"
+    need_sleep = hasattr(request.node, "callspec") and "M_BF16_128K_FULL" in request.node.callspec.id and get_platform() == "npu"
 
     def fn():
         if need_sleep:

--- a/mojo_opset/tests/perf/test_attention.py
+++ b/mojo_opset/tests/perf/test_attention.py
@@ -1,4 +1,5 @@
 import math
+import time
 
 from typing import Optional
 
@@ -13,6 +14,7 @@ from mojo_opset import MojoPagedDecodeSWA
 from mojo_opset import MojoSWA
 from mojo_opset.tests.utils import auto_switch_platform
 from mojo_opset.tests.utils import bypass_not_implemented
+from mojo_opset.utils.platform import get_platform
 
 
 def generate_paged_decode_data(
@@ -373,6 +375,7 @@ def test_paged_prefill_gqa(
     block_tables: torch.Tensor,
     gqa_layout: str,
     cu_total_seq_lens: Optional[torch.Tensor],
+    request,
 ):
     paged_attn_prefill = MojoPagedPrefillGQA(
         is_causal=True,
@@ -382,8 +385,16 @@ def test_paged_prefill_gqa(
     head_dim = query.shape[-1]
     softmax_scale = 1.0 / math.sqrt(head_dim)
 
-    perf(  # noqa: F821
-        lambda: paged_attn_prefill(
+    # The 128K full prefill case runs long, high-density computation that can
+    # trigger NPU thermal throttling (frequency down-shifting). Insert a short
+    # sleep before each execution on NPU to let the device cool down and avoid
+    # frequency throttling skewing the benchmark results.
+    need_sleep = "M_BF16_128K_FULL" in request.node.callspec.id and get_platform() == "npu"
+
+    def fn():
+        if need_sleep:
+            time.sleep(0.5)
+        return paged_attn_prefill(
             query,
             k_cache,
             v_cache,
@@ -392,7 +403,8 @@ def test_paged_prefill_gqa(
             softmax_scale=softmax_scale,
             cu_total_seq_lens=cu_total_seq_lens,
         )
-    )
+
+    perf(fn)  # noqa: F821
 
 
 def generate_test_data(


### PR DESCRIPTION
1. Update SWA/GQA aggregation kernel with for page_iter in tl.extra.cann.extension.parallel
2. Add sleep for big shape to avoid NPU frequency down-shifting
3. Fix load balance for general shape