### PR TITLE
[NPU] performance optimization for layernorm and gelu

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/gelu.py
+++ b/mojo_opset/backends/ttx/kernels/npu/gelu.py
@@ -1,17 +1,18 @@
 import torch
 import triton
 import triton.language as tl
-try:
-    import triton.language.extra.cann.libdevice as libdevice
-except ModuleNotFoundError:
-    libdevice = tl
 
-from .utils import get_num_cores, libentry
+from .utils import libentry
+
+from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES
+from mojo_opset.backends.ttx.kernels.utils import align
 
 """
 This file contains the implementation of GELU (Gaussian Error Linear Unit) for NPU.
 
-GELU formula: gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+GELU formula: gelu(x) = x * sigmoid(2 * sqrt(2/pi) * (x + 0.044715 * x^3))
+                    = x / (1 + exp(-x * (c + k * x^2)))
+  where c = 2 * sqrt(2/pi), k = c * 0.044715
 
 Based on Liger Kernel implementation:
 https://github.com/linkedin/Liger-Kernel/blob/main/src/liger_kernel/ops/geglu.py
@@ -20,37 +21,73 @@ Modifications for NPU architecture by triton-x team, 2025.
 """
 
 
+COL_BLOCKING_THRESHOLD = 4096
+FWD_2D_THRESHOLD = 10240
 MAX_BLOCK_SIZE_N = 1024
-
-
-GELU_TANH_BLOCK_SIZE_M_CONFIGS = [
-    triton.Config({"BLOCK_SIZE_M": 1}),
-    triton.Config({"BLOCK_SIZE_M": 2}),
-    triton.Config({"BLOCK_SIZE_M": 4}),
-    triton.Config({"BLOCK_SIZE_M": 8}),
-]
-
-GELU_TANH_MAX_BLOCK_SIZE_M = max(
-    config.kwargs["BLOCK_SIZE_M"] for config in GELU_TANH_BLOCK_SIZE_M_CONFIGS
-)
 
 
 @triton.jit
 def gelu_tanh_approx(x):
-    """GELU activation using tanh approximation."""
-    sqrt_2_over_pi = 0.7978845608028654  # sqrt(2 / pi)
-    x_cubed = x * x * x
-    tanh_arg = sqrt_2_over_pi * (x + 0.044715 * x_cubed)
-    return 0.5 * x * (1 + libdevice.tanh(tanh_arg))
+    """GELU activation using sigmoid (exp) approximation."""
+    c = 1.5957691216057308   # 2 * sqrt(2/pi)
+    k = 0.07135481627260025  # c * 0.044715
+    x_sq = x * x
+    inner = x * (c + k * x_sq)
+    return x / (1 + tl.math.exp(-inner))
 
 
 @triton.autotune(
-    configs=GELU_TANH_BLOCK_SIZE_M_CONFIGS,
-    key=["n_rows", "n_cols"],
+    configs=[
+        triton.Config({"BLOCK_SIZE": 2048}),
+        triton.Config({"BLOCK_SIZE": 4096}),
+        triton.Config({"BLOCK_SIZE": 8192}),
+        triton.Config({"BLOCK_SIZE": 16384}),
+    ],
+    key=["n_elements"],
 )
 @libentry()
 @triton.jit
 def _gelu_fwd_kernel(
+    x,
+    y,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    1D flattened GELU kernel.
+    """
+    pid = tl.program_id(axis=0)
+    grid_size = tl.num_programs(axis=0)
+
+    num_blocks = tl.cdiv(n_elements, BLOCK_SIZE)
+
+    for block_id in range(pid, num_blocks, grid_size):
+        offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x_chunk = tl.load(x + offsets, mask=mask, other=0.0)
+        x_f32 = x_chunk.to(tl.float32)
+        y_f32 = gelu_tanh_approx(x_f32)
+        y_chunk = y_f32.to(x_chunk.dtype)
+        tl.store(y + offsets, y_chunk, mask=mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE_M": 1}),
+        triton.Config({"BLOCK_SIZE_M": 2}),
+        triton.Config({"BLOCK_SIZE_M": 4}),
+        triton.Config({"BLOCK_SIZE_M": 8}),
+        triton.Config({"BLOCK_SIZE_M": 12}),
+        triton.Config({"BLOCK_SIZE_M": 16}),
+        triton.Config({"BLOCK_SIZE_M": 20}),
+        triton.Config({"BLOCK_SIZE_M": 24}),
+        triton.Config({"BLOCK_SIZE_M": 32}),
+    ],
+    key=["n_rows", "n_cols"],
+)
+@libentry()
+@triton.jit
+def _gelu_fwd_2d_kernel(
     x,
     y,
     stride_row,
@@ -58,7 +95,12 @@ def _gelu_fwd_kernel(
     n_cols,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
+    COL_ALIGNED: tl.constexpr,
 ):
+    """
+    2D GELU kernel for large column counts (n_cols > FWD_2D_THRESHOLD).
+    Iterates over column blocks per row block to avoid loading entire rows at once.
+    """
     pid = tl.program_id(axis=0)
     grid_size = tl.num_programs(axis=0)
 
@@ -71,98 +113,42 @@ def _gelu_fwd_kernel(
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            cols_mask = cols_off < n_cols
-            block_mask = rows_mask[:, None] & cols_mask[None, :]
 
             x_ptrs = x + rows_off[:, None] * stride_row + cols_off[None, :]
             y_ptrs = y + rows_off[:, None] * stride_row + cols_off[None, :]
 
-            x_chunk = tl.load(x_ptrs, mask=block_mask, other=0.0)
+            if COL_ALIGNED:
+                rows_only_mask = rows_mask[:, None]
+                x_chunk = tl.load(x_ptrs, mask=rows_only_mask, other=0.0)
+            else:
+                cols_mask = cols_off < n_cols
+                block_mask = rows_mask[:, None] & cols_mask[None, :]
+                x_chunk = tl.load(x_ptrs, mask=block_mask, other=0.0)
 
-            x_f32 = x_chunk.to(tl.float32)
-            y_f32 = gelu_tanh_approx(x_f32)
-
-            y_chunk = y_f32.to(x_chunk.dtype)
-
-            tl.store(y_ptrs, y_chunk, mask=block_mask)
-
-
-@triton.autotune(
-    configs=GELU_TANH_BLOCK_SIZE_M_CONFIGS,
-    key=["n_rows", "n_cols"],
-)
-@libentry()
-@triton.jit
-def _gelu_fwd_nomask_kernel(
-    x,
-    y,
-    stride_row,
-    n_rows,
-    n_cols,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-):
-    pid = tl.program_id(axis=0)
-    grid_size = tl.num_programs(axis=0)
-
-    num_row_tasks = (n_rows + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M
-
-    for row_task_id in range(pid, num_row_tasks, grid_size):
-        block_start_row = row_task_id * BLOCK_SIZE_M
-        rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
-
-        for col_offset in range(0, n_cols, BLOCK_SIZE_N):
-            cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-
-            x_ptrs = x + rows_off[:, None] * stride_row + cols_off[None, :]
-            y_ptrs = y + rows_off[:, None] * stride_row + cols_off[None, :]
-
-            x_chunk = tl.load(x_ptrs)
             x_f32 = x_chunk.to(tl.float32)
             y_f32 = gelu_tanh_approx(x_f32)
             y_chunk = y_f32.to(x_chunk.dtype)
 
-            tl.store(y_ptrs, y_chunk)
+            if COL_ALIGNED:
+                tl.store(y_ptrs, y_chunk, mask=rows_mask[:, None])
+            else:
+                cols_mask = cols_off < n_cols
+                block_mask = rows_mask[:, None] & cols_mask[None, :]
+                tl.store(y_ptrs, y_chunk, mask=block_mask)
 
 
 @triton.autotune(
-    configs=GELU_TANH_BLOCK_SIZE_M_CONFIGS,
-    key=["n_rows", "n_cols"],
-)
-@libentry()
-@triton.jit
-def _gelu_fwd_nomask_single_kernel(
-    x,
-    y,
-    stride_row,
-    n_rows,
-    n_cols,
-    BLOCK_SIZE_N: tl.constexpr,
-    BLOCK_SIZE_M: tl.constexpr,
-):
-    pid = tl.program_id(axis=0)
-    grid_size = tl.num_programs(axis=0)
-
-    num_row_tasks = (n_rows + BLOCK_SIZE_M - 1) // BLOCK_SIZE_M
-    cols_off = tl.arange(0, BLOCK_SIZE_N)
-
-    for row_task_id in range(pid, num_row_tasks, grid_size):
-        block_start_row = row_task_id * BLOCK_SIZE_M
-        rows_off = block_start_row + tl.arange(0, BLOCK_SIZE_M)
-
-        x_ptrs = x + rows_off[:, None] * stride_row + cols_off[None, :]
-        y_ptrs = y + rows_off[:, None] * stride_row + cols_off[None, :]
-
-        x_chunk = tl.load(x_ptrs)
-        x_f32 = x_chunk.to(tl.float32)
-        y_f32 = gelu_tanh_approx(x_f32)
-        y_chunk = y_f32.to(x_chunk.dtype)
-
-        tl.store(y_ptrs, y_chunk)
-
-
-@triton.autotune(
-    configs=GELU_TANH_BLOCK_SIZE_M_CONFIGS,
+    configs=[
+        triton.Config({"BLOCK_SIZE_M": 1}),
+        triton.Config({"BLOCK_SIZE_M": 2}),
+        triton.Config({"BLOCK_SIZE_M": 4}),
+        triton.Config({"BLOCK_SIZE_M": 8}),
+        triton.Config({"BLOCK_SIZE_M": 12}),
+        triton.Config({"BLOCK_SIZE_M": 16}),
+        triton.Config({"BLOCK_SIZE_M": 20}),
+        triton.Config({"BLOCK_SIZE_M": 24}),
+        triton.Config({"BLOCK_SIZE_M": 32}),
+    ],
     key=["n_rows", "n_cols"],
     restore_value=["dy", "dx"],
 )
@@ -177,6 +163,7 @@ def _gelu_bwd_kernel(
     n_cols,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
+    COL_ALIGNED: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     grid_size = tl.num_programs(axis=0)
@@ -190,105 +177,83 @@ def _gelu_bwd_kernel(
 
         for col_offset in range(0, n_cols, BLOCK_SIZE_N):
             cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
-            cols_mask = cols_off < n_cols
-            block_mask = rows_mask[:, None] & cols_mask[None, :]
 
             dy_ptrs = dy + rows_off[:, None] * stride_row + cols_off[None, :]
             x_ptrs = x + rows_off[:, None] * stride_row + cols_off[None, :]
             dx_ptrs = dx + rows_off[:, None] * stride_row + cols_off[None, :]
 
-            dy_chunk = tl.load(dy_ptrs, mask=block_mask, other=0.0)
-            x_chunk = tl.load(x_ptrs, mask=block_mask, other=0.0)
+            if COL_ALIGNED:
+                rows_only_mask = rows_mask[:, None]
+                dy_chunk = tl.load(dy_ptrs, mask=rows_only_mask, other=0.0)
+                x_chunk = tl.load(x_ptrs, mask=rows_only_mask, other=0.0)
+            else:
+                cols_mask = cols_off < n_cols
+                block_mask = rows_mask[:, None] & cols_mask[None, :]
+                dy_chunk = tl.load(dy_ptrs, mask=block_mask, other=0.0)
+                x_chunk = tl.load(x_ptrs, mask=block_mask, other=0.0)
 
             x_f32 = x_chunk.to(tl.float32)
-            sqrt_2_over_pi = 0.7978845608028654
-            x_cubed = x_f32 * x_f32 * x_f32
-            tanh_arg = sqrt_2_over_pi * (x_f32 + 0.044715 * x_cubed)
-            tanh_result = libdevice.tanh(tanh_arg)
+            c_fwd = 1.5957691216057308       # 2 * sqrt(2/pi)
+            k_fwd = 0.07135481627260025      # c_fwd * 0.044715
+            c_orig = 0.7978845608028654      # sqrt(2/pi)
+            kkk = 0.10703222440890038        # 3 * c_orig * 0.044715
 
-            term1 = 0.5 * (1 + tanh_result)
-            tanh_sq = tanh_result * tanh_result
-            term2 = (
-                0.5
-                * x_f32
-                * (1 - tanh_sq)
-                * (sqrt_2_over_pi * (1 + 3 * 0.044715 * x_f32 * x_f32))
-            )
-            dgelu_dx = term1 + term2
+            x_sq = x_f32 * x_f32
+            inner = x_f32 * (c_fwd + k_fwd * x_sq)
+            s = 1.0 / (1.0 + tl.math.exp(-inner))
+            dy_dx = c_orig + kkk * x_sq
+            s_mul_1_minus_s = s * (1.0 - s)
+            dgelu_dx = s + 2.0 * x_f32 * s_mul_1_minus_s * dy_dx
 
             dx_chunk = dy_chunk * dgelu_dx.to(dy_chunk.dtype)
 
-            tl.store(dx_ptrs, dx_chunk, mask=block_mask)
-
-
-def _rowwise_block_size_n(n_cols):
-    return min(triton.next_power_of_2(n_cols), MAX_BLOCK_SIZE_N)
-
-
-def _rowwise_grid(n_rows, block_size_m):
-    num_row_tasks = (n_rows + block_size_m - 1) // block_size_m
-    return (max(1, min(get_num_cores("vector"), num_row_tasks)),)
-
-
-def _rowwise_autotune_grid(n_rows):
-    return lambda META: _rowwise_grid(n_rows, META["BLOCK_SIZE_M"])
-
-
-def _can_use_nomask_kernel(n_rows, n_cols, block_size_n):
-    return n_cols % block_size_n == 0 and n_rows % GELU_TANH_MAX_BLOCK_SIZE_M == 0
-
-
-def _can_use_nomask_single_kernel(n_rows, n_cols, block_size_n):
-    return n_cols == block_size_n and n_rows % GELU_TANH_MAX_BLOCK_SIZE_M == 0
+            if COL_ALIGNED:
+                tl.store(dx_ptrs, dx_chunk, mask=rows_mask[:, None])
+            else:
+                cols_mask = cols_off < n_cols
+                block_mask = rows_mask[:, None] & cols_mask[None, :]
+                tl.store(dx_ptrs, dx_chunk, mask=block_mask)
 
 
 def gelu_fwd_impl(x: torch.Tensor) -> torch.Tensor:
     """
     Forward pass for GELU.
 
-    Args:
-        x: Input tensor
-
-    Returns:
-        y: Output tensor y = gelu(x)
+    Uses 1D flattened kernel by default; switches to 2D row-blocked kernel
+    when the last dimension exceeds FWD_2D_THRESHOLD to avoid excessive memory.
     """
     ori_shape = x.shape
     n_cols = ori_shape[-1]
 
-    x_2d = x.reshape(-1, n_cols)
-    n_rows = x_2d.shape[0]
+    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
+    grid = (num_programs,)
 
-    y = torch.empty_like(x_2d)
+    if n_cols > FWD_2D_THRESHOLD:
+        x_2d = x.reshape(-1, n_cols)
+        n_rows = x_2d.shape[0]
+        y = torch.empty_like(x_2d)
 
-    block_size_n = _rowwise_block_size_n(n_cols)
-    grid = _rowwise_autotune_grid(n_rows)
+        BLOCK_SIZE_N = min(triton.next_power_of_2(n_cols), MAX_BLOCK_SIZE_N)
+        col_aligned = (n_cols % BLOCK_SIZE_N) == 0
 
-    if _can_use_nomask_single_kernel(n_rows, n_cols, block_size_n):
-        _gelu_fwd_nomask_single_kernel[grid](
+        _gelu_fwd_2d_kernel[grid](
             x_2d,
             y,
             x_2d.stride(0),
             n_rows,
             n_cols,
-            BLOCK_SIZE_N=block_size_n,
-        )
-    elif _can_use_nomask_kernel(n_rows, n_cols, block_size_n):
-        _gelu_fwd_nomask_kernel[grid](
-            x_2d,
-            y,
-            x_2d.stride(0),
-            n_rows,
-            n_cols,
-            BLOCK_SIZE_N=block_size_n,
+            BLOCK_SIZE_N=BLOCK_SIZE_N,
+            COL_ALIGNED=col_aligned,
         )
     else:
+        x_1d = x.reshape(-1).contiguous()
+        n_elements = x_1d.numel()
+        y = torch.empty_like(x_1d)
+
         _gelu_fwd_kernel[grid](
-            x_2d,
+            x_1d,
             y,
-            x_2d.stride(0),
-            n_rows,
-            n_cols,
-            BLOCK_SIZE_N=block_size_n,
+            n_elements,
         )
 
     return y.reshape(*ori_shape)
@@ -317,8 +282,13 @@ def gelu_bwd_impl(
 
     dx = torch.empty_like(x_2d)
 
-    block_size_n = _rowwise_block_size_n(n_cols)
-    grid = _rowwise_autotune_grid(n_rows)
+    if n_cols > COL_BLOCKING_THRESHOLD:
+        BLOCK_SIZE_N = 2048
+    else:
+        BLOCK_SIZE_N = align(dy, n_cols, VEC_ALIGN_BYTES)
+    col_aligned = (n_cols % BLOCK_SIZE_N) == 0
+    num_programs = triton.runtime.driver.active.utils.get_device_properties("npu")["num_vectorcore"]
+    grid = (num_programs,)
 
     _gelu_bwd_kernel[grid](
         dy_2d,
@@ -327,7 +297,8 @@ def gelu_bwd_impl(
         dy_2d.stride(0),
         n_rows,
         n_cols,
-        BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        COL_ALIGNED=col_aligned,
     )
 
     return dx.reshape(*ori_shape)

--- a/mojo_opset/backends/ttx/kernels/npu/layernorm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/layernorm.py
@@ -8,7 +8,8 @@ from mojo_opset.backends.ttx.kernels.npu.utils import VEC_ALIGN_BYTES
 from mojo_opset.backends.ttx.kernels.utils import align, ceil_div, torch_to_triton_dtype
 
 COL_BLOCKING_THRESHOLD = 2048
-
+SINGLE_PASS_THRESHOLD = 2048
+TWO_PASS_BLOCK_SIZE_N = 4096
 TOKEN_BLOCK_SIZE_TABLE = {
     2048: 4,
     1024: 8,
@@ -65,7 +66,19 @@ def layer_norm_fwd_heuristics(args):
     return 4
 
 
-@triton.heuristics({"BLOCK_SIZE_M": layer_norm_fwd_heuristics})
+def layer_norm_fwd_two_pass_heuristics(args):
+    hidden_dim = args["n_cols"]
+    if hidden_dim <= COL_BLOCKING_THRESHOLD:
+        if hidden_dim in TOKEN_BLOCK_SIZE_TABLE:
+            return TOKEN_BLOCK_SIZE_TABLE[hidden_dim]
+        for dim_thresh, block_size in sorted(TOKEN_BLOCK_SIZE_TABLE.items()):
+            if hidden_dim <= dim_thresh:
+                return block_size
+        return 1
+    else:
+        return 2
+
+
 @libentry()
 @triton.jit
 def _layernorm_fwd_kernel(
@@ -79,11 +92,12 @@ def _layernorm_fwd_kernel(
     stride_y_row,
     n_rows,
     n_cols,
-    eps,
+    eps: tl.constexpr,
     DROP_COLS_MASK: tl.constexpr,
     DROP_ROWS_MASK: tl.constexpr,
     STORE_STATS: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_N_PASS1: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
 ):
     pid = tl.program_id(0)
@@ -104,8 +118,8 @@ def _layernorm_fwd_kernel(
         X_ptr_row_block = X_ptr + rows_off[:, None] * stride_x_row
         Y_ptr_row_block = Y_ptr + rows_off[:, None] * stride_y_row
 
-        for col_offset in range(0, n_cols, BLOCK_SIZE_N):
-            cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N)
+        for col_offset in range(0, n_cols, BLOCK_SIZE_N_PASS1):
+            cols_off = col_offset + tl.arange(0, BLOCK_SIZE_N_PASS1)
 
             if DROP_ROWS_MASK:
                 if DROP_COLS_MASK:
@@ -214,7 +228,7 @@ def _layernorm_fwd_single_pass_kernel(
     stride_y_row,
     n_rows,
     n_cols,
-    eps,
+    eps: tl.constexpr,
     DROP_COLS_MASK: tl.constexpr,
     DROP_ROWS_MASK: tl.constexpr,
     STORE_STATS: tl.constexpr,
@@ -507,13 +521,15 @@ def _launch_layernorm_fwd_kernel(
     block_size_n,
     store_stats: bool,
 ):
-    block_size_m = layer_norm_fwd_heuristics(
-        {"n_rows": n_rows, "n_cols": n_cols, "x_dtype": x_2d.dtype}
+    block_size_m = layer_norm_fwd_two_pass_heuristics(
+        {"n_cols": n_cols}
     )
     drop_cols_mask = n_cols % block_size_n == 0
     drop_rows_mask = n_rows % block_size_m == 0
-    use_single_pass = n_cols <= block_size_n
-    grid = _layernorm_fwd_grid(n_rows, n_cols, x_2d.dtype)
+    block_size_n_pass1 = 8192 if n_cols <= 8192 else TWO_PASS_BLOCK_SIZE_N
+    use_single_pass = n_cols <= SINGLE_PASS_THRESHOLD
+    num_programs = get_num_cores()
+    grid = (num_programs,)
 
     if use_single_pass:
         _layernorm_fwd_single_pass_kernel[grid](
@@ -551,6 +567,8 @@ def _launch_layernorm_fwd_kernel(
         DROP_ROWS_MASK=drop_rows_mask,
         STORE_STATS=store_stats,
         BLOCK_SIZE_N=block_size_n,
+        BLOCK_SIZE_N_PASS1=block_size_n_pass1,
+        BLOCK_SIZE_M=block_size_m,
     )
 
 
@@ -565,10 +583,10 @@ def layernorm_infer_impl(
     x_2d = hidden_states.reshape(-1, dim)
     n_rows, n_cols = x_2d.shape
 
-    if n_cols > COL_BLOCKING_THRESHOLD:
-        BLOCK_SIZE_N = 2048
+    if n_cols <= SINGLE_PASS_THRESHOLD:
+        BLOCK_SIZE_N = triton.next_power_of_2(n_cols)
     else:
-        BLOCK_SIZE_N = align(hidden_states, n_cols, VEC_ALIGN_BYTES)
+        BLOCK_SIZE_N = TWO_PASS_BLOCK_SIZE_N
 
     y = torch.empty_like(x_2d)
 
@@ -595,10 +613,10 @@ def layernorm_fwd_impl(x, w, b, eps):
     x_2d = x.reshape(-1, dim)
     n_rows, n_cols = x_2d.shape
 
-    if n_cols > COL_BLOCKING_THRESHOLD:
-        BLOCK_SIZE_N = 2048
+    if n_cols  <= SINGLE_PASS_THRESHOLD:
+        BLOCK_SIZE_N = triton.next_power_of_2(n_cols)
     else:
-        BLOCK_SIZE_N = align(x, n_cols, VEC_ALIGN_BYTES)
+        BLOCK_SIZE_N = TWO_PASS_BLOCK_SIZE_N
 
     y = torch.empty_like(x_2d)
     mean = torch.empty(n_rows, dtype=torch.float32, device=x.device)
@@ -618,7 +636,7 @@ def layernorm_bwd_impl(dy, x_2d, w, b, mean, rstd):
     n_rows, n_cols = dy_2d.shape
 
     if n_cols > COL_BLOCKING_THRESHOLD:
-        BLOCK_SIZE_N = 2048
+        BLOCK_SIZE_N = TWO_PASS_BLOCK_SIZE_N
     else:
         BLOCK_SIZE_N = align(x_2d, n_cols, VEC_ALIGN_BYTES)
 


### PR DESCRIPTION
[NPU] performance optimization
1. layernorm: Optimize grid core allocation strategy
2. gelu forward: 1d flatten for small shapes; Add more block_size_m config in autotune
3. gelu backward: Formula update(tanh->exp); Remove redundant mask