### PR TITLE
[NPU] triton ops optimization

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/fused_add_rmsnorm.py
@@ -24,42 +24,22 @@ TOKEN_BLOCK_SIZE_TABLE = {
 }
 
 
-def rms_norm_fwd_heuristics(args):
-    hidden_dim = args["n_cols"]
-    n_rows = args["n_rows"] if "n_rows" in args else 0
-
-    if hidden_dim >= 8192:
-        return 1
-    if hidden_dim >= 4096:
-        return 2
-    if hidden_dim >= 2048:
-        return 4
-    if hidden_dim >= 1024:
-        return 8
-    if hidden_dim >= 512:
-        return 16
-
-    if hidden_dim <= 128:
-        if n_rows > 0 and n_rows <= 32:
-            return 4
-        return 32
-
-    if hidden_dim <= COL_BLOCKING_THRESHOLD:
-        if hidden_dim in TOKEN_BLOCK_SIZE_TABLE:
-            return TOKEN_BLOCK_SIZE_TABLE[hidden_dim]
-
-        for dim_thresh, block_size in sorted(TOKEN_BLOCK_SIZE_TABLE.items()):
-            if hidden_dim <= dim_thresh:
-                return block_size
-        return 1
-    return 4
-
-
 def _num_vectorcores():
     return get_num_cores("vector")
 
 
-@triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
+def _block_size_n_heur(args):
+    n_cols = args["n_cols"]
+    if n_cols <= 1024:
+        return 1024
+    elif n_cols <= 2048:
+        return 2048
+    elif n_cols <= 4096:
+        return 4096
+    else:
+        return 8192
+
+
 @libentry()
 @triton.jit
 def _fused_add_rmsnorm_fwd_kernel(
@@ -257,7 +237,6 @@ def _fused_add_rmsnorm_fwd_kernel(
                 tl.store(Y_ptr_row_block + cols_off[None, :], Y_chunk, mask=block_mask)
 
 
-@triton.heuristics({"BLOCK_SIZE_M": rms_norm_fwd_heuristics})
 @libentry()
 @triton.jit
 def _fused_add_rmsnorm_fwd_single_pass_kernel(
@@ -521,10 +500,7 @@ def fused_add_rmsnorm_infer_impl(
     residual_2d = residual.reshape(-1, dim)
     n_rows, n_cols = hidden_states_2d.shape
 
-    if n_cols > COL_BLOCKING_THRESHOLD:
-        BLOCK_SIZE_N = 2048
-    else:
-        BLOCK_SIZE_N = align(hidden_states, n_cols, VEC_ALIGN_BYTES)
+    BLOCK_SIZE_N = _block_size_n_heur({"n_cols": n_cols})
 
     str_to_casting_mode = {"llama": 0, "gemma": 1, "none": -1}
     _casting_mode = str_to_casting_mode[casting_mode]
@@ -532,7 +508,7 @@ def fused_add_rmsnorm_infer_impl(
     rstd_dtype = torch.float32 if _casting_mode in (0, 1) else hidden_states.dtype
     RSTD = torch.empty(n_rows, dtype=rstd_dtype, device=hidden_states.device)
 
-    BLOCK_SIZE_M = rms_norm_fwd_heuristics({"n_rows": n_rows, "n_cols": n_cols})
+    BLOCK_SIZE_M = max(1, min(8, ceil_div(4096, n_cols)))
     num_row_tasks = ceil_div(n_rows, BLOCK_SIZE_M)
     grid = (max(1, min(_num_vectorcores(), num_row_tasks)),)
 
@@ -564,6 +540,7 @@ def fused_add_rmsnorm_infer_impl(
             STORE_RSTD=True,
             DROP_COLS_MASK=drop_cols_mask,
             DROP_ROWS_MASK=drop_rows_mask,
+            BLOCK_SIZE_M=BLOCK_SIZE_M,
             BLOCK_SIZE_N=BLOCK_SIZE_N,
             sync_solver=True,
         )
@@ -595,6 +572,7 @@ def fused_add_rmsnorm_infer_impl(
         STORE_RSTD=True,
         DROP_COLS_MASK=drop_cols_mask,
         DROP_ROWS_MASK=drop_rows_mask,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
         BLOCK_SIZE_N=BLOCK_SIZE_N,
         sync_solver=True,
     )

--- a/mojo_opset/backends/ttx/kernels/npu/kv_cache.py
+++ b/mojo_opset/backends/ttx/kernels/npu/kv_cache.py
@@ -185,7 +185,7 @@ def _store_paged_kv_cache_chunk_kernel(
         chunk_idx = p_idx // num_kv_heads
 
         chunk_base = chunk_meta_ptr + chunk_idx * stride_cm_row
-        src_token_start = tl.load(chunk_base + 0 * stride_cm_col, care_padding=False)
+        src_token_start = tl.load(chunk_base + 0 * stride_cm_col)
         dst_block_id = tl.load(chunk_base + 1 * stride_cm_col)
         dst_block_offset = tl.load(chunk_base + 2 * stride_cm_col)
         chunk_len = tl.load(chunk_base + 3 * stride_cm_col)
@@ -222,7 +222,7 @@ def _store_paged_kv_cache_chunk_kernel(
                 + offs_d[None, :] * stride_vc_dim
             )
 
-            k_val = tl.load(base_src_k_ptr + h * stride_k_head, mask=mask_sub[:, None], care_padding=False)
+            k_val = tl.load(base_src_k_ptr + h * stride_k_head, mask=mask_sub[:, None])
             v_val = tl.load(base_src_v_ptr + h * stride_v_head, mask=mask_sub[:, None])
             tl.store(base_dst_k_ptr + h * stride_kc_head, k_val, mask=mask_sub[:, None])
             tl.store(base_dst_v_ptr + h * stride_vc_head, v_val, mask=mask_sub[:, None])

--- a/mojo_opset/backends/ttx/kernels/npu/quant.py
+++ b/mojo_opset/backends/ttx/kernels/npu/quant.py
@@ -167,7 +167,6 @@ def static_quant_kernel(
     q_max: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
-    multibuffer: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     grid_size = tl.num_programs(axis=0)
@@ -230,7 +229,6 @@ def dynamic_quant_impl(
         total_tokens=total_tokens,
         dims=dims,
         align_dims=align_dims,
-        BLOCK_SIZE_N=256,
     )
 
     return output_tensor, quant_scale_tensor.unsqueeze(-1)
@@ -238,14 +236,15 @@ def dynamic_quant_impl(
 
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_SIZE_M": 8, "multibuffer": True}),
-        triton.Config({"BLOCK_SIZE_M": 16, "multibuffer": True}),
-        triton.Config({"BLOCK_SIZE_M": 32, "multibuffer": True}),
-        triton.Config({"BLOCK_SIZE_M": 64, "multibuffer": True}),
-        triton.Config({"BLOCK_SIZE_M": 8, "multibuffer": False}),
-        triton.Config({"BLOCK_SIZE_M": 16, "multibuffer": False}),
-        triton.Config({"BLOCK_SIZE_M": 32, "multibuffer": False}),
-        triton.Config({"BLOCK_SIZE_M": 64, "multibuffer": False}),
+        triton.Config({"BLOCK_SIZE_M": bm, "BLOCK_SIZE_N": bn, "multibuffer": mb})
+        for bm in [8, 16, 32, 64]
+        for bn in [256, 512, 1024, 2048]
+        for mb in [True, False]
+    ] + [
+        triton.Config({"BLOCK_SIZE_M": bm, "BLOCK_SIZE_N": bn, "multibuffer": mb})
+        for bm in [2, 4, 8]
+        for bn in [4096, 8192]
+        for mb in [True, False]
     ],
     key=["dims"],
 )
@@ -302,11 +301,15 @@ def scale_dynamic_quant_kernel(
 
             input_ptr = input + input_offset
             block_mask = element_mask[:, None] & dims_mask[None, :]
-            input_vals = tl.load(input_ptr, mask=block_mask, other=0.0).to(tl.float32)
 
+            # Load instruction reordering: first load `scale` (no dependencies, can be issued early), then load `input`.
             if scale is not None:
                 scale_ptr = scale + dims_off
                 scale_vals = tl.load(scale_ptr, mask=dims_mask, other=1.0).to(tl.float32)
+
+            input_vals = tl.load(input_ptr, mask=block_mask, other=0.0).to(tl.float32)
+
+            if scale is not None:
                 scaled_vals = input_vals * scale_vals
             else:
                 scaled_vals = input_vals
@@ -334,12 +337,15 @@ def scale_dynamic_quant_kernel(
 
             block_mask = element_mask[:, None] & dims_mask[None, :]
 
+            # Load instruction reordering: first load `scale` (no dependencies, can be issued early), then load `input`.
+            if scale is not None:
+                scale_ptr = scale + dims_off
+                scale_vals = tl.load(scale_ptr, mask=dims_mask, other=1.0).to(tl.float32)
+
             input_vals = tl.load(input_ptr, mask=block_mask, other=0.0).to(tl.float32)
 
             # Apply scaling and quantization
             if scale is not None:
-                scale_ptr = scale + dims_off
-                scale_vals = tl.load(scale_ptr, mask=dims_mask, other=1.0).to(tl.float32)
                 scaled_vals = input_vals * scale_vals
             else:
                 scaled_vals = input_vals

--- a/mojo_opset/backends/ttx/kernels/npu/sdpa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/sdpa.py
@@ -414,16 +414,18 @@ def kernel_sdpa_fwd(
             block_v = tl.load(ptr_v, mask=mask_kv, other=0.0)
 
             block_s = tl.dot(block_q, tl.trans(block_k)) * scale
-            block_s -= (1.0 - block_mask.to(HIGH_TYPE)) * 1e6
+            block_s = tl.where(block_mask, block_s, -1e6)
             block_m_1 = tl.maximum(block_m, tl.max(block_s, axis=1,
-                                   propagate_nan=tl.PropagateNan.ALL),propagate_nan=tl.PropagateNan.ALL)
-            block_s = tl.exp(block_s - block_m_1[:, None])
-            block_l_1 = tl.exp(block_m - block_m_1) * block_l + tl.sum(block_s, axis=1)
-            block_o = tl.exp(block_m - block_m_1)[:, None] * block_o + tl.dot(block_s.to(LOW_TYPE), block_v).to(
-                HIGH_TYPE
-            )
+                                                   propagate_nan=tl.PropagateNan.ALL),
+                                   propagate_nan=tl.PropagateNan.ALL)
+            block_s = tl.math.exp(block_s - block_m_1[:, None])
+            block_l_1= tl.sum(block_s, axis=1)
+            alpha = tl.math.exp(block_m - block_m_1)
+            block_l = alpha * block_l + block_l_1
+            block_o = block_o * alpha[:, None]
+            block_o = tl.dot(block_s.to(LOW_TYPE), block_v, block_o).to(HIGH_TYPE)
             block_m = block_m_1
-            block_l = block_l_1
+
 
         block_o = block_o / block_l[:, None]
         block_lse = tl.log(block_l) + block_m
@@ -617,8 +619,8 @@ def kernel_sdpa_bwd_q(
             block_s -= (1.0 - block_mask.to(HIGH_TYPE)) * 1e6
             block_p = tl.exp(block_s - block_lse[:, None])
             block_dp = tl.dot(block_do, block_v.T).to(HIGH_TYPE)
-            block_ds = block_p * (block_dp - block_d[:, None])
-            block_dq += tl.dot(block_ds.to(LOW_TYPE), block_k).to(HIGH_TYPE) * scale
+            block_ds = block_p * (block_dp - block_d[:, None]) * scale
+            block_dq += tl.dot(block_ds.to(LOW_TYPE), block_k).to(HIGH_TYPE)
 
         tl.store(ptr_dq, block_dq.to(LOW_TYPE), mask=mask_q)
 
@@ -768,8 +770,8 @@ def kernel_sdpa_bwd_kv(
                 block_p = tl.exp(block_s - block_lse[:, None])
                 block_dv += tl.dot(block_p.to(LOW_TYPE).T, block_do).to(HIGH_TYPE)
                 block_dp = tl.dot(block_do, block_v.T).to(HIGH_TYPE)
-                block_ds = block_p * (block_dp - block_d[:, None])
-                block_dk += tl.dot(block_ds.to(LOW_TYPE).T, block_q).to(HIGH_TYPE) * scale
+                block_ds = block_p * (block_dp - block_d[:, None]) * scale
+                block_dk += tl.dot(block_ds.to(LOW_TYPE).T, block_q).to(HIGH_TYPE)
 
         tl.store(ptr_dk, block_dk.to(LOW_TYPE), mask=mask_kv)
         tl.store(ptr_dv, block_dv.to(LOW_TYPE), mask=mask_kv)
@@ -857,6 +859,7 @@ def sdpa_infer_impl(
         set_workspace_multibuffer=4,
         tile_mix_vector_loop=8,
         tile_mix_cube_loop=4,
+        limit_auto_multi_buffer_buffer="no-limit",
         enable_dynamic_cv_pipeline=True,
         enable_cube_block_merge=True,
         hfusion_enable_multiple_consumer_fusion=True,
@@ -934,6 +937,7 @@ def sdpa_fwd_impl(
         lse.stride(0),
         lse.stride(1),
         lse.stride(2),
+        limit_auto_multi_buffer_buffer="no-limit",
         enable_dynamic_cv_pipeline=True,
         enable_cube_block_merge=True,
         hfusion_enable_multiple_consumer_fusion=True,
@@ -983,13 +987,13 @@ def sdpa_bwd_impl(
     assert q.shape[3] == k.shape[3] and k.shape[3] == v.shape[3] and q.shape[3] in {64, 128}
     assert q.shape[0] == lse.shape[0] and q.shape[1] == lse.shape[1] and q.shape[2] == lse.shape[2]
 
-    num_cores, _ = get_device_properties()
+    num_cores, num_vec_cores = get_device_properties()
     d = torch.empty_like(lse)
     dq = torch.empty_like(q)
     dk = torch.empty_like(k)
     dv = torch.empty_like(v)
 
-    kernel_sdpa_bwd_d[(num_cores,)](
+    kernel_sdpa_bwd_d[(num_vec_cores,)](
         o,
         do,
         d,
@@ -1035,6 +1039,11 @@ def sdpa_bwd_impl(
         d.stride(0),
         d.stride(1),
         d.stride(2),
+        limit_auto_multi_buffer_buffer="no-limit",
+        hfusion_enable_multiple_consumer_fusion=True,
+        unit_flag=True,
+        limit_auto_multi_buffer_of_local_buffer="no-l0c",
+        intra_cache_num=1,
     )
     kernel_sdpa_bwd_kv[(num_cores,)](
         q,
@@ -1067,6 +1076,12 @@ def sdpa_bwd_impl(
         d.stride(0),
         d.stride(1),
         d.stride(2),
+        limit_auto_multi_buffer_buffer="no-limit",
+        hfusion_enable_multiple_consumer_fusion=True,
+        unit_flag=True,
+        limit_auto_multi_buffer_of_local_buffer="no-l0c",
+        intra_cache_num=3,
+        inter_cache_num=2,
     )
 
     return dq, dk, dv

--- a/mojo_opset/backends/ttx/kernels/npu/swa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/swa.py
@@ -356,10 +356,9 @@ def _sdpa_infer_kernel(
     stride_vt,
     stride_vh,
     stride_vd,
-    aux_mask_ptr,
-    aux_mask_size,
-    stride_mask_m,
-    stride_mask_n,
+    causal_mask_ptr,
+    causal_mask_m_size: tl.constexpr,
+    causal_mask_n_size: tl.constexpr,
     IS_CAUSAL: tl.constexpr,
     GLOBAL_WINDOW: tl.constexpr,
     LOCAL_WINDOW: tl.constexpr,
@@ -374,17 +373,6 @@ def _sdpa_infer_kernel(
     tl.static_assert(HEAD_DIM <= BLOCK_D, "BLOCK_SIZE_D should not be less than HEAD_DIM")
     pid = tl.program_id(0)
     n_programs = tl.num_programs(0)
-
-    # Hint(chenyifan):
-    #   the prepared aux_mask is [[empty, triu, full, tril, empty],
-    #                             [full, empty, empty, full, empty]]
-    #   every mask [BLOCK_M, BLOCK_N] can be sliced from the aux_mask and further combined
-    aux_mask_ptr_01 = aux_mask_ptr + aux_mask_size * 1 * stride_mask_m + aux_mask_size * 3 * stride_mask_n
-    aux_mask_ptr_10 = aux_mask_ptr + aux_mask_size * 1 * stride_mask_m + aux_mask_size * 1 * stride_mask_n
-    aux_mask_ptr_triu = aux_mask_ptr + aux_mask_size * 1 * stride_mask_n
-    aux_mask_ptr_tril = aux_mask_ptr + aux_mask_size * 3 * stride_mask_n
-    aux_mask_ptr_01t = aux_mask_ptr + aux_mask_size * 1 * stride_mask_m
-    aux_mask_ptr_10t = aux_mask_ptr + aux_mask_size * 1 * stride_mask_m + aux_mask_size * 2 * stride_mask_n
 
     cu_q_chunks = 0
     for b_id in range(bsz):
@@ -409,53 +397,11 @@ def _sdpa_infer_kernel(
             else:
                 kv_head_id = q_head_id // (NUM_Q_HEADS // NUM_KV_HEADS)
 
-            # q_block_ptr = tl.make_block_ptr(
-            #     base=q_ptr + q_start * stride_qt + q_head_id * stride_qh,
-            #     shape=(q_seq_len, HEAD_DIM),
-            #     strides=(stride_qt, stride_qd),
-            #     offsets=(0, 0),
-            #     block_shape=(BLOCK_M, BLOCK_D),
-            #     order=(1, 0),
-            # )
-            # o_block_ptr = tl.make_block_ptr(
-            #     base=o_ptr + q_start * stride_ot + q_head_id * stride_oh,
-            #     shape=(q_seq_len, HEAD_DIM),
-            #     strides=(stride_ot, stride_od),
-            #     offsets=(0, 0),
-            #     block_shape=(BLOCK_M, BLOCK_D),
-            #     order=(1, 0),
-            # )
-            # k_block_ptr = tl.make_block_ptr(
-            #     base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
-            #     shape=(kv_seq_len, HEAD_DIM),
-            #     strides=(stride_kt, stride_kd),
-            #     offsets=(0, 0),
-            #     block_shape=(BLOCK_N, BLOCK_D),
-            #     order=(1, 0),
-            # )
-            # v_block_ptr = tl.make_block_ptr(
-            #     base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
-            #     shape=(kv_seq_len, HEAD_DIM),
-            #     strides=(stride_vt, stride_vd),
-            #     offsets=(0, 0),
-            #     block_shape=(BLOCK_N, BLOCK_D),
-            #     order=(1, 0),
-            # )
-            q_mask = gen_mask_m_right_bound(
-                aux_mask_ptr_10t,
-                aux_mask_size,
-                stride_mask_m,
-                stride_mask_n,
-                BLOCK_M,
-                BLOCK_N,
-                q_block_id * BLOCK_M,
-                q_seq_len,
-            )
             q_block_start = q_block_id * BLOCK_M
             q_block_end = min(q_block_start + BLOCK_M, q_seq_len)
             q_block_len = q_block_end - q_block_start
+            q_mask = (q_block_start + tl.arange(0, BLOCK_M)[:, None]) < q_seq_len
 
-            # cur_q_block_ptr = tl.advance(q_block_ptr, (q_block_start.to(tl.int32), 0))
             cur_q_block_ptr = tl.make_block_ptr(
                 base=q_ptr + q_start * stride_qt + q_head_id * stride_qh,
                 shape=(q_seq_len, HEAD_DIM),
@@ -480,57 +426,32 @@ def _sdpa_infer_kernel(
                 LOCAL_WINDOW,
             )
 
-            for kv_block_id in range(num_global_window_blocks):
+            num_blocks_to_process = num_global_window_blocks + (num_total_blocks - non_global_window_start_block)
+
+            for idx in range(0, num_blocks_to_process):
+                is_non_global = (idx >= num_global_window_blocks).to(tl.int32)
+                kv_block_id = idx + is_non_global * (non_global_window_start_block - num_global_window_blocks)
                 kv_block_start = kv_block_id * BLOCK_N
-                kv_mask = gen_mask_n_right_bound(
-                    aux_mask_ptr_10,
-                    aux_mask_size,
-                    stride_mask_m,
-                    stride_mask_n,
-                    BLOCK_M,
-                    BLOCK_N,
-                    kv_block_start,
-                    kv_seq_len,
-                )
+                kv_mask = (kv_block_start + tl.arange(0, BLOCK_N)[None, :]) < kv_seq_len
+
                 if IS_CAUSAL:
-                    # actually, it must be true for global window blocks
-                    mask_gw = gen_mask_n_right_bound(
-                        aux_mask_ptr_10,
-                        aux_mask_size,
-                        stride_mask_m,
-                        stride_mask_n,
+                    q_pos = q_block_start + kv_computed_len
+                    mask = gen_mask_causal_with_window(
+                        causal_mask_ptr,
+                        causal_mask_m_size,
+                        causal_mask_n_size,
                         BLOCK_M,
                         BLOCK_N,
+                        q_pos,
                         kv_block_start,
                         GLOBAL_WINDOW,
+                        LOCAL_WINDOW,
+                        q_seq_len,
+                        kv_seq_len,
                     )
-                    if LOCAL_WINDOW is not None:
-                        mask_sw = gen_mask_triu(
-                            aux_mask_ptr_triu,
-                            aux_mask_size,
-                            stride_mask_m,
-                            stride_mask_n,
-                            BLOCK_M,
-                            BLOCK_N,
-                            q_block_start + kv_computed_len,
-                            kv_block_start + LOCAL_WINDOW,
-                        )
-                        mask_gw = mask_gw | mask_sw
-                    mask_causal = gen_mask_tril(
-                        aux_mask_ptr_tril,
-                        aux_mask_size,
-                        stride_mask_m,
-                        stride_mask_n,
-                        BLOCK_M,
-                        BLOCK_N,
-                        q_block_start + kv_computed_len,
-                        kv_block_start,
-                    )
-                    mask_causal = mask_gw & mask_causal
-                    mask = mask_causal & q_mask & kv_mask
                 else:
                     mask = q_mask & kv_mask
-                # cur_k_block_ptr = tl.advance(k_block_ptr, (kv_block_start.to(tl.int32), 0))
+
                 cur_k_block_ptr = tl.make_block_ptr(
                     base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
                     shape=(kv_seq_len, HEAD_DIM),
@@ -539,7 +460,6 @@ def _sdpa_infer_kernel(
                     block_shape=(BLOCK_N, BLOCK_D),
                     order=(1, 0),
                 )
-                # cur_v_block_ptr = tl.advance(v_block_ptr, (kv_block_start.to(tl.int32), 0))
                 cur_v_block_ptr = tl.make_block_ptr(
                     base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
                     shape=(kv_seq_len, HEAD_DIM),
@@ -565,80 +485,6 @@ def _sdpa_infer_kernel(
                     v_ptr.dtype.element_ty == tl.float8e5,
                 )
 
-            for kv_block_id in range(non_global_window_start_block, num_total_blocks):
-                kv_block_start = kv_block_id * BLOCK_N
-                kv_mask = gen_mask_n_right_bound(
-                    aux_mask_ptr_10,
-                    aux_mask_size,
-                    stride_mask_m,
-                    stride_mask_n,
-                    BLOCK_M,
-                    BLOCK_N,
-                    kv_block_start,
-                    kv_seq_len,
-                )
-                if IS_CAUSAL:
-                    mask_causal = gen_mask_tril(
-                        aux_mask_ptr_tril,
-                        aux_mask_size,
-                        stride_mask_m,
-                        stride_mask_n,
-                        BLOCK_M,
-                        BLOCK_N,
-                        q_block_start + kv_computed_len,
-                        kv_block_start,
-                    )
-                    if LOCAL_WINDOW is not None:
-                        mask_sw = gen_mask_triu(
-                            aux_mask_ptr_triu,
-                            aux_mask_size,
-                            stride_mask_m,
-                            stride_mask_n,
-                            BLOCK_M,
-                            BLOCK_N,
-                            q_block_start + kv_computed_len,
-                            kv_block_start + LOCAL_WINDOW,
-                        )
-                        mask_causal = mask_causal & mask_sw
-
-                    mask = mask_causal & q_mask & kv_mask
-                else:
-                    mask = q_mask & kv_mask
-                # cur_k_block_ptr = tl.advance(k_block_ptr, (kv_block_start.to(tl.int32), 0))
-                cur_k_block_ptr = tl.make_block_ptr(
-                    base=k_ptr + kv_start * stride_kt + kv_head_id * stride_kh,
-                    shape=(kv_seq_len, HEAD_DIM),
-                    strides=(stride_kt, stride_kd),
-                    offsets=(kv_block_start.to(tl.int32), 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                # cur_v_block_ptr = tl.advance(v_block_ptr, (kv_block_start.to(tl.int32), 0))
-                cur_v_block_ptr = tl.make_block_ptr(
-                    base=v_ptr + kv_start * stride_vt + kv_head_id * stride_vh,
-                    shape=(kv_seq_len, HEAD_DIM),
-                    strides=(stride_vt, stride_vd),
-                    offsets=(kv_block_start.to(tl.int32), 0),
-                    block_shape=(BLOCK_N, BLOCK_D),
-                    order=(1, 0),
-                )
-                acc, l_i, m_i = _sdpa_acc_fwd_MxN(
-                    acc,
-                    l_i,
-                    m_i,
-                    cur_q_block,
-                    cur_k_block_ptr,
-                    cur_v_block_ptr,
-                    mask,
-                    scale,
-                    HEAD_DIM,
-                    BLOCK_M,
-                    BLOCK_N,
-                    BLOCK_D,
-                    v_ptr.dtype.element_ty == tl.float8e5,
-                )
-
-            # cur_o_block_ptr = tl.advance(o_block_ptr, (q_block_start.to(tl.int32), 0))
             cur_o_block_ptr = tl.make_block_ptr(
                 base=o_ptr + q_start * stride_ot + q_head_id * stride_oh,
                 shape=(q_seq_len, HEAD_DIM),
@@ -663,7 +509,17 @@ def swa_infer_impl(
     softmax_scale: Optional[float] = None,
     gqa_interleave: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    mask_size, mask = get_aux_mask()
+    if global_window_size is None:
+        global_window_size = 0
+
+    causal_mask = get_mask_causal_with_window(
+        256,
+        256,
+        local_window_size,
+        global_window_size,
+    )
+    causal_mask_m_size, causal_mask_n_size = causal_mask.shape
+
     bsz = cu_q_lens.shape[0] - 1
     tot_q_toks, num_q_heads, head_dim = q.shape
     tot_kv_toks, num_kv_heads, _ = k.shape
@@ -705,10 +561,9 @@ def swa_infer_impl(
         v.stride(0),
         v.stride(1),
         v.stride(2),
-        mask,
-        mask_size,
-        mask.stride(0),
-        mask.stride(1),
+        causal_mask,
+        causal_mask_m_size,
+        causal_mask_n_size,
         is_causal,
         global_window_size,
         local_window_size,
@@ -720,6 +575,11 @@ def swa_infer_impl(
         BLOCK_N,
         BLOCK_D,
         enable_ubuf_saving=True,
+        limit_auto_multi_buffer_of_local_buffer="no-l0c",
+        limit_auto_multi_buffer_buffer="no-limit",
+        hfusion_enable_multiple_consumer_fusion=True,
+        intra_cache_num=3,
+        inter_cache_num=2,
     )
     return o
 

--- a/mojo_opset/tests/perf/test_sdpa_impl.py
+++ b/mojo_opset/tests/perf/test_sdpa_impl.py
@@ -1,0 +1,235 @@
+import math
+import os
+import sys
+import pytest
+import torch
+import torch_npu
+from mojo_opset.tests.utils import auto_switch_platform
+from mojo_opset.tests.utils import bypass_not_implemented
+
+from mojo_opset.backends.ttx.kernels import sdpa_fwd, sdpa_bwd
+
+
+def generate_diffusion_attention_mask(seq_length, block_size):
+    total_length = seq_length * 2
+    i = torch.arange(total_length).unsqueeze(1)
+    j = torch.arange(total_length).unsqueeze(0)
+    block_i = i // block_size
+    block_j = j // block_size
+
+    same_block = block_i == block_j
+    cross = (j >= seq_length) & (i < seq_length) & (((j - seq_length) // block_size) < block_i)
+    lower_tri = (i >= seq_length) & (j >= seq_length) & (block_j < block_i)
+
+    return same_block | cross | lower_tri
+
+
+def sdpa_fwd_ref(q, k, v, mask, scale, enable_gqa):
+    if enable_gqa:
+        group_size = q.shape[1] // k.shape[1]
+        k_exp = k.repeat_interleave(group_size, dim=1)
+        v_exp = v.repeat_interleave(group_size, dim=1)
+    else:
+        k_exp = k
+        v_exp = v
+
+    q_f32 = q.to(torch.float32)
+    k_f32 = k_exp.to(torch.float32)
+    v_f32 = v_exp.to(torch.float32)
+
+    scores = torch.matmul(q_f32, k_f32.transpose(-2, -1)) * scale
+    scores = scores.masked_fill(~mask, float("-inf"))
+    lse = torch.logsumexp(scores, dim=-1)
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v_f32).to(q.dtype)
+    return out, lse
+
+
+def sdpa_bwd_ref(q, k, v, do, mask, scale, enable_gqa):
+    q_f32 = q.to(torch.float32).clone().requires_grad_(True)
+    k_f32 = k.to(torch.float32).clone().requires_grad_(True)
+    v_f32 = v.to(torch.float32).clone().requires_grad_(True)
+    do_f32 = do.to(torch.float32)
+
+    if enable_gqa:
+        group_size = q.shape[1] // k.shape[1]
+        k_exp = k_f32.repeat_interleave(group_size, dim=1)
+        v_exp = v_f32.repeat_interleave(group_size, dim=1)
+    else:
+        k_exp = k_f32
+        v_exp = v_f32
+
+    scores = torch.matmul(q_f32, k_exp.transpose(-2, -1)) * scale
+    scores = scores.masked_fill(~mask, float("-inf"))
+    attn = torch.softmax(scores, dim=-1)
+    out = torch.matmul(attn, v_exp)
+
+    out.backward(do_f32)
+    return q_f32.grad, k_f32.grad, v_f32.grad
+
+
+def sdpa_npu_ref(q, k, v, mask, scale, enable_gqa):
+    q_head_num = q.shape[1]
+    kv_head_num = k.shape[1]
+
+    atten_mask = ~mask
+    if atten_mask.dim() == 2:
+        atten_mask = atten_mask.unsqueeze(0)
+
+    q1 = q.clone().detach().requires_grad_(True)
+    k1 = k.clone().detach().requires_grad_(True)
+    v1 = v.clone().detach().requires_grad_(True)
+    atten_mask= atten_mask.squeeze(0)
+    o = torch_npu.npu_fusion_attention(
+        q1,
+        k1,
+        v1,
+        atten_mask=atten_mask,
+        head_num=q_head_num,
+        scale=scale,
+        input_layout="BNSD",
+        sparse_mode=0,
+    )
+    out, softmax_max, softmax_sum = o[0], o[1][..., 0], o[2][..., 0]
+    lse = softmax_max + torch.log(softmax_sum)
+    return out, lse
+
+
+def sdpa_npu_bwd_ref(q, k, v, do, mask, scale, enable_gqa):
+    q_head_num = q.shape[1]
+
+    atten_mask = ~mask
+    if atten_mask.dim() == 2:
+        atten_mask = atten_mask.unsqueeze(0)
+    atten_mask = atten_mask.squeeze(0)
+
+    q1 = q.clone().detach().requires_grad_(True)
+    k1 = k.clone().detach().requires_grad_(True)
+    v1 = v.clone().detach().requires_grad_(True)
+
+    o = torch_npu.npu_fusion_attention(
+        q1,
+        k1,
+        v1,
+        atten_mask=atten_mask,
+        head_num=q_head_num,
+        scale=scale,
+        input_layout="BNSD",
+        sparse_mode=0,
+    )
+    out = o[0]
+    out.backward(do)
+    return q1.grad, k1.grad, v1.grad
+
+
+@pytest.mark.parametrize(
+    "bsz, q_head_num, kv_head_num, head_dim, seq_length, block_size",
+    [
+        (1, 5, 1, 128, 2048, 32),
+        (1, 8, 2, 128, 8192, 32),
+    ]
+)
+@auto_switch_platform(set_perf=True)
+@bypass_not_implemented
+def test_sdpa_impl(bsz, q_head_num, kv_head_num, head_dim, seq_length, block_size):
+    enable_gqa = q_head_num != kv_head_num
+    scale = 1.0 / math.sqrt(head_dim)
+
+    sdpa_fwd, sdpa_bwd, sdpa_npu_ref, sdpa_npu_bwd_ref, sdpa_bwd_ref = (
+        globals()["sdpa_fwd"], globals()["sdpa_bwd"], globals()["sdpa_npu_ref"],
+        globals()["sdpa_npu_bwd_ref"], globals()["sdpa_bwd_ref"],
+    )
+
+    device = torch.npu.current_device()
+
+    query_cpu = torch.randn(bsz, q_head_num, seq_length * 2, head_dim, dtype=torch.bfloat16)
+    key_cpu = torch.randn(bsz, kv_head_num, seq_length * 2, head_dim, dtype=torch.bfloat16)
+    value_cpu = torch.randn(bsz, kv_head_num, seq_length * 2, head_dim, dtype=torch.bfloat16)
+    mask_cpu = generate_diffusion_attention_mask(seq_length, block_size)
+
+    query = query_cpu.to(device)
+    key = key_cpu.to(device)
+    value = value_cpu.to(device)
+    mask = mask_cpu.to(device)
+
+    print(f"Shapes: q={query.shape}, k={key.shape}, v={value.shape}, mask={mask.shape}")
+    print(f"enable_gqa={enable_gqa}, scale={scale:.6f}")
+
+    # ---- Forward ----
+    o, lse = sdpa_fwd(query, key, value, mask, scale, gqa_enabled=enable_gqa)
+    o_ref, lse_ref = sdpa_fwd_ref(query_cpu, key_cpu, value_cpu, mask_cpu, scale, enable_gqa)
+
+    perf(lambda: sdpa_fwd(query, key, value, mask, scale, gqa_enabled=enable_gqa))
+    # perf(lambda: sdpa_fwd_ref(query_cpu, key_cpu, value_cpu, mask_cpu, scale, enable_gqa))
+
+    o_diff = (o.cpu().to(torch.float32) - o_ref.to(torch.float32)).abs()
+    lse_diff = (lse.cpu() - lse_ref).abs()
+    print(f"\n[Forward]")
+    print(f"  o   max_abs_diff={o_diff.max().item():.6f}  mean_abs_diff={o_diff.mean().item():.6f}")
+    print(f"  lse max_abs_diff={lse_diff.max().item():.6f}  mean_abs_diff={lse_diff.mean().item():.6f}")
+
+    torch.testing.assert_close(o.cpu(), o_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(lse.cpu(), lse_ref, atol=1e-2, rtol=1e-2)
+    print("  Forward PASSED")
+    #
+    # ---- Forward vs torch_npu.npu_fused_infer_attention_score ----
+
+    o_npu, lse_npu = sdpa_npu_ref(query, key, value, mask, scale, enable_gqa)
+    perf(lambda: sdpa_npu_ref(query, key, value, mask, scale, enable_gqa))
+
+    o_diff_npu = (o.cpu().to(torch.float32) - o_npu.cpu().to(torch.float32)).abs()
+    lse_diff_npu = (lse.cpu() - lse_npu.cpu()).abs()
+    print(f"\n[Forward vs torch_npu]")
+    print(f"  o   max_abs_diff={o_diff_npu.max().item():.6f}  mean_abs_diff={o_diff_npu.mean().item():.6f}")
+    print(f"  lse max_abs_diff={lse_diff_npu.max().item():.6f}  mean_abs_diff={lse_diff_npu.mean().item():.6f}")
+
+    torch.testing.assert_close(o.cpu(), o_npu.cpu(), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(lse.cpu(), lse_npu.cpu(), atol=1e-2, rtol=1e-2)
+
+    print("  Forward vs torch_npu PASSED")
+
+    # ---- Backward ----
+    do = torch.randn_like(o)
+
+    perf(lambda: sdpa_bwd(o, do, query, key, value, lse, mask, scale, gqa_enabled=enable_gqa))
+    perf(lambda: sdpa_npu_bwd_ref(query, key, value, do, mask, scale, enable_gqa))
+
+    dq, dk, dv = sdpa_bwd(o, do, query, key, value, lse, mask, scale, gqa_enabled=enable_gqa)
+
+    dq_ref, dk_ref, dv_ref = sdpa_bwd_ref(query_cpu, key_cpu, value_cpu, do.cpu(), mask_cpu, scale, enable_gqa)
+
+    dq_diff = (dq.cpu().to(torch.float32) - dq_ref.to(torch.float32)).abs()
+    dk_diff = (dk.cpu().to(torch.float32) - dk_ref.to(torch.float32)).abs()
+    dv_diff = (dv.cpu().to(torch.float32) - dv_ref.to(torch.float32)).abs()
+    print(f"\n[Backward]")
+    print(f"  dq max_abs_diff={dq_diff.max().item():.6f}  mean_abs_diff={dq_diff.mean().item():.6f}")
+    print(f"  dk max_abs_diff={dk_diff.max().item():.6f}  mean_abs_diff={dk_diff.mean().item():.6f}")
+    print(f"  dv max_abs_diff={dv_diff.max().item():.6f}  mean_abs_diff={dv_diff.mean().item():.6f}")
+
+    torch.testing.assert_close(dq.cpu().to(torch.float32), dq_ref.to(torch.float32), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(dk.cpu().to(torch.float32), dk_ref.to(torch.float32), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(dv.cpu().to(torch.float32), dv_ref.to(torch.float32), atol=1e-2, rtol=1e-2)
+    print("  Backward PASSED")
+
+    # ---- Backward vs torch_npu (fused backward via autograd) ----
+
+    dq_npu, dk_npu, dv_npu = sdpa_npu_bwd_ref(query, key, value, do, mask, scale, enable_gqa)
+
+    dq_diff_npu = (dq.cpu().to(torch.float32) - dq_npu.cpu().to(torch.float32)).abs()
+    dk_diff_npu = (dk.cpu().to(torch.float32) - dk_npu.cpu().to(torch.float32)).abs()
+    dv_diff_npu = (dv.cpu().to(torch.float32) - dv_npu.cpu().to(torch.float32)).abs()
+    print(f"\n[Backward vs torch_npu]")
+    print(f"  dq max_abs_diff={dq_diff_npu.max().item():.6f}  mean_abs_diff={dq_diff_npu.mean().item():.6f}")
+    print(f"  dk max_abs_diff={dk_diff_npu.max().item():.6f}  mean_abs_diff={dk_diff_npu.mean().item():.6f}")
+    print(f"  dv max_abs_diff={dv_diff_npu.max().item():.6f}  mean_abs_diff={dv_diff_npu.mean().item():.6f}")
+
+    torch.testing.assert_close(dq.cpu().to(torch.float32), dq_npu.cpu().to(torch.float32), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(dk.cpu().to(torch.float32), dk_npu.cpu().to(torch.float32), atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(dv.cpu().to(torch.float32), dv_npu.cpu().to(torch.float32), atol=1e-2, rtol=1e-2)
+    print("  Backward vs torch_npu PASSED")
+
+    print("\n========== All tests PASSED ==========")
+
+
+if __name__ == "__main__":
+    test_sdpa_impl(bsz=1, q_head_num=8, kv_head_num=2, head_dim=128, seq_length=8192, block_size=32)


### PR DESCRIPTION
**Perf: optimize operator performance and bugfix for kv_cache.py**
1. fused_add_rmsnorm.py:
   - Optimize grid core allocation strategy to improve parallelism.

2. sdpa.py:
   - Add test cases for sdpa_impl to ensure coverage.
   - Forward pass: Replace multiplication with 'where' for mask operation to eliminate the 'block_l_1' assignment.  Added A5 compiler parameters.
   - Backward pass: Move scale multiplication earlier to reduce fixpipe pressure. Added A5 compiler parameters.

3. quant.py:
   - Add block_size_n to autotune config.
   - Reorder load instructions: Move loads forward to enable parallel execution of two load operations.
4. swa.py
   - Combine mask
   - Added A5 compiler parameters.

**Bugfix:**
1. kv_cache.py:
   - In Triton-ascend 3.6 and ascendc, 'tl.load' no longer supports the 'care_padding' parameter.