### PR TITLE
[bugfix] replace monkey patch with import mojo for torch comparison

### DIFF
--- a/mojo_opset/modeling/qwen3/mojo_qwen3_dense.py
+++ b/mojo_opset/modeling/qwen3/mojo_qwen3_dense.py
@@ -270,6 +270,9 @@ class Qwen3Attention(nn.Module):
             q = query_states.permute(0, 2, 1, 3).reshape(total_tokens, num_q_heads, head_dim)
 
             current_seq_lens = context_lens + q_len
+            cu_current_seq_lens = torch.cat(
+                [torch.tensor([0], device=device, dtype=torch.int32), current_seq_lens.cumsum(0, dtype=torch.int32)]
+            )
 
             k_cache = past_key_values.k_cache
             v_cache = past_key_values.v_cache
@@ -284,7 +287,7 @@ class Qwen3Attention(nn.Module):
                 cu_q_lens,
                 block_tables,
                 self.scaling,
-                cu_total_seq_lens=current_seq_lens,
+                cu_total_seq_lens=cu_current_seq_lens,
             )
             attn_output = attn_output_tnd.reshape(bsz, q_len, num_q_heads, head_dim)
             attn_output = attn_output.transpose(1, 2)

--- a/mojo_opset/modeling/qwen3/torch_qwen3_dense.py
+++ b/mojo_opset/modeling/qwen3/torch_qwen3_dense.py
@@ -379,10 +379,10 @@ class Qwen3Attention(nn.Module):
         self.gamma = nn.Parameter(torch.ones(self.head_dim))
 
         self.q_norm = (
-            Qwen3RMSNorm(eps=config.rms_norm_eps, gamma=self.gamma) if hasattr(config, "q_norm") else nn.Identity()
+            Qwen3RMSNorm(eps=config.rms_norm_eps, weight=self.gamma) if hasattr(config, "q_norm") else nn.Identity()
         )
         self.k_norm = (
-            Qwen3RMSNorm(eps=config.rms_norm_eps, gamma=self.gamma) if hasattr(config, "k_norm") else nn.Identity()
+            Qwen3RMSNorm(eps=config.rms_norm_eps, weight=self.gamma) if hasattr(config, "k_norm") else nn.Identity()
         )
 
     def forward(self, hidden_states, position_embeddings, attention_mask, past_key_values, use_cache, **kwargs):
@@ -416,7 +416,7 @@ class Qwen3Attention(nn.Module):
             context_lens=context_lens,
         )
 
-        attn_output = query_states.reshape(bsz, q_len, self.hidden_size).contiguous()
+        attn_output = attn_output.transpose(1, 2).reshape(bsz, q_len, self.hidden_size).contiguous()
         return self.o_proj(attn_output), None
 
 

--- a/mojo_opset/tests/test_qwen3_dense_patching.py
+++ b/mojo_opset/tests/test_qwen3_dense_patching.py
@@ -3,18 +3,19 @@ from typing import Tuple
 import torch
 
 from mojo_opset.modeling.qwen3 import torch_qwen3_dense
+from mojo_opset.modeling.qwen3 import mojo_qwen3_dense
 from mojo_opset.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 
-def run_single_pass(config, device: str, dtype: torch.dtype, model_data: tuple) -> Tuple[torch.Tensor, torch.Tensor]:
+def run_single_pass(config, device: str, dtype: torch.dtype, model_data: tuple, cache_class) -> Tuple[torch.Tensor, torch.Tensor]:
     decoder_layer, rotary_emb, prefill_data, decode_data, batch_size = model_data
 
     hidden_states_prefill, attention_mask_prefill, position_ids_prefill = prefill_data
     hidden_states_decode, position_ids_decode_template = decode_data
 
-    past_key_values = torch_qwen3_dense.PagedDummyCache(
+    past_key_values = cache_class(
         config=config,
         batch_size=batch_size,
         device=device,
@@ -50,14 +51,39 @@ def run_single_pass(config, device: str, dtype: torch.dtype, model_data: tuple) 
     return output_prefill[0], output_decode[0]
 
 
-def test_qwen3_dense_patch():
-    device = "npu"
+def _transfer_weights(torch_layer, mojo_layer):
+    """Transfer weights from torch_qwen3_dense decoder layer to mojo_qwen3_dense decoder layer.
 
+    Handles structural differences:
+    - torch has shared `gamma` parameters; mojo has separate norm weights
+    - torch may have attention bias; mojo does not
+    """
+    mojo_layer.self_attn.q_proj.weight.data.copy_(torch_layer.self_attn.q_proj.weight.data)
+    mojo_layer.self_attn.k_proj.weight.data.copy_(torch_layer.self_attn.k_proj.weight.data)
+    mojo_layer.self_attn.v_proj.weight.data.copy_(torch_layer.self_attn.v_proj.weight.data)
+    mojo_layer.self_attn.o_proj.weight.data.copy_(torch_layer.self_attn.o_proj.weight.data)
+
+    mojo_layer.mlp.gate_proj.weight.data.copy_(torch_layer.mlp.gate_proj.weight.data)
+    mojo_layer.mlp.up_proj.weight.data.copy_(torch_layer.mlp.up_proj.weight.data)
+    mojo_layer.mlp.down_proj.weight.data.copy_(torch_layer.mlp.down_proj.weight.data)
+
+    mojo_layer.input_layernorm.weight.data.copy_(torch_layer.gamma.data)
+    mojo_layer.post_attention_layernorm.weight.data.copy_(torch_layer.gamma.data)
+
+    mojo_layer.self_attn.q_norm.weight.data.copy_(torch_layer.self_attn.gamma.data)
+    mojo_layer.self_attn.k_norm.weight.data.copy_(torch_layer.self_attn.gamma.data)
+
+
+def test_qwen3_dense():
+    device = "npu"
     dtype = torch.bfloat16
     torch.manual_seed(42)
 
     config = torch_qwen3_dense.Qwen3Config()
     config.num_key_value_heads = 2
+    config.attention_bias = False
+    config.q_norm = True
+    config.k_norm = True
 
     batch_size, prefill_len, decode_len = 8, 128, 1
     prefill_data = (
@@ -73,49 +99,30 @@ def test_qwen3_dense_patch():
     native_decoder_layer = torch_qwen3_dense.Qwen3DecoderLayer(config, 0).to(device).to(dtype).eval()
     native_rotary_emb = torch_qwen3_dense.Qwen3RotaryEmbedding(config, device=device)
 
+    mojo_decoder = mojo_qwen3_dense.Qwen3DecoderLayer(config, 0).to(device).to(dtype).eval()
+    mojo_rotary = mojo_qwen3_dense.Qwen3RotaryEmbedding(config, device=device)
+
+    _transfer_weights(native_decoder_layer, mojo_decoder)
+
     native_model_data = (native_decoder_layer, native_rotary_emb, prefill_data, decode_data, batch_size)
+    mojo_model_data = (mojo_decoder, mojo_rotary, prefill_data, decode_data, batch_size)
 
-    original_rmsnorm_class = torch_qwen3_dense.Qwen3RMSNorm
-    original_mlp_class = torch_qwen3_dense.Qwen3MLP
-    original_apply_rotary_pos_emb = torch_qwen3_dense.apply_rotary_pos_emb
-    original_attn_prefill = torch_qwen3_dense.paged_attention_prefill
-    original_attn_decode = torch_qwen3_dense.paged_attention_decode
+    native_prefill_out, native_decode_out = run_single_pass(
+        config, device, dtype, native_model_data, torch_qwen3_dense.PagedDummyCache
+    )
+    mojo_prefill_out, mojo_decode_out = run_single_pass(
+        config, device, dtype, mojo_model_data, mojo_qwen3_dense.PagedDummyCache
+    )
 
-    native_prefill_out, native_decode_out = run_single_pass(config, device, dtype, native_model_data)
-
-    from mojo_opset.utils.patching import apply_mojo_to_qwen3
-
-    apply_mojo_to_qwen3()
-
-    patched_decoder_layer = torch_qwen3_dense.Qwen3DecoderLayer(config, 0).to(device).to(dtype).eval()
-    patched_decoder_layer.load_state_dict(native_decoder_layer.state_dict())
-    patched_rotary_emb = torch_qwen3_dense.Qwen3RotaryEmbedding(config, device=device)
-
-    patched_model_data = (patched_decoder_layer, patched_rotary_emb, prefill_data, decode_data, batch_size)
-
-    patched_rmsnorm_class = torch_qwen3_dense.Qwen3RMSNorm
-    patched_mlp_class = torch_qwen3_dense.Qwen3MLP
-    patched_apply_rotary_pos_emb = torch_qwen3_dense.apply_rotary_pos_emb
-    patched_attn_prefill = torch_qwen3_dense.paged_attention_prefill
-    patched_attn_decode = torch_qwen3_dense.paged_attention_decode
-
-    patched_prefill_out, patched_decode_out = run_single_pass(config, device, dtype, patched_model_data)
-
-    prefill_match = torch.allclose(native_prefill_out, patched_prefill_out, atol=1e-2, rtol=1e-2)
-    decode_match = torch.allclose(native_decode_out, patched_decode_out, atol=1e-2, rtol=1e-2)
+    prefill_match = torch.allclose(native_prefill_out, mojo_prefill_out, atol=1e-2, rtol=1e-2)
+    decode_match = torch.allclose(native_decode_out, mojo_decode_out, atol=1e-2, rtol=1e-2)
 
     if not prefill_match:
         logger.warning("Prefill outputs differ!")
-        logger.warning("Max diff:", (native_prefill_out - patched_prefill_out).abs().max())
+        logger.warning("Max diff: %s", (native_prefill_out - mojo_prefill_out).abs().max())
     if not decode_match:
         logger.warning("Decode outputs differ!")
-        logger.warning("Max diff:", (native_decode_out - patched_decode_out).abs().max())
+        logger.warning("Max diff: %s", (native_decode_out - mojo_decode_out).abs().max())
 
-    assert prefill_match, "Paged prefill outputs do not match post-patching!"
-    assert decode_match, "Paged decode outputs do not match post-patching!"
-
-    assert patched_rmsnorm_class is not original_rmsnorm_class, "Qwen3RMSNorm class not patched!"
-    assert patched_mlp_class is not original_mlp_class, "Qwen3MLP class not patched!"
-    assert patched_apply_rotary_pos_emb is not original_apply_rotary_pos_emb, "apply_rotary_pos_emb func not patched!"
-    assert patched_attn_prefill is not original_attn_prefill, "paged_attention_prefill func not patched!"
-    assert patched_attn_decode is not original_attn_decode, "paged_attention_decode func not patched!"
+    assert prefill_match, "Prefill outputs do not match between torch and mojo implementations!"
+    assert decode_match, "Decode outputs do not match between torch and mojo implementations!"


### PR DESCRIPTION
compare Mojo and Torch implementations by importing mojo directly instead of using monkey patching.

bugfix:
- Preserve attention results
- Rename parameter gamma to weight
- Update cu_total_seq_lens to require cumulative format