### PR TITLE
[ NPU ] triton ops optimization v1

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/int8_gemm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/int8_gemm.py
@@ -14,11 +14,11 @@ import triton.language as tl
 
 from mojo_opset.backends.ttx.kernels.npu.utils import get_num_cores
 
-# Padding alignment — must be divisible by every BLOCK size in the autotune configs.
-# BLOCK_M ∈ {64, 128}  → pad M to 128
+# Padding alignment — _PAD_M must be divisible by the minimum BLOCK_M.
+# BLOCK_M ∈ {32, 64, 128}  → pad M to 32 (GCD of all BLOCK_M values)
 # BLOCK_N ∈ {64, 128, 256}  → pad N to 256
 # BLOCK_K ∈ {256, 512}  → pad K to 512
-_PAD_M = 128
+_PAD_M = 32
 _PAD_N = 256
 _PAD_K = 512
 
@@ -39,10 +39,45 @@ def _get_autotune_configs():
         # Small M tiles
         triton.Config({**_vmix, "BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 256}),
         triton.Config({**_vmix, "BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 256}),
+        # Very small M tiles — for M=1~32 (e.g. decode, single-token inference)
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 128, "BLOCK_K": 256}),
+        triton.Config({**_vmix, "BLOCK_M": 32, "BLOCK_N": 128, "BLOCK_K": 256}),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 128, "BLOCK_K": 512}),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 256, "BLOCK_K": 256}),
+        triton.Config({**_vmix, "BLOCK_M": 32, "BLOCK_N": 256, "BLOCK_K": 256}),
+        triton.Config({"BLOCK_M": 32, "BLOCK_N": 256, "BLOCK_K": 512}),
     ]
 
 
-@triton.autotune(configs=_get_autotune_configs(), key=["M", "N", "K"])
+def _prune_oversized_tiles(configs, nargs, **kwargs):
+    """Filter out configs whose tiles exceed the padded M/N/K dimensions.
+
+    The kernel uses ``M // BLOCK_M`` (floor division) to compute the number
+    of M-tiles.  When ``BLOCK_M > M`` the quotient is zero, so no tiles are
+    processed and the output is silently filled with zeros.  The autotuner
+    cannot detect this — a config that skips all work is always “fastest”.
+
+    This prune function removes such dangerous configs before benchmarking
+    so only tiles that fit within the (already host-padded) problem size are
+    considered.
+    """
+    M = nargs["M"]
+    N = nargs["N"]
+    K = nargs["K"]
+    return [
+        cfg
+        for cfg in configs
+        if cfg.kwargs.get("BLOCK_M", 0) <= M
+           and cfg.kwargs.get("BLOCK_N", 0) <= N
+           and cfg.kwargs.get("BLOCK_K", 0) <= K
+    ]
+
+
+@triton.autotune(
+    configs=_get_autotune_configs(),
+    key=["M", "N", "K"],
+    prune_configs_by={"early_config_prune": _prune_oversized_tiles},
+)
 @triton.jit
 def _int8_gemm_dequant_kernel(
     a_ptr, bt_ptr, c_ptr,
@@ -108,19 +143,24 @@ def _pad_to(x, mult):
     return ((x + mult - 1) // mult) * mult
 
 
-def prepare_b_impl(b: torch.Tensor) -> torch.Tensor:
-    """Transpose B to (N, K) row-major and pad to block boundaries.
+def prepare_b_impl(b: torch.Tensor, transposed: bool = False) -> torch.Tensor:
+    """Prepare B to (N, K) row-major and pad to block boundaries.
 
     For inference: weight B is fixed, call once and reuse.
 
     Args:
-        b: (K, N) int8
+        b: (K, N) int8 when transposed=False, (N, K) int8 when transposed=True
+        transposed: if True, b is already (N, K) and only padding is applied.
 
     Returns:
         bt: (N_padded, K_padded) int8, contiguous
     """
-    K_orig, N_orig = b.shape
-    bt = b.T.contiguous()
+    if transposed:
+        N_orig, K_orig = b.shape
+        bt = b.contiguous()
+    else:
+        K_orig, N_orig = b.shape
+        bt = b.T.contiguous()
 
     pN = _pad_to(N_orig, _PAD_N)
     pK = _pad_to(K_orig, _PAD_K)
@@ -206,7 +246,6 @@ def int8_gemm_dequant_impl(
         b_transposed.stride(0), b_transposed.stride(1),
         c.stride(0), c.stride(1),
         HAS_BIAS=has_bias,
-        multibuffer=True,
     )
 
     return c[:M_orig, :N_orig]

--- a/mojo_opset/backends/ttx/kernels/npu/kv_cache.py
+++ b/mojo_opset/backends/ttx/kernels/npu/kv_cache.py
@@ -185,7 +185,7 @@ def _store_paged_kv_cache_chunk_kernel(
         chunk_idx = p_idx // num_kv_heads
 
         chunk_base = chunk_meta_ptr + chunk_idx * stride_cm_row
-        src_token_start = tl.load(chunk_base + 0 * stride_cm_col)
+        src_token_start = tl.load(chunk_base + 0 * stride_cm_col, care_padding=False)
         dst_block_id = tl.load(chunk_base + 1 * stride_cm_col)
         dst_block_offset = tl.load(chunk_base + 2 * stride_cm_col)
         chunk_len = tl.load(chunk_base + 3 * stride_cm_col)
@@ -222,7 +222,7 @@ def _store_paged_kv_cache_chunk_kernel(
                 + offs_d[None, :] * stride_vc_dim
             )
 
-            k_val = tl.load(base_src_k_ptr + h * stride_k_head, mask=mask_sub[:, None])
+            k_val = tl.load(base_src_k_ptr + h * stride_k_head, mask=mask_sub[:, None], care_padding=False)
             v_val = tl.load(base_src_v_ptr + h * stride_v_head, mask=mask_sub[:, None])
             tl.store(base_dst_k_ptr + h * stride_kc_head, k_val, mask=mask_sub[:, None])
             tl.store(base_dst_v_ptr + h * stride_vc_head, v_val, mask=mask_sub[:, None])

--- a/mojo_opset/backends/ttx/kernels/npu/rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/rmsnorm.py
@@ -215,7 +215,10 @@ def rmsnorm_infer_impl(
     y = torch.empty_like(X_2d)
 
     if n_cols > COL_BLOCKING_THRESHOLD:
-        BLOCK_SIZE_N = COL_BLOCKING_THRESHOLD
+        if n_cols * 8 <= 200000:
+            BLOCK_SIZE_N = n_cols # only load X for once
+        else:
+            BLOCK_SIZE_N = COL_BLOCKING_THRESHOLD # load X for twice
     else:
         BLOCK_SIZE_N = align(x, n_cols, VEC_ALIGN_BYTES)
 

--- a/mojo_opset/backends/ttx/kernels/npu/rope.py
+++ b/mojo_opset/backends/ttx/kernels/npu/rope.py
@@ -9,38 +9,6 @@ from mojo_opset.backends.ttx.kernels.npu.utils import get_num_cores
 from mojo_opset.backends.ttx.kernels.utils import prepare_lens
 from mojo_opset.backends.ttx.kernels.utils import tensor_cache
 
-ROPE_TOKEN_BLOCK_SIZE_TABLE = {
-    (2, 1): 36,
-    (4, 1): 16,
-    (8, 1): 10,
-    (16, 16): 5,
-    (32, 32): 2,
-    (64, 64): 1,
-}
-
-SRAM_ALIGNMENT = 32
-
-
-# When the half RoPE dimension satisfies the SRAM byte-alignment requirement,
-# we can leverage a more efficient extension API to perform the RoPE computation.
-def _is_half_rope_dim_aligned(half_rope_dim: int, dtype_size: int = 2) -> bool:
-    return (half_rope_dim * dtype_size) % SRAM_ALIGNMENT == 0
-
-
-def _get_token_block_size(n_qh: int, n_kh: int) -> int:
-    assert n_qh <= 84 and n_kh <= 84, "don't support head_num > 84, please raise an issue."
-
-    if (n_qh, n_kh) in ROPE_TOKEN_BLOCK_SIZE_TABLE:
-        return ROPE_TOKEN_BLOCK_SIZE_TABLE[(n_qh, n_kh)]
-
-    for (q_thresh, k_thresh), block_size in sorted(
-        ROPE_TOKEN_BLOCK_SIZE_TABLE.items(), key=lambda x: (x[0][0], x[0][1])
-    ):
-        if n_qh <= q_thresh and n_kh <= k_thresh:
-            return block_size
-
-    return 1
-
 
 @tensor_cache
 def prepare_chunk_indices(
@@ -141,15 +109,17 @@ def _rot_pos_embed_kernel(
     grid_size = tl.num_programs(0)
 
     dim_offsets = tl.arange(0, ROPE_DIM)
+    token_block_size_offsets = tl.arange(0, TOKEN_BLOCK_SIZE)
 
     for block_id in range(pid, total_blocks, grid_size):
-        chunk_idx = tl.load(chunk_indices_ptr + block_id * 5 + 1)
-        seq_start = tl.load(chunk_indices_ptr + block_id * 5 + 2)
-        context_len = tl.load(chunk_indices_ptr + block_id * 5 + 3)
-        actual_seq_len = tl.load(chunk_indices_ptr + block_id * 5 + 4)
+        chunk_indices_ptr_offset = chunk_indices_ptr + block_id * 5
+        chunk_idx = tl.load(chunk_indices_ptr_offset + 1)
+        seq_start = tl.load(chunk_indices_ptr_offset + 2)
+        context_len = tl.load(chunk_indices_ptr_offset + 3)
+        actual_seq_len = tl.load(chunk_indices_ptr_offset + 4)
 
         block_start = chunk_idx * TOKEN_BLOCK_SIZE
-        seq_offsets = block_start + tl.arange(0, TOKEN_BLOCK_SIZE)
+        seq_offsets = block_start + token_block_size_offsets
         mask = seq_offsets < actual_seq_len
 
         table_positions = context_len + seq_offsets
@@ -188,17 +158,18 @@ def _rot_pos_embed_kernel(
         triton.Config({"TOKEN_BLOCK_SIZE": 16}),
         triton.Config({"TOKEN_BLOCK_SIZE": 32}),
     ],
-    key=["n_qh", "n_kh"],
-    restore_value=["q_ptr", "k_ptr"],
+    key=["n_qh", "n_kh", "half_rope_dim"],
 )
 @triton.jit(do_not_specialize=["seq_len"])
-def _rope_inplace_kernel(
+def _rope_kernel(
     q_ptr,
     q_batch_stride,
     q_seq_stride,
     k_ptr,
     k_batch_stride,
     k_seq_stride,
+    q_out_ptr,
+    k_out_ptr,
     cos_ptr,
     cos_batch_stride,
     cos_seq_stride,
@@ -206,7 +177,6 @@ def _rope_inplace_kernel(
     sin_batch_stride,
     sin_seq_stride,
     seq_len,
-    # num_seq_blocks,
     bs,
     n_qh: tl.constexpr,
     n_kh: tl.constexpr,
@@ -224,21 +194,26 @@ def _rope_inplace_kernel(
     num_seq_blocks = (seq_len + TOKEN_BLOCK_SIZE -1) // TOKEN_BLOCK_SIZE
     total_blocks = bs * num_seq_blocks
 
+    token_block_size_offsets = tl.arange(0, TOKEN_BLOCK_SIZE)
+    half_rope_dim_offsets = tl.arange(0, half_rope_dim)
+    half_rope_dim_mask = half_rope_dim_offsets < half_rope_dim
+    head_q_offsets = tl.arange(0, n_qh)
+    head_k_offsets = tl.arange(0, n_kh)
+    if ALIGNED:
+        rope_dim_offsets = tl.arange(0, rope_dim)
+        rope_dim_mask = rope_dim_offsets < rope_dim
     for block_id in range(pid, total_blocks, grid_size):
         batch_idx = block_id // num_seq_blocks
         seq_block_id = block_id % num_seq_blocks
 
         block_start_seq_idx = seq_block_id * TOKEN_BLOCK_SIZE
-        seq_offsets = block_start_seq_idx + tl.arange(0, TOKEN_BLOCK_SIZE)
+        seq_offsets = block_start_seq_idx + token_block_size_offsets
         seq_mask = seq_offsets < seq_len
 
         global_seq_offsets = seq_offsets
 
         cos_token_ptr = cos_ptr + batch_idx * cos_batch_stride + seq_offsets[:, None] * cos_seq_stride
         sin_token_ptr = sin_ptr + batch_idx * sin_batch_stride + seq_offsets[:, None] * sin_seq_stride
-
-        half_rope_dim_offsets = tl.arange(0, half_rope_dim)
-        half_rope_dim_mask = half_rope_dim_offsets < half_rope_dim
 
         cos_block_2d = tl.load(
             cos_token_ptr + half_rope_dim_offsets[None, :],
@@ -251,16 +226,38 @@ def _rope_inplace_kernel(
             other=0,
         )
 
-        head_q_offsets = tl.arange(0, n_qh)
-        head_k_offsets = tl.arange(0, n_kh)
-
         cos_tile = tl.reshape(cos_block_2d, (TOKEN_BLOCK_SIZE, 1, half_rope_dim), can_reorder=True)
         sin_tile = tl.reshape(sin_block_2d, (TOKEN_BLOCK_SIZE, 1, half_rope_dim), can_reorder=True)
 
-        if ALIGNED:
-            rope_dim_offsets = tl.arange(0, rope_dim)
-            rope_dim_mask = rope_dim_offsets < rope_dim
+        # Copy the nope_dim (non-rotary) part from input to output.
+        # In the non-inplace design, q_out is freshly allocated (empty_like),
+        # so we must explicitly copy the nope_dim region. When nope_dim == 0
+        # (rope_dim == head_dim), this block is eliminated at compile time.
+        if nope_dim > 0:
+            nope_dim_offsets = tl.arange(0, nope_dim)
+            nope_dim_mask = nope_dim_offsets < nope_dim
 
+            q_nope_offsets = (
+                batch_idx * q_batch_stride
+                + global_seq_offsets[:, None, None] * q_seq_stride
+                + head_q_offsets[None, :, None] * head_dim
+                + nope_dim_offsets[None, None, :]
+            )
+            q_nope_mask = seq_mask[:, None, None] & (head_q_offsets[None, :, None] < n_qh) & nope_dim_mask[None, None, :]
+            q_nope_tile = tl.load(q_ptr + q_nope_offsets, mask=q_nope_mask, other=0.0)
+            tl.store(q_out_ptr + q_nope_offsets, q_nope_tile, mask=q_nope_mask)
+
+            k_nope_offsets = (
+                batch_idx * k_batch_stride
+                + global_seq_offsets[:, None, None] * k_seq_stride
+                + head_k_offsets[None, :, None] * head_dim
+                + nope_dim_offsets[None, None, :]
+            )
+            k_nope_mask = seq_mask[:, None, None] & (head_k_offsets[None, :, None] < n_kh) & nope_dim_mask[None, None, :]
+            k_nope_tile = tl.load(k_ptr + k_nope_offsets, mask=k_nope_mask, other=0.0)
+            tl.store(k_out_ptr + k_nope_offsets, k_nope_tile, mask=k_nope_mask)
+
+        if ALIGNED:
             q_offsets = (
                 batch_idx * q_batch_stride
                 + global_seq_offsets[:, None, None] * q_seq_stride
@@ -272,7 +269,7 @@ def _rope_inplace_kernel(
 
             q_tile = tl.load(q_ptr + q_offsets, mask=q_mask, other=0.0).to(sin_block_2d.dtype)
             q_tile = _compute_rope(q_tile, sin_tile, cos_tile, n_qh, half_rope_dim, TOKEN_BLOCK_SIZE, INVERSE)
-            tl.store(q_ptr + q_offsets, q_tile, mask=q_mask)
+            tl.store(q_out_ptr + q_offsets, q_tile, mask=q_mask)
 
             k_offsets = (
                 batch_idx * k_batch_stride
@@ -285,7 +282,7 @@ def _rope_inplace_kernel(
 
             k_tile = tl.load(k_ptr + k_offsets, mask=k_mask, other=0).to(sin_block_2d.dtype)
             k_tile = _compute_rope(k_tile, sin_tile, cos_tile, n_kh, half_rope_dim, TOKEN_BLOCK_SIZE, INVERSE)
-            tl.store(k_ptr + k_offsets, k_tile, mask=k_mask)
+            tl.store(k_out_ptr + k_offsets, k_tile, mask=k_mask)
         else:
             q_offsets_half1 = (
                 batch_idx * q_batch_stride
@@ -294,14 +291,7 @@ def _rope_inplace_kernel(
                 + nope_dim
                 + half_rope_dim_offsets[None, None, :]
             )
-            q_offsets_half2 = (
-                batch_idx * q_batch_stride
-                + global_seq_offsets[:, None, None] * q_seq_stride
-                + head_q_offsets[None, :, None] * head_dim
-                + nope_dim
-                + half_rope_dim
-                + half_rope_dim_offsets[None, None, :]
-            )
+            q_offsets_half2 = q_offsets_half1 + half_rope_dim
             q_half_mask = (
                 seq_mask[:, None, None] & (head_q_offsets[None, :, None] < n_qh) & half_rope_dim_mask[None, None, :]
             )
@@ -309,8 +299,8 @@ def _rope_inplace_kernel(
             q_tile_1 = tl.load(q_ptr + q_offsets_half1, mask=q_half_mask, other=0.0).to(sin_block_2d.dtype)
             q_tile_2 = tl.load(q_ptr + q_offsets_half2, mask=q_half_mask, other=0.0).to(sin_block_2d.dtype)
             new_q_1, new_q_2 = _compute_rope_separated(q_tile_1, q_tile_2, sin_tile, cos_tile, INVERSE)
-            tl.store(q_ptr + q_offsets_half1, new_q_1, mask=q_half_mask)
-            tl.store(q_ptr + q_offsets_half2, new_q_2, mask=q_half_mask)
+            tl.store(q_out_ptr + q_offsets_half1, new_q_1, mask=q_half_mask)
+            tl.store(q_out_ptr + q_offsets_half2, new_q_2, mask=q_half_mask)
 
             k_offsets_half1 = (
                 batch_idx * k_batch_stride
@@ -319,14 +309,7 @@ def _rope_inplace_kernel(
                 + nope_dim
                 + half_rope_dim_offsets[None, None, :]
             )
-            k_offsets_half2 = (
-                batch_idx * k_batch_stride
-                + global_seq_offsets[:, None, None] * k_seq_stride
-                + head_k_offsets[None, :, None] * head_dim
-                + nope_dim
-                + half_rope_dim
-                + half_rope_dim_offsets[None, None, :]
-            )
+            k_offsets_half2 = k_offsets_half1 + half_rope_dim
             k_half_mask = (
                 seq_mask[:, None, None] & (head_k_offsets[None, :, None] < n_kh) & half_rope_dim_mask[None, None, :]
             )
@@ -334,51 +317,115 @@ def _rope_inplace_kernel(
             k_tile_1 = tl.load(k_ptr + k_offsets_half1, mask=k_half_mask, other=0.0).to(sin_block_2d.dtype)
             k_tile_2 = tl.load(k_ptr + k_offsets_half2, mask=k_half_mask, other=0.0).to(sin_block_2d.dtype)
             new_k_1, new_k_2 = _compute_rope_separated(k_tile_1, k_tile_2, sin_tile, cos_tile, INVERSE)
-            tl.store(k_ptr + k_offsets_half1, new_k_1, mask=k_half_mask)
-            tl.store(k_ptr + k_offsets_half2, new_k_2, mask=k_half_mask)
+            tl.store(k_out_ptr + k_offsets_half1, new_k_1, mask=k_half_mask)
+            tl.store(k_out_ptr + k_offsets_half2, new_k_2, mask=k_half_mask)
 
 
-def _normalize_to_bsnd(
+def _normalize_for_rope(
+    x: torch.Tensor,
+    head_first: bool,
+) -> Tuple[torch.Tensor, int, int, bool, int, int, int, int]:
+    """Normalize a tensor for the RoPE kernel.
+
+    The kernel hardcodes head_dim as the head stride, so it requires the physical
+    layout to be [B,S,N,D] (head stride == head_dim). This function detects whether
+    the input already has this layout (optimized path, no transpose needed) or
+    falls back to transpose+contiguous.
+
+    Returns: (x, batch_stride, seq_stride, need_transpose_back, batch_size, seq_len, n_head, head_dim)
+    """
+    need_transpose_back = False
+
+    if x.dim() == 4:
+        batch_size = x.shape[0]
+        if head_first:
+            # Logical [B, N, S, D]
+            n_head, seq_len, head_dim = x.shape[1], x.shape[2], x.shape[3]
+            if x.stride(1) == head_dim:
+                # Physical [B,S,N,D] (e.g. after transpose): head stride == head_dim
+                batch_stride, seq_stride = x.stride(0), x.stride(2)
+            else:
+                # Physical [B,N,S,D] contiguous: need transpose to [B,S,N,D]
+                need_transpose_back = True
+                x = x.transpose(1, 2).contiguous()
+                batch_stride, seq_stride = x.stride(0), x.stride(1)
+        else:
+            # [B, S, N, D]: already in the correct layout
+            seq_len, n_head, head_dim = x.shape[1], x.shape[2], x.shape[3]
+            batch_stride, seq_stride = x.stride(0), x.stride(1)
+    else:
+        assert x.dim() == 3
+        batch_size = 1
+        if head_first:
+            # Logical [N, T, D]
+            n_head, seq_len, head_dim = x.shape[0], x.shape[1], x.shape[2]
+            if x.stride(0) == head_dim:
+                # Physical [T,N,D] (e.g. after transpose): head stride == head_dim
+                batch_stride, seq_stride = 0, x.stride(1)
+            else:
+                # Physical [N,T,D] contiguous: need transpose to [T,N,D]
+                need_transpose_back = True
+                x = x.transpose(0, 1).contiguous()
+                batch_stride, seq_stride = 0, x.stride(0)
+        else:
+            # [T, N, D]: already in the correct layout
+            seq_len, n_head, head_dim = x.shape[0], x.shape[1], x.shape[2]
+            batch_stride, seq_stride = 0, x.stride(0)
+
+    return x, batch_stride, seq_stride, need_transpose_back, batch_size, seq_len, n_head, head_dim
+
+
+def _run_rope_kernel(
     q: torch.Tensor,
     k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
     head_first: bool,
-) -> Tuple[torch.Tensor, torch.Tensor, int, int, int, int, int, int, int, int, int]:
-    """Normalize q/k to [B, S, N, D] layout, returning strides and metadata."""
+    inverse: bool,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Shared kernel launch logic for forward and backward RoPE.
 
-    if q.dim() == 3:
-        assert k.dim() == 3
-        if head_first:
-            # [N, T, D] -> [BS, N, D]
-            seq_len = q.shape[0]
-            q = q.transpose(0, 1).clone(memory_format=torch.contiguous_format)
-            k = k.transpose(0, 1).clone(memory_format=torch.contiguous_format)
-        else:
-            q = q.clone(memory_format=torch.contiguous_format)
-            k = k.clone(memory_format=torch.contiguous_format)
-        batch_size = 1
-        seq_len, n_q_head, head_dim = q.shape
-        n_kv_head = k.shape[1]
-        q_batch_stride, q_seq_stride = 0, q.stride(0)
-        k_batch_stride, k_seq_stride = 0, k.stride(0)
-    else:
-        assert q.dim() == 4 and k.dim() == 4
-        if head_first:
-            q = q.transpose(1, 2).clone(memory_format=torch.contiguous_format)
-            k = k.transpose(1, 2).clone(memory_format=torch.contiguous_format)
-        else:
-            q = q.clone(memory_format=torch.contiguous_format)
-            k = k.clone(memory_format=torch.contiguous_format)
+    Allocates output buffers via empty_like (alloc only, no data copy) and launches
+    the non-inplace kernel. If the input required transpose, transposes the output back.
+    """
+    q, q_bs, q_ss, need_tb, batch_size, seq_len, n_qh, head_dim = _normalize_for_rope(q, head_first)
+    k, k_bs, k_ss, _, _, _, n_kh, _ = _normalize_for_rope(k, head_first)
 
-        batch_size, seq_len, n_q_head, head_dim = q.shape
-        n_kv_head = k.shape[2]
-        q_batch_stride, q_seq_stride = q.stride(0), q.stride(1)
-        k_batch_stride, k_seq_stride = k.stride(0), k.stride(1)
-        
+    q_out = torch.empty_like(q)
+    k_out = torch.empty_like(k)
 
-    return (
-        q, k, batch_size, seq_len, n_q_head, n_kv_head, head_dim,
-        q_batch_stride, q_seq_stride, k_batch_stride, k_seq_stride,
+    rope_dim = cos.shape[-1]
+    nope_dim = head_dim - rope_dim
+    half_rope_dim = rope_dim // 2
+
+    if not cos.is_contiguous():
+        cos = cos.contiguous()
+    if not sin.is_contiguous():
+        sin = sin.contiguous()
+    cos_batch_stride = cos.stride(0) if (cos.dim() == 3 and cos.shape[0] > 1) else 0
+    sin_batch_stride = sin.stride(0) if (sin.dim() == 3 and sin.shape[0] > 1) else 0
+
+    grid = (get_num_cores(),)
+    _rope_kernel[grid](
+        q, q_bs, q_ss,
+        k, k_bs, k_ss,
+        q_out, k_out,
+        cos, cos_batch_stride, cos.stride(-2),
+        sin, sin_batch_stride, sin.stride(-2),
+        seq_len, batch_size,
+        n_qh, n_kh, head_dim, nope_dim, rope_dim, half_rope_dim,
+        ALIGNED=True, INVERSE=inverse,
     )
+
+    if need_tb:
+        if q_out.dim() == 4:
+            q_out = q_out.transpose(1, 2).contiguous()
+            k_out = k_out.transpose(1, 2).contiguous()
+        else:
+            q_out = q_out.transpose(0, 1).contiguous()
+            k_out = k_out.transpose(0, 1).contiguous()
+
+    return q_out, k_out
 
 
 def rot_pos_embed_impl(
@@ -408,7 +455,7 @@ def rot_pos_embed_impl(
     else:
         context_lens = None
 
-    token_block_size = _get_token_block_size(1, 1)
+    token_block_size = 32
     chunk_indices = prepare_chunk_indices(cu_q_lens, token_block_size, context_lens)
     total_blocks = chunk_indices.shape[0]
     rope_dim = cos.shape[-1]
@@ -438,72 +485,14 @@ def rope_fwd_impl(
     sin: torch.Tensor,
     head_first: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Apply RoPE to q/k with pre-extracted cos/sin.
+    """Apply RoPE to q/k with pre-extracted cos/sin (forward pass).
 
-    Supports:
-    - 4D padded prefill: q [B, S, N, D] or [B, N, S, D], cos [S, rope_dim]
-    - 3D varlen:  q [T, N, D] or [N, T, D], cos [T, rope_dim]
-    - 3D decode:  q [B, N, D] or [N, B, D], cos [B, rope_dim]
+    Supports 4D [B,S,N,D]/[B,N,S,D] and 3D [T,N,D]/[N,T,D] inputs.
+    Uses a non-inplace kernel with empty_like output allocation to avoid clone overhead.
     """
     cos = cos.to(q.dtype)
     sin = sin.to(q.dtype)
-
-    orig_q_shape = q.shape
-    orig_k_shape = k.shape
-    (
-        q, k, batch_size, seq_len, n_q_head, n_kv_head, head_dim,
-        q_batch_stride, q_seq_stride, k_batch_stride, k_seq_stride,
-    ) = _normalize_to_bsnd(q, k, head_first)
-
-    rope_dim = cos.shape[-1]
-    nope_dim = head_dim - rope_dim
-    half_rope_dim = rope_dim // 2
-
-    is_aligned = _is_half_rope_dim_aligned(half_rope_dim)
-
-    num_programs = get_num_cores()
-    grid = (num_programs,)
-
-    cos = cos.contiguous()
-    sin = sin.contiguous()
-    if cos.dim() == 3 and cos.shape[0] > 1:
-        cos_batch_stride = cos.stride(0)
-        sin_batch_stride = sin.stride(0)
-    else:
-        cos_batch_stride = 0
-        sin_batch_stride = 0
-
-    _rope_inplace_kernel[grid](
-        q,
-        q_batch_stride,
-        q_seq_stride,
-        k,
-        k_batch_stride,
-        k_seq_stride,
-        cos,
-        cos_batch_stride,
-        cos.stride(-2),
-        sin,
-        sin_batch_stride,
-        sin.stride(-2),
-        seq_len,
-        batch_size,
-        n_q_head,
-        n_kv_head,
-        head_dim,
-        nope_dim,
-        rope_dim,
-        half_rope_dim,
-        ALIGNED=is_aligned,
-        INVERSE=False,
-    )
-
-    if head_first:
-        q = q.transpose(-2, -3).contiguous()
-        k = k.transpose(-2, -3).contiguous()
-    q = q.reshape(*orig_q_shape)
-    k = k.reshape(*orig_k_shape)
-    return q, k
+    return _run_rope_kernel(q, k, cos, sin, head_first, inverse=False)
 
 
 def rope_bwd_impl(
@@ -513,60 +502,8 @@ def rope_bwd_impl(
     sin: torch.Tensor,
     head_first: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Backward pass of RoPE with pre-extracted cos/sin."""
-    orig_q_shape = dq.shape
-    orig_k_shape = dk.shape
-    (
-        dq, dk, batch_size, seq_len, n_q_head, n_kv_head, head_dim,
-        dq_batch_stride, dq_seq_stride, dk_batch_stride, dk_seq_stride,
-    ) = _normalize_to_bsnd(dq, dk, head_first)
+    """Apply inverse RoPE to dq/dk (backward pass).
 
-    rope_dim = cos.shape[-1]
-    nope_dim = head_dim - rope_dim
-    half_rope_dim = rope_dim // 2
-
-    is_aligned = _is_half_rope_dim_aligned(half_rope_dim)
-
-    num_programs = get_num_cores()
-    grid = (num_programs,)
-
-    cos = cos.contiguous()
-    sin = sin.contiguous()
-    if cos.dim() == 3:
-        cos_batch_stride = cos.stride(0)
-        sin_batch_stride = sin.stride(0)
-    else:
-        cos_batch_stride = 0
-        sin_batch_stride = 0
-
-    _rope_inplace_kernel[grid](
-        dq,
-        dq_batch_stride,
-        dq_seq_stride,
-        dk,
-        dk_batch_stride,
-        dk_seq_stride,
-        cos,
-        cos_batch_stride,
-        cos.stride(-2),
-        sin,
-        sin_batch_stride,
-        sin.stride(-2),
-        seq_len,
-        batch_size,
-        n_q_head,
-        n_kv_head,
-        head_dim,
-        nope_dim,
-        rope_dim,
-        half_rope_dim,
-        ALIGNED=is_aligned,
-        INVERSE=True,
-    )
-
-    if head_first:
-        dq = dq.transpose(-2, -3).contiguous()
-        dk = dk.transpose(-2, -3).contiguous()
-    dq = dq.reshape(*orig_q_shape)
-    dk = dk.reshape(*orig_k_shape)
-    return dq, dk
+    Uses a non-inplace kernel with empty_like output allocation to avoid clone overhead.
+    """
+    return _run_rope_kernel(dq, dk, cos, sin, head_first, inverse=True)

--- a/mojo_opset/backends/ttx/kernels/npu/sdpa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/sdpa.py
@@ -857,6 +857,11 @@ def sdpa_infer_impl(
         set_workspace_multibuffer=4,
         tile_mix_vector_loop=8,
         tile_mix_cube_loop=4,
+        enable_dynamic_cv_pipeline=True,
+        enable_cube_block_merge=True,
+        hfusion_enable_multiple_consumer_fusion=True,
+        intra_cache_num=3,
+        inter_cache_num=2,
         **extra_kern_args,
     )
     return o
@@ -929,6 +934,11 @@ def sdpa_fwd_impl(
         lse.stride(0),
         lse.stride(1),
         lse.stride(2),
+        enable_dynamic_cv_pipeline=True,
+        enable_cube_block_merge=True,
+        hfusion_enable_multiple_consumer_fusion=True,
+        intra_cache_num=3,
+        inter_cache_num=2,
     )
 
     return o, lse

--- a/mojo_opset/backends/ttx/kernels/npu/silu.py
+++ b/mojo_opset/backends/ttx/kernels/npu/silu.py
@@ -19,9 +19,95 @@ MAX_BLOCK_SIZE_N = 2048
 
 @triton.jit
 def silu_activation(x):
-    """SiLU activation function: x * sigmoid(x)"""
-    return x * tl.sigmoid(x)
+    """SiLU activation function: x / (1 + exp(-x))
 
+    Uses tl.fdiv + tl.exp instead of x * tl.sigmoid(x) for better NPU performance.
+    Reference: docs_for_triton_agent/19-fused-swiglu-migration.md fast_silu pattern.
+    """
+    return tl.fdiv(x, 1.0 + tl.exp(-x))
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 1024}),
+        triton.Config({"BLOCK_SIZE": 2048}),
+        triton.Config({"BLOCK_SIZE": 4096}),
+        triton.Config({"BLOCK_SIZE": 8192}),
+        triton.Config({"BLOCK_SIZE": 16384}),
+    ],
+    key=["n_elements"],
+)
+@libentry()
+@triton.jit
+def _silu_fwd_flatten_kernel(
+        x,
+        y,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    grid_size = tl.num_programs(axis=0)
+
+    num_blocks = (n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE
+    blocks_per_core = (num_blocks + grid_size - 1) // grid_size
+    block_start = pid * blocks_per_core
+    block_end = min(block_start + blocks_per_core, num_blocks)
+
+    for block_id in range(block_start, block_end):
+        offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x_chunk = tl.load(x + offsets, mask=mask, other=0.0)
+        x_fp32 = x_chunk.to(tl.float32)
+        y_fp32 = silu_activation(x_fp32)
+        y_chunk = y_fp32.to(x_chunk.dtype)
+        tl.store(y + offsets, y_chunk, mask=mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 1024}),
+        triton.Config({"BLOCK_SIZE": 2048}),
+        triton.Config({"BLOCK_SIZE": 4096}),
+        triton.Config({"BLOCK_SIZE": 8192}),
+        triton.Config({"BLOCK_SIZE": 16384}),
+    ],
+    key=["n_elements"],
+)
+@libentry()
+@triton.jit
+def _silu_bwd_flatten_kernel(
+        dy,
+        x,
+        dx,
+        n_elements,
+        BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    grid_size = tl.num_programs(axis=0)
+
+    num_blocks = (n_elements + BLOCK_SIZE - 1) // BLOCK_SIZE
+    blocks_per_core = (num_blocks + grid_size - 1) // grid_size
+    block_start = pid * blocks_per_core
+    block_end = min(block_start + blocks_per_core, num_blocks)
+
+    for block_id in range(block_start, block_end):
+        offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        dy_chunk = tl.load(dy + offsets, mask=mask, other=0.0)
+        x_chunk = tl.load(x + offsets, mask=mask, other=0.0)
+        x_fp32 = x_chunk.to(tl.float32)
+
+        sigmoid_x = tl.sigmoid(x_fp32)
+        sigmoid_neg_x = tl.sigmoid(-x_fp32)
+        dsilu_dx = sigmoid_x + x_fp32 * sigmoid_x * sigmoid_neg_x
+
+        dx_chunk = dy_chunk * dsilu_dx.to(dy_chunk.dtype)
+        tl.store(dx + offsets, dx_chunk, mask=mask)
+
+
+def _flatten_grid(n_elements):
+    num_cores = get_num_cores("vector")
+    return lambda META: (max(1, min(num_cores, triton.cdiv(n_elements, META["BLOCK_SIZE"]))),)
 
 @triton.autotune(
     configs=[
@@ -262,10 +348,25 @@ def silu_fwd_impl(
 
     x_2d = x.reshape(-1, n_cols)
     n_rows = x_2d.shape[0]
+    block_size_n = _rowwise_block_size_n(n_cols)
 
+    if n_rows < get_num_cores("vector") or triton.next_power_of_2(n_cols) < 10 * MAX_BLOCK_SIZE_N:
+        n_elements = x.numel()
+
+        x_flat = x.reshape(-1)
+        y_flat = torch.empty_like(x_flat)
+
+        grid = _flatten_grid(n_elements)
+
+        _silu_fwd_flatten_kernel[grid](
+            x_flat,
+            y_flat,
+            n_elements,
+        )
+
+        return y_flat.reshape(*ori_shape)
     y = torch.empty_like(x_2d)
 
-    block_size_n = _rowwise_block_size_n(n_cols)
     grid = _rowwise_autotune_grid(n_rows)
 
     if _can_use_nomask_single_kernel(n_rows, n_cols, block_size_n):
@@ -317,22 +418,39 @@ def silu_bwd_impl(
     n_cols = ori_shape[-1]
 
     dy_2d = dy.reshape(-1, n_cols)
-    x_2d = x.reshape(-1, n_cols)
     n_rows = dy_2d.shape[0]
-
-    dx = torch.empty_like(x_2d)
-
     block_size_n = _rowwise_block_size_n(n_cols)
-    grid = _rowwise_autotune_grid(n_rows)
 
-    _silu_bwd_kernel[grid](
-        dy_2d,
-        x_2d,
-        dx,
-        dy_2d.stride(0),
-        n_rows,
-        n_cols,
-        BLOCK_SIZE_N=block_size_n,
-    )
+    if n_rows < get_num_cores("vector") or triton.next_power_of_2(n_cols) < 10 * MAX_BLOCK_SIZE_N:
+        n_elements = dy.numel()
 
-    return dx.reshape(*ori_shape)
+        dy_flat = dy.reshape(-1)
+        x_flat = x.reshape(-1)
+        dx_flat = torch.empty_like(x_flat)
+
+        grid = _flatten_grid(n_elements)
+
+        _silu_bwd_flatten_kernel[grid](
+            dy_flat,
+            x_flat,
+            dx_flat,
+            n_elements,
+        )
+
+        return dx_flat.reshape(*ori_shape)
+    else:
+        x_2d = x.reshape(-1, n_cols)
+        dx = torch.empty_like(x_2d)
+
+        grid = _rowwise_autotune_grid(n_rows)
+        _silu_bwd_kernel[grid](
+            dy_2d,
+            x_2d,
+            dx,
+            dy_2d.stride(0),
+            n_rows,
+            n_cols,
+            BLOCK_SIZE_N=block_size_n,
+        )
+
+        return dx.reshape(*ori_shape)

--- a/mojo_opset/backends/ttx/kernels/npu/vision_rope.py
+++ b/mojo_opset/backends/ttx/kernels/npu/vision_rope.py
@@ -144,6 +144,7 @@ def _vision_rope_apply_kernel(
     TOKEN_BLOCK_SIZE: tl.constexpr,
     ALIGNED: tl.constexpr,
     CAST_TO_FP32: tl.constexpr,
+    TOKEN_ALIGNED: tl.constexpr,
 ):
     """Apply vision 2D RoPE to q and k in a single kernel.
 
@@ -152,149 +153,229 @@ def _vision_rope_apply_kernel(
     pid = tl.program_id(axis=0)
     grid_size = tl.num_programs(axis=0)
 
+    half_dim_offsets = tl.arange(0, HALF_D)
+    head_q_offsets = tl.arange(0, n_qh)
+    head_k_offsets = tl.arange(0, n_kh)
+
     for block_id in range(pid, num_token_blocks, grid_size):
         token_start = block_id * TOKEN_BLOCK_SIZE
         token_offsets = token_start + tl.arange(0, TOKEN_BLOCK_SIZE)
-        token_mask = token_offsets < T
-
-        half_dim_offsets = tl.arange(0, HALF_D)
-        half_dim_mask = half_dim_offsets < HALF_D
 
         cos_token_ptr = cos_ptr + token_offsets[:, None] * cos_token_stride
         sin_token_ptr = sin_ptr + token_offsets[:, None] * sin_token_stride
 
-        head_q_offsets = tl.arange(0, n_qh)
-        head_k_offsets = tl.arange(0, n_kh)
-
         if ALIGNED:
-            # The current vision RoPE table duplicates the first half into the
-            # second half, so we only load half of cos/sin and reuse it.
-            cos_half = tl.load(
-                cos_token_ptr + half_dim_offsets[None, :],
-                mask=token_mask[:, None] & half_dim_mask[None, :],
-                other=0.0,
-            )
-            sin_half = tl.load(
-                sin_token_ptr + half_dim_offsets[None, :],
-                mask=token_mask[:, None] & half_dim_mask[None, :],
-                other=0.0,
-            )
+            if TOKEN_ALIGNED:
+                # cos/sin: 2D block_ptr [TOKEN_BLOCK_SIZE, HALF_D]
+                cos_block_ptr = tl.make_block_ptr(
+                    base=cos_ptr,
+                    shape=(T, HALF_D),
+                    strides=(cos_token_stride, 1),
+                    offsets=(token_start, 0),
+                    block_shape=(TOKEN_BLOCK_SIZE, HALF_D),
+                    order=(1, 0),
+                )
+                sin_block_ptr = tl.make_block_ptr(
+                    base=sin_ptr,
+                    shape=(T, HALF_D),
+                    strides=(sin_token_stride, 1),
+                    offsets=(token_start, 0),
+                    block_shape=(TOKEN_BLOCK_SIZE, HALF_D),
+                    order=(1, 0),
+                )
+                cos_half = tl.load(cos_block_ptr)
+                sin_half = tl.load(sin_block_ptr)
 
-            cos_half_tile = tl.reshape(cos_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
-            sin_half_tile = tl.reshape(sin_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+                cos_half_tile = tl.reshape(cos_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+                sin_half_tile = tl.reshape(sin_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
 
-            dim_offsets = tl.arange(0, D)
-            dim_mask = dim_offsets < D
+                # Q: 3D block_ptr [TOKEN_BLOCK_SIZE, n_qh, D]
+                q_block_ptr = tl.make_block_ptr(
+                    base=q_ptr,
+                    shape=(T, n_qh, D),
+                    strides=(q_token_stride, q_head_stride, 1),
+                    offsets=(token_start, 0, 0),
+                    block_shape=(TOKEN_BLOCK_SIZE, n_qh, D),
+                    order=(2, 1, 0),
+                )
+                q_tile = tl.load(q_block_ptr)
+                q_load_dtype = q_tile.dtype
+                if CAST_TO_FP32:
+                    q_tile = q_tile.to(cos_half.dtype)
+                q_tile = _compute_vision_rope(q_tile, sin_half_tile, cos_half_tile, n_qh, HALF_D, TOKEN_BLOCK_SIZE)
+                tl.store(q_block_ptr, q_tile.to(q_load_dtype))
 
-            # Q: 3D load [TOKEN_BLOCK_SIZE, n_qh, D], rotate, store
-            q_offsets = (
-                token_offsets[:, None, None] * q_token_stride
-                + head_q_offsets[None, :, None] * q_head_stride
-                + dim_offsets[None, None, :]
-            )
-            q_mask = token_mask[:, None, None] & (head_q_offsets[None, :, None] < n_qh) & dim_mask[None, None, :]
-            q_tile = tl.load(q_ptr + q_offsets, mask=q_mask, other=0.0)
-            if CAST_TO_FP32:
-                q_tile = q_tile.to(cos_half.dtype)
-            q_tile = _compute_vision_rope(q_tile, sin_half_tile, cos_half_tile, n_qh, HALF_D, TOKEN_BLOCK_SIZE)
-            tl.store(q_ptr + q_offsets, q_tile, mask=q_mask)
+                # K: 3D block_ptr [TOKEN_BLOCK_SIZE, n_kh, D]
+                k_block_ptr = tl.make_block_ptr(
+                    base=k_ptr,
+                    shape=(T, n_kh, D),
+                    strides=(k_token_stride, k_head_stride, 1),
+                    offsets=(token_start, 0, 0),
+                    block_shape=(TOKEN_BLOCK_SIZE, n_kh, D),
+                    order=(2, 1, 0),
+                )
+                k_tile = tl.load(k_block_ptr)
+                k_load_dtype = k_tile.dtype
+                if CAST_TO_FP32:
+                    k_tile = k_tile.to(cos_half.dtype)
+                k_tile = _compute_vision_rope(k_tile, sin_half_tile, cos_half_tile, n_kh, HALF_D, TOKEN_BLOCK_SIZE)
+                tl.store(k_block_ptr, k_tile.to(k_load_dtype))
+            else:
+                token_mask = token_offsets < T
 
-            # K: 3D load [TOKEN_BLOCK_SIZE, n_kh, D], rotate, store
-            k_offsets = (
-                token_offsets[:, None, None] * k_token_stride
-                + head_k_offsets[None, :, None] * k_head_stride
-                + dim_offsets[None, None, :]
-            )
-            k_mask = token_mask[:, None, None] & (head_k_offsets[None, :, None] < n_kh) & dim_mask[None, None, :]
-            k_tile = tl.load(k_ptr + k_offsets, mask=k_mask, other=0.0)
-            if CAST_TO_FP32:
-                k_tile = k_tile.to(cos_half.dtype)
-            k_tile = _compute_vision_rope(k_tile, sin_half_tile, cos_half_tile, n_kh, HALF_D, TOKEN_BLOCK_SIZE)
-            tl.store(k_ptr + k_offsets, k_tile, mask=k_mask)
+                cos_half = tl.load(
+                    cos_token_ptr + half_dim_offsets[None, :],
+                    mask=token_mask[:, None],
+                    other=0.0,
+                    )
+                sin_half = tl.load(
+                    sin_token_ptr + half_dim_offsets[None, :],
+                    mask=token_mask[:, None],
+                    other=0.0,
+                    )
+
+                cos_half_tile = tl.reshape(cos_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+                sin_half_tile = tl.reshape(sin_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+
+                dim_offsets = tl.arange(0, D)
+
+                q_offsets = (
+                        token_offsets[:, None, None] * q_token_stride
+                        + head_q_offsets[None, :, None] * q_head_stride
+                        + dim_offsets[None, None, :]
+                )
+                q_mask = token_mask[:, None, None]
+                q_tile = tl.load(q_ptr + q_offsets, mask=q_mask, other=0.0)
+                if CAST_TO_FP32:
+                    q_tile = q_tile.to(cos_half.dtype)
+                q_tile = _compute_vision_rope(q_tile, sin_half_tile, cos_half_tile, n_qh, HALF_D, TOKEN_BLOCK_SIZE)
+                tl.store(q_ptr + q_offsets, q_tile, mask=q_mask)
+
+                k_offsets = (
+                        token_offsets[:, None, None] * k_token_stride
+                        + head_k_offsets[None, :, None] * k_head_stride
+                        + dim_offsets[None, None, :]
+                )
+                k_mask = token_mask[:, None, None]
+                k_tile = tl.load(k_ptr + k_offsets, mask=k_mask, other=0.0)
+                if CAST_TO_FP32:
+                    k_tile = k_tile.to(cos_half.dtype)
+                k_tile = _compute_vision_rope(k_tile, sin_half_tile, cos_half_tile, n_kh, HALF_D, TOKEN_BLOCK_SIZE)
+                tl.store(k_ptr + k_offsets, k_tile, mask=k_mask)
         else:
-            # The current vision RoPE table duplicates the first half into the
-            # second half, so we only load half of cos/sin and reuse it.
-            cos_half = tl.load(
-                cos_token_ptr + half_dim_offsets[None, :],
-                mask=token_mask[:, None] & half_dim_mask[None, :],
-                other=0.0,
-            )
-            sin_half = tl.load(
-                sin_token_ptr + half_dim_offsets[None, :],
-                mask=token_mask[:, None] & half_dim_mask[None, :],
-                other=0.0,
-            )
+            if TOKEN_ALIGNED:
+                cos_half = tl.load(cos_token_ptr + half_dim_offsets[None, :])
+                sin_half = tl.load(sin_token_ptr + half_dim_offsets[None, :])
 
-            cos_half_tile = tl.reshape(cos_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
-            sin_half_tile = tl.reshape(sin_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+                cos_half_tile = tl.reshape(cos_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+                sin_half_tile = tl.reshape(sin_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
 
-            # Q halves
-            q_offsets_half1 = (
-                token_offsets[:, None, None] * q_token_stride
-                + head_q_offsets[None, :, None] * q_head_stride
-                + half_dim_offsets[None, None, :]
-            )
-            q_offsets_half2 = (
-                token_offsets[:, None, None] * q_token_stride
-                + head_q_offsets[None, :, None] * q_head_stride
-                + HALF_D
-                + half_dim_offsets[None, None, :]
-            )
-            q_half_mask = (
-                token_mask[:, None, None] & (head_q_offsets[None, :, None] < n_qh) & half_dim_mask[None, None, :]
-            )
+                q_offsets_half1 = (
+                        token_offsets[:, None, None] * q_token_stride
+                        + head_q_offsets[None, :, None] * q_head_stride
+                        + half_dim_offsets[None, None, :]
+                )
+                q_offsets_half2 = (
+                        token_offsets[:, None, None] * q_token_stride
+                        + head_q_offsets[None, :, None] * q_head_stride
+                        + HALF_D
+                        + half_dim_offsets[None, None, :]
+                )
 
-            q_tile_1 = tl.load(q_ptr + q_offsets_half1, mask=q_half_mask, other=0.0)
-            q_tile_2 = tl.load(q_ptr + q_offsets_half2, mask=q_half_mask, other=0.0)
-            if CAST_TO_FP32:
-                q_tile_1 = q_tile_1.to(tl.float32)
-                q_tile_2 = q_tile_2.to(tl.float32)
-            new_q_1, new_q_2 = _compute_vision_rope_separated(
-                q_tile_1,
-                q_tile_2,
-                sin_half_tile,
-                cos_half_tile,
-            )
-            tl.store(q_ptr + q_offsets_half1, new_q_1, mask=q_half_mask)
-            tl.store(q_ptr + q_offsets_half2, new_q_2, mask=q_half_mask)
+                q_tile_1 = tl.load(q_ptr + q_offsets_half1)
+                q_tile_2 = tl.load(q_ptr + q_offsets_half2)
+                if CAST_TO_FP32:
+                    q_tile_1 = q_tile_1.to(tl.float32)
+                    q_tile_2 = q_tile_2.to(tl.float32)
+                roped_x1 = q_tile_1 * cos_half_tile - q_tile_2 * sin_half_tile
+                roped_x2 = q_tile_2 * cos_half_tile + q_tile_1 * sin_half_tile
+                tl.store(q_ptr + q_offsets_half1, roped_x1)
+                tl.store(q_ptr + q_offsets_half2, roped_x2)
 
-            # K halves
-            k_offsets_half1 = (
-                token_offsets[:, None, None] * k_token_stride
-                + head_k_offsets[None, :, None] * k_head_stride
-                + half_dim_offsets[None, None, :]
-            )
-            k_offsets_half2 = (
-                token_offsets[:, None, None] * k_token_stride
-                + head_k_offsets[None, :, None] * k_head_stride
-                + HALF_D
-                + half_dim_offsets[None, None, :]
-            )
-            k_half_mask = (
-                token_mask[:, None, None] & (head_k_offsets[None, :, None] < n_kh) & half_dim_mask[None, None, :]
-            )
+                k_offsets_half1 = (
+                        token_offsets[:, None, None] * k_token_stride
+                        + head_k_offsets[None, :, None] * k_head_stride
+                        + half_dim_offsets[None, None, :]
+                )
+                k_offsets_half2 = (
+                        token_offsets[:, None, None] * k_token_stride
+                        + head_k_offsets[None, :, None] * k_head_stride
+                        + HALF_D
+                        + half_dim_offsets[None, None, :]
+                )
 
-            k_tile_1 = tl.load(k_ptr + k_offsets_half1, mask=k_half_mask, other=0.0)
-            k_tile_2 = tl.load(k_ptr + k_offsets_half2, mask=k_half_mask, other=0.0)
-            if CAST_TO_FP32:
-                k_tile_1 = k_tile_1.to(tl.float32)
-                k_tile_2 = k_tile_2.to(tl.float32)
-            new_k_1, new_k_2 = _compute_vision_rope_separated(
-                k_tile_1,
-                k_tile_2,
-                sin_half_tile,
-                cos_half_tile,
-            )
-            tl.store(k_ptr + k_offsets_half1, new_k_1, mask=k_half_mask)
-            tl.store(k_ptr + k_offsets_half2, new_k_2, mask=k_half_mask)
+                k_tile_1 = tl.load(k_ptr + k_offsets_half1)
+                k_tile_2 = tl.load(k_ptr + k_offsets_half2)
+                if CAST_TO_FP32:
+                    k_tile_1 = k_tile_1.to(tl.float32)
+                    k_tile_2 = k_tile_2.to(tl.float32)
+                roped_k1 = k_tile_1 * cos_half_tile - k_tile_2 * sin_half_tile
+                roped_k2 = k_tile_2 * cos_half_tile + k_tile_1 * sin_half_tile
+                tl.store(k_ptr + k_offsets_half1, roped_k1)
+                tl.store(k_ptr + k_offsets_half2, roped_k2)
+            else:
+                token_mask = token_offsets < T
 
+                cos_half = tl.load(
+                    cos_token_ptr + half_dim_offsets[None, :],
+                    mask=token_mask[:, None],
+                    other=0.0,
+                    )
+                sin_half = tl.load(
+                    sin_token_ptr + half_dim_offsets[None, :],
+                    mask=token_mask[:, None],
+                    other=0.0,
+                    )
 
-def _get_token_block_size(n_qh: int, n_kh: int) -> int:
-    if n_qh <= 8 and n_kh <= 8:
-        return 16
-    if n_qh <= 32 and n_kh <= 32:
-        return 8
-    return 4
+                cos_half_tile = tl.reshape(cos_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+                sin_half_tile = tl.reshape(sin_half, (TOKEN_BLOCK_SIZE, 1, HALF_D), can_reorder=True)
+
+                q_offsets_half1 = (
+                        token_offsets[:, None, None] * q_token_stride
+                        + head_q_offsets[None, :, None] * q_head_stride
+                        + half_dim_offsets[None, None, :]
+                )
+                q_offsets_half2 = (
+                        token_offsets[:, None, None] * q_token_stride
+                        + head_q_offsets[None, :, None] * q_head_stride
+                        + HALF_D
+                        + half_dim_offsets[None, None, :]
+                )
+                q_half_mask = token_mask[:, None, None]
+
+                q_tile_1 = tl.load(q_ptr + q_offsets_half1, mask=q_half_mask, other=0.0)
+                q_tile_2 = tl.load(q_ptr + q_offsets_half2, mask=q_half_mask, other=0.0)
+                if CAST_TO_FP32:
+                    q_tile_1 = q_tile_1.to(tl.float32)
+                    q_tile_2 = q_tile_2.to(tl.float32)
+                roped_x1 = q_tile_1 * cos_half_tile - q_tile_2 * sin_half_tile
+                roped_x2 = q_tile_2 * cos_half_tile + q_tile_1 * sin_half_tile
+                tl.store(q_ptr + q_offsets_half1, roped_x1, mask=q_half_mask)
+                tl.store(q_ptr + q_offsets_half2, roped_x2, mask=q_half_mask)
+
+                k_offsets_half1 = (
+                        token_offsets[:, None, None] * k_token_stride
+                        + head_k_offsets[None, :, None] * k_head_stride
+                        + half_dim_offsets[None, None, :]
+                )
+                k_offsets_half2 = (
+                        token_offsets[:, None, None] * k_token_stride
+                        + head_k_offsets[None, :, None] * k_head_stride
+                        + HALF_D
+                        + half_dim_offsets[None, None, :]
+                )
+                k_half_mask = token_mask[:, None, None]
+
+                k_tile_1 = tl.load(k_ptr + k_offsets_half1, mask=k_half_mask, other=0.0)
+                k_tile_2 = tl.load(k_ptr + k_offsets_half2, mask=k_half_mask, other=0.0)
+                if CAST_TO_FP32:
+                    k_tile_1 = k_tile_1.to(tl.float32)
+                    k_tile_2 = k_tile_2.to(tl.float32)
+                roped_k1 = k_tile_1 * cos_half_tile - k_tile_2 * sin_half_tile
+                roped_k2 = k_tile_2 * cos_half_tile + k_tile_1 * sin_half_tile
+                tl.store(k_ptr + k_offsets_half1, roped_k1, mask=k_half_mask)
+                tl.store(k_ptr + k_offsets_half2, roped_k2, mask=k_half_mask)
+
 
 
 def vision_rope_apply_impl(
@@ -328,10 +409,12 @@ def vision_rope_apply_impl(
     is_aligned = _is_half_rope_dim_aligned(half_D)
     cast_to_fp32 = q.dtype != torch.float32
 
-    token_block_size = _get_token_block_size(n_qh, n_kh)
+    token_block_size = 2
     num_token_blocks = (T + token_block_size - 1) // token_block_size
+    token_aligned = (T % token_block_size == 0)
 
     num_programs = get_num_cores()
+    num_programs = min(num_programs, num_token_blocks)
 
     cos = cos.contiguous()
     sin = sin.contiguous()
@@ -357,6 +440,7 @@ def vision_rope_apply_impl(
         token_block_size,
         is_aligned,
         cast_to_fp32,
+        token_aligned,
     )
 
     return q, k

--- a/mojo_opset/backends/ttx/operators/gemm.py
+++ b/mojo_opset/backends/ttx/operators/gemm.py
@@ -23,15 +23,20 @@ class TTXQuantGemm(MojoQuantGemm):
 
     supported_platforms_list = ["npu", "ilu"]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._bt_cache = None
+        self._bt_cache_key = None
+
     def forward(self, input: torch.Tensor, input_scale: torch.Tensor) -> torch.Tensor:
-        weight = self.weight
-        if self.trans_weight:
-            weight = weight.t().contiguous()
-
         M, K = input.shape
-        K_w, N = weight.shape
+        N = self.out_features
 
-        bt = prepare_b(weight)
+        key = (self.weight.data_ptr(), self.trans_weight)
+        if self._bt_cache_key != key:
+            self._bt_cache = prepare_b(self.weight, transposed=self.trans_weight)
+            self._bt_cache_key = key
+        bt = self._bt_cache
 
         if not input.is_contiguous():
             input = input.contiguous()


### PR DESCRIPTION
1. gemm.py
(1) Optimize weight transposition to be performed only once, reducing redundant computation.

2. int8_gemm.py:
(1) Add Autotune configuration to enhance adaptive performance.
(2) Adjust pad_m size to minimize padding overhead for small shapes.

3. kv_cache.py:
(1) Performance & Parallelism: Set padding_size=False during data loading to ignore existing padding, thereby improving data loading parallelism and throughput.

4. rmsnorm.py:
(1) When the entire row fits into the Unified Buffer (UB), load input x only once instead of twice, reducing memory bandwidth usage.

5. rope.py:
(1) Replace clone with empty_like to save memory equivalent to one q tensor peak usage.
(2) Performance Improvement: Hardcode ALIGNED=True. Enable extract_slice and insert_slice to support non-aligned rope_dim. This significantly improves performance compared to the ALIGNED=False mode.

6. sdpa.py:
(1) Add A5 compilation parameters to boost execution performance.

7. silu.py
(1) 1d flattening for small shapes