### PR TITLE
optimize flex attention

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/flex_attention.py
+++ b/mojo_opset/backends/ttx/kernels/npu/flex_attention.py
@@ -102,7 +102,7 @@ def flex_attention_kernel(
         OUT_ptr = OUT + out_offset
         LSE_ptr = LSE + lse_offset
 
-        m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+        m_i = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
         l_i = tl.zeros([BLOCK_M], dtype=tl.float32)
         acc = tl.zeros([BLOCK_M, V_HEAD_DIM], dtype=tl.float32)
 
@@ -112,7 +112,7 @@ def flex_attention_kernel(
 
         q = tl.load(
             Q_ptr + offs_m[:, None] * stride_qm + offs_k[None, :] * stride_qk,
-            mask=(offs_m[:, None] < Q_LEN) & (offs_k[None, :] < QK_HEAD_DIM),
+            mask=(offs_m[:, None] < Q_LEN),
             other=0.0
         )
 
@@ -162,12 +162,12 @@ def flex_attention_kernel(
 
             k = tl.load(
                 K_ptr + offs_n_load[:, None] * stride_kn + offs_k[None, :] * stride_kk,
-                mask=(offs_n_load[:, None] < KV_LEN) & (offs_k[None, :] < QK_HEAD_DIM),
+                mask=(offs_n_load[:, None] < KV_LEN),
                 other=0.0
             )
             v = tl.load(
                 V_ptr + offs_n_load[:, None] * stride_vn + offs_v[None, :] * stride_vk,
-                mask=(offs_n_load[:, None] < KV_LEN) & (offs_v[None, :] < V_HEAD_DIM),
+                mask=(offs_n_load[:, None] < KV_LEN),
                 other=0.0
             )
             k = tl.trans(k)
@@ -175,7 +175,7 @@ def flex_attention_kernel(
             qk = tl.dot(q, k, input_precision="ieee")
             qk *= SM_SCALE
 
-            qk = tl.where(mask & (offs_n_load[None, :] < KV_LEN), qk, float("-inf"))
+            qk = tl.where(mask, qk, float("-inf"))
 
             m_ij = tl.maximum(m_i, tl.max(qk, 1, propagate_nan=True), propagate_nan=tl.PropagateNan.ALL)
             masked_out_rows = (m_ij == float("-inf"))
@@ -202,12 +202,12 @@ def flex_attention_kernel(
                 offs_n_load = kv_start + tl.arange(0, BLOCK_N)
                 k = tl.load(
                     K_ptr + offs_n_load[:, None] * stride_kn + offs_k[None, :] * stride_kk,
-                    mask=(offs_n_load[:, None] < KV_LEN) & (offs_k[None, :] < QK_HEAD_DIM),
+                    mask=(offs_n_load[:, None] < KV_LEN),
                     other=0.0
                 )
                 v = tl.load(
                     V_ptr + offs_n_load[:, None] * stride_vn + offs_v[None, :] * stride_vk,
-                    mask=(offs_n_load[:, None] < KV_LEN) & (offs_v[None, :] < V_HEAD_DIM),
+                    mask=(offs_n_load[:, None] < KV_LEN),
                     other=0.0
                 )
                 k = tl.trans(k)
@@ -215,14 +215,9 @@ def flex_attention_kernel(
                 qk = tl.dot(q, k, input_precision="ieee")
                 qk *= SM_SCALE
 
-                qk = tl.where(offs_n_load[None, :] < KV_LEN, qk, float("-inf"))
-
                 m_ij = tl.maximum(m_i, tl.max(qk, 1, propagate_nan=True), propagate_nan=tl.PropagateNan.ALL)
-                masked_out_rows = (m_ij == float("-inf"))
-                m_ij_masked = tl.where(masked_out_rows, 0, m_ij)
-
-                alpha = tl.math.exp(m_i - m_ij_masked)
-                p = tl.math.exp(qk - m_ij_masked[:, None])
+                alpha = tl.math.exp(m_i - m_ij)
+                p = tl.math.exp(qk - m_ij[:, None])
 
                 pv = tl.dot(p.to(Q.dtype.element_ty), v, input_precision="ieee")
                 l_i = l_i * alpha + tl.sum(p, 1)
@@ -363,6 +358,7 @@ def bwd_dq_block_mn(
     return dq
 
 
+
 @triton.jit(
     do_not_specialize=[
         "stride_mask_m",
@@ -431,7 +427,6 @@ def flex_attention_backward_dq_kernel(
     num_core = tl.num_programs(0).to(tl.int32)
     sparse_q_multiple = SPARSE_Q_BLOCK_SIZE // BLOCK_M
     KV_BLOCK_SIZE: tl.constexpr = BLOCK_N * NUM_KV_SUB_BLOCKS
-    sparse_kv_multiple = SPARSE_KV_BLOCK_SIZE // KV_BLOCK_SIZE
     MATMUL_PRECISION = Q.dtype.element_ty
 
     for task_id in range(pid, NUM_TASKS, num_core):
@@ -542,7 +537,7 @@ def flex_attention_backward_dq_kernel(
                         Q_LEN=Q_LEN,
                         KV_LEN=KV_LEN,
                     )
-                qk = tl.where(mask & (offs_n[None, :] < KV_LEN), qk, float("-inf"))
+                qk = tl.where(mask, qk, float("-inf"))
 
                 p = tl.math.exp(qk - lse[:, None])
                 dp = tl.dot(do, tl.trans(v), input_precision="ieee")
@@ -574,7 +569,6 @@ def flex_attention_backward_dq_kernel(
 
                     qk = tl.dot(q, tl.trans(k), input_precision="ieee")
                     qk *= SM_SCALE
-                    qk = tl.where(offs_n[None, :] < KV_LEN, qk, float("-inf"))
 
                     p = tl.math.exp(qk - lse[:, None])
                     dp = tl.dot(do, tl.trans(v), input_precision="ieee")
@@ -834,7 +828,6 @@ def bwd_dkdv_block_mn(
     qk = tl.dot(q, tl.trans(k), input_precision="ieee")
     qk *= SM_SCALE
 
-    mask = True
     if not IS_FULL_BLOCKS:
         if USE_PACKED_PARTIAL_MASK:
             partial_block_idx = tl.load(
@@ -868,10 +861,7 @@ def bwd_dkdv_block_mn(
                 Q_LEN=Q_LEN,
                 KV_LEN=KV_LEN,
             )
-        qk = tl.where(mask & (offs_n[None, :] < KV_LEN), qk, float("-inf"))
-    else:
-        qk = tl.where(offs_n[None, :] < KV_LEN, qk, float("-inf"))
-
+        qk = tl.where(mask, qk, float("-inf"))
     p = tl.math.exp(qk - lse[:, None])
 
     dv = tl.dot(tl.trans(p.to(MATMUL_PRECISION)), do, input_precision="ieee")
@@ -1169,7 +1159,6 @@ def flex_attention_bwd_impl(
         limit_auto_multi_buffer_of_local_buffer="no-l0c",
         intra_cache_num=2,
         inter_cache_num=1,
-        # enable_cross_if_fusion=True,
     )
 
     return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype)

--- a/mojo_opset/tests/accuracy/functions/test_flex_attention.py
+++ b/mojo_opset/tests/accuracy/functions/test_flex_attention.py
@@ -663,11 +663,12 @@ def build_problem(mask_mod):
     "mask_func",
     [
         _sparse_mask_mod,
+        _full_mask_mod,
         _stair_mask_mod,
         _video_stair_mask_mod,
         _cross_sample_causal_video_bidir_mask_mod,
     ],
-    ids=["sparse", "stair", "video_stair", "cross_sample_causal_video_bidir"],
+    ids=["sparse", "stair", "full", "video_stair", "cross_sample_causal_video_bidir"],
 )
 @pytest.mark.skipif(get_platform() != "npu", reason="FlexAttention TTX backend requires NPU")
 @bypass_not_implemented
@@ -720,7 +721,7 @@ def test_flex_attention(mask_func):
 # ============================================================================
 # Performance benchmark (torch_npu.profiler based)
 # ============================================================================
-def _perf_benchmark(label, build_mask_fn, fwd_fn, q, k, v, prof_dir_root):
+def _perf_benchmark(label, build_mask_fn, fwd_fn, q, k, v, prof_dir_root, mask_func):
     import torch_npu
 
     q = q.detach().requires_grad_(True)
@@ -728,18 +729,6 @@ def _perf_benchmark(label, build_mask_fn, fwd_fn, q, k, v, prof_dir_root):
     v = v.detach().requires_grad_(True)
 
     return_grid = torch.tensor(520000, dtype=DTYPE, device=torch.device(_device()))
-
-    # warmup: fwd+bwd once, then release
-    mask = build_mask_fn()
-    out = fwd_fn(q, k, v, mask)
-    _sync()
-    out.float().mean().backward(return_grid)
-    _sync()
-    q.grad = k.grad = v.grad = None
-    del out, mask
-    torch.npu.empty_cache()
-    gc.collect()
-    _sync()
 
     # mask build measurement: peak + stable
     torch.npu.empty_cache()
@@ -793,12 +782,26 @@ def _perf_benchmark(label, build_mask_fn, fwd_fn, q, k, v, prof_dir_root):
         on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(prof_dir),
     ) as prof:
         for i in range(12):
+            # 重新构造数据，避免L2 Cache影响
+            problem = build_problem(mask_func)
+            q = problem["q"].detach().clone().requires_grad_(True)
+            k = problem["k"].detach().clone().requires_grad_(True)
+            v = problem["v"].detach().clone().requires_grad_(True)
+
             out = fwd_fn(q, k, v, mask)
             _sync()
+
+            # 插入其他算子，重置L2 Cache, 112M，总访存224MB覆盖112MB L2, 模拟整网调用场景
+            for j in range(5):
+                a = torch.randn(19573419, dtype=torch.float32, device="cpu").to(q.device)
+                b = torch.randn(19573419, dtype=torch.float32, device="cpu").to(q.device)
+                c = a + b       # 冲刷全部L2
+            _sync()
+
             out.float().mean().backward(return_grid)
             _sync()
-            q.grad = k.grad = v.grad = None
             prof.step()
+            del a,b,c
     print(f"======================== prof end ({label}) ====================")
 
     del out, mask
@@ -836,6 +839,7 @@ def _perf_flex_attention(mask_func, problem=None):
         lambda q, k, v, bm: _flex_attention_mojo(q, k, v, None, bm, 0.0, None),
         problem["q"], problem["k"], problem["v"],
         prof_dir_root,
+        mask_func,
     )
 
     # ascendc: torch SDPA + dense_mask
@@ -848,6 +852,7 @@ def _perf_flex_attention(mask_func, problem=None):
         lambda q, k, v, m: _sdpa_with_dense_mask(q, k, v, m, 0.0, None),
         problem["q"], problem["k"], problem["v"],
         prof_dir_root,
+        mask_func,
     )
     return results
 
@@ -856,11 +861,12 @@ def _perf_flex_attention(mask_func, problem=None):
     "mask_func",
     [
         _sparse_mask_mod,
+        _full_mask_mod,
         _stair_mask_mod,
         _video_stair_mask_mod,
         _cross_sample_causal_video_bidir_mask_mod,
     ],
-    ids=["sparse", "stair", "video_stair", "cross_sample_causal_video_bidir"],
+    ids=["sparse", "full", "stair", "video_stair", "cross_sample_causal_video_bidir"],
 )
 @pytest.mark.skipif(get_platform() != "npu", reason="FlexAttention TTX backend requires NPU")
 def test_flex_attention_perf(mask_func):


### PR DESCRIPTION
Removing redundant border protection operations. 
The test procedure is modified to simulate the entire network scenario to avoid the impact of the L2 cache.
