### PR TITLE
[ttx/npu] optimize lightning_indexer_kernel by changing the position of k_scale

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/a2/lightning_indexer.py
+++ b/mojo_opset/backends/ttx/kernels/npu/a2/lightning_indexer.py
@@ -153,7 +153,7 @@ def lightning_indexer_kernel(
         q = tl.load(query_ptrs)
 
         mul_qk = tl.dot(q.to(k.dtype), tl.trans(k))
-        relu_qk = tl.maximum(mul_qk * k_scale[None, :], 0.0)
+        relu_qk = tl.maximum(mul_qk, 0.0)
 
         query_scale_ptrs = (
             query_scale_ptr
@@ -163,7 +163,7 @@ def lightning_indexer_kernel(
         )
         q_scale = tl.load(query_scale_ptrs)
 
-        o = tl.sum(relu_qk * q_scale[:, None], axis=0)
+        o = tl.sum(relu_qk * q_scale[:, None], axis=0)  * k_scale
 
         output_ptrs = (
             output_ptr

--- a/mojo_opset/experimental/operators/indexer.py
+++ b/mojo_opset/experimental/operators/indexer.py
@@ -108,7 +108,7 @@ class MojoIndexer(MojoOperator):
 
         self.wq_b = nn.Linear(q_lora_rank, n_heads * head_dim, bias=False)
         self.wk = nn.Linear(self.dim, self.head_dim, bias=False)
-        self.k_norm = MojoLayerNorm(self.head_dim)
+        self.k_norm = MojoLayerNorm._registry.get(self._backend)(self.head_dim)
         self.weights_proj = nn.Linear(self.dim, self.n_heads, bias=False)
 
         self.register_buffer(
@@ -122,10 +122,10 @@ class MojoIndexer(MojoOperator):
             persistent=False,
         )
 
-        self.rope = MojoApplyRoPE()
-        self.activation = MojoRotateActivation()
-        self.quant = MojoDynamicQuant()
-        self.lightning_indexer = MojoLightningIndexer()
+        self.rope = MojoApplyRoPE._registry.get(self._backend)()
+        self.activation = MojoRotateActivation._registry.get(self._backend)()
+        self.quant = MojoDynamicQuant._registry.get(self._backend)()
+        self.lightning_indexer = MojoLightningIndexer._registry.get(self._backend)()
 
     def forward(
         self,

--- a/mojo_opset/experimental/operators/indexer.py
+++ b/mojo_opset/experimental/operators/indexer.py
@@ -71,12 +71,11 @@ class MojoLightningIndexer(MojoOperator):
 
         for batch_id in range(batch_size):
             key_batch = key[batch_id].to(torch.float32)  # [N, K]
-            key_scale_batch = key_scale[batch_id].unsqueeze(-1)  # [N, 1]
-            key_scaled = key_batch * key_scale_batch  # [N, K]
+            key_scale_batch = key_scale[batch_id]  # [N]
 
             for i in range(q_seq_len):
                 q_slice = query[batch_id, i].to(torch.float32)  # [H, K]
-                dot_product = torch.matmul(q_slice, key_scaled.transpose(0, 1))  # [H, N]
+                dot_product = torch.matmul(q_slice, key_batch.transpose(0, 1)) * key_scale_batch  # [H, N]
                 relu_out = torch.maximum(dot_product, torch.tensor(0.0))
                 q_scale_slice = query_scale[batch_id, i].unsqueeze(-1)  # [H, 1]
                 scaled_out = relu_out * q_scale_slice

--- a/mojo_opset/experimental/operators/indexer.py
+++ b/mojo_opset/experimental/operators/indexer.py
@@ -75,11 +75,11 @@ class MojoLightningIndexer(MojoOperator):
 
             for i in range(q_seq_len):
                 q_slice = query[batch_id, i].to(torch.float32)  # [H, K]
-                dot_product = torch.matmul(q_slice, key_batch.transpose(0, 1)) * key_scale_batch  # [H, N]
+                dot_product = torch.matmul(q_slice, key_batch.transpose(0, 1))  # [H, N]
                 relu_out = torch.maximum(dot_product, torch.tensor(0.0))
                 q_scale_slice = query_scale[batch_id, i].unsqueeze(-1)  # [H, 1]
                 scaled_out = relu_out * q_scale_slice
-                index_score[batch_id, i] = torch.sum(scaled_out, dim=0)
+                index_score[batch_id, i] = torch.sum(scaled_out, dim=0) * key_scale_batch
 
         return index_score
 


### PR DESCRIPTION
According to the original version of LightningIndexer, the computation order should be: qk_dot -> relu -> q_scale -> sum -> k_scale