### PR TITLE
optimize sdpa_bwd

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/convolution.py
+++ b/mojo_opset/backends/ttx/kernels/npu/convolution.py
@@ -664,18 +664,9 @@ def causal_conv1d_update_kernel_bdt_fwd(
         bi = bti // NUM_T_CHK
         ti = bti % NUM_T_CHK
 
-        w = tl.load(
-            tl.make_block_ptr(
-                weight_ptr,
-                shape=(dim, width),
-                strides=(width, 1),
-                offsets=(di * D_CHK_SIZE, 0),
-                block_shape=(D_CHK_SIZE, width),
-                order=(1, 0),
-            ),
-            boundary_check=(0, 1),
-            padding_option="zero",
-        )
+        w_off_d = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)[:, None]
+        w_off_w = tl.arange(0, width)[None, :]
+        w = tl.load(weight_ptr + w_off_d * width + w_off_w).to(tl.float32)
 
         if ti == 0:
             st_b = tl.load(
@@ -690,69 +681,72 @@ def causal_conv1d_update_kernel_bdt_fwd(
                 boundary_check=(0, 1),
                 padding_option="zero",
             )
-            offset0_x = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)
-            offset1_x = ti * T_CHK_SIZE + tl.arange(0, T_CHK_SIZE)
-            mask_x = (offset0_x < dim)[:, None] & ((offset1_x >= 0) & (offset1_x < seq_len))[None, :]
-            block_off_x = bi * dim * seq_len + offset0_x[:, None] * seq_len + offset1_x[None, :]
-            x_b_tmp = tl.load(x_ptr + block_off_x, mask=mask_x, other=0)
+            x_b_tmp = tl.load(
+                tl.make_block_ptr(
+                    x_ptr + bi * dim * seq_len,
+                    shape=(dim, seq_len),
+                    strides=(seq_len, 1),
+                    offsets=(di * D_CHK_SIZE, 0),
+                    block_shape=(D_CHK_SIZE, T_CHK_SIZE),
+                    order=(1, 0),
+                ),
+                boundary_check=(0, 1),
+                padding_option="zero",
+            )
             x_b = tl.extra.cann.extension.insert_slice(st_b, x_b_tmp, (0, width - 1), (D_CHK_SIZE, T_CHK_SIZE), (1, 1))
         else:
-            offset0 = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)
-            offset1 = ti * T_CHK_SIZE - (width - 1) + tl.arange(0, T_CHK_SIZE + width - 1)
-            mask = (offset0 < dim)[:, None] & ((offset1 >= 0) & (offset1 < seq_len))[None, :]
-            block_off = bi * dim * seq_len + offset0[:, None] * seq_len + offset1[None, :]
-            x_b = tl.load(x_ptr + block_off, mask=mask, other=0)
+            x_b = tl.load(
+                tl.make_block_ptr(
+                    x_ptr + bi * dim * seq_len,
+                    shape=(dim, seq_len),
+                    strides=(seq_len, 1),
+                    offsets=(di * D_CHK_SIZE, ti * T_CHK_SIZE - (width - 1)),
+                    block_shape=(D_CHK_SIZE, T_CHK_SIZE + width - 1),
+                    order=(1, 0),
+                ),
+                boundary_check=(0, 1),
+                padding_option="zero",
+            )
 
-        out_block = tl.zeros((T_CHK_SIZE, D_CHK_SIZE), dtype=x_ptr.dtype.element_ty)
-        x_b = tl.trans(x_b, (1, 0))
-        w = tl.trans(w, (1, 0))
+        out_block = tl.zeros((D_CHK_SIZE, T_CHK_SIZE), dtype=tl.float32)
+        x_b = x_b.to(tl.float32)
 
         new_state_start_off = seq_len - state_len
         t_start_off = ti * T_CHK_SIZE - (width - 1)
         t_end_off = (ti + 1) * T_CHK_SIZE
         if t_end_off >= new_state_start_off:
-            t_off = t_start_off - new_state_start_off
-            if t_off < -(width - 1):
-                # NOTE: In order to avoid use tl.maximum for negative offset,
-                #       we pre-compute a fix head tile size (ST_STORE_HEAD_TILE_SIZE)
-                #       to store the scene of negative address
-                x_new_h = tl.extra.cann.extension.extract_slice(x_b, (-t_off, 0), (ST_STORE_HEAD_TILE_SIZE, D_CHK_SIZE), (1, 1))
-                x_new_h = tl.trans(x_new_h, (1, 0))
-                nst_off_y0 = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)[:, None]
-                nst_off_y1_h = tl.arange(0, ST_STORE_HEAD_TILE_SIZE)[None, :]
-                nst_mask_h = (nst_off_y0 < dim) & (nst_off_y1_h >= 0) & (nst_off_y1_h < state_len)
-                block_ptr_h = bi * dim * state_len + nst_off_y0 * state_len + nst_off_y1_h
-                tl.store(conv_state_update_ptr + block_ptr_h, x_new_h, mask=nst_mask_h)
-            else:
-                x_new_s = tl.extra.cann.extension.extract_slice(x_b, (width - 1, 0), (T_CHK_SIZE, D_CHK_SIZE), (1, 1))
-                x_new_s = tl.trans(x_new_s, (1, 0))
-                nst_off_y0 = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)[:, None]
-                nst_off_y1 = width - 1 + t_off + tl.arange(0, T_CHK_SIZE)[None, :]
-                nst_mask = (nst_off_y0 < dim) & (nst_off_y1 >= 0) & (nst_off_y1 < state_len)
-                block_ptr = bi * dim * state_len + nst_off_y0 * state_len + nst_off_y1
-                tl.store(conv_state_update_ptr + block_ptr, x_new_s, mask=nst_mask)
+            nst_off_y0 = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)[:, None]
+            nst_off_y1 = tl.arange(0, state_len)[None, :]
+            nst_mask = (nst_off_y0 < dim) & (nst_off_y1 < state_len)
+            block_ptr_st = bi * dim * state_len + nst_off_y0 * state_len + nst_off_y1
+
+            if new_state_start_off < 0:
+                cs_src_idx = seq_len + nst_off_y1
+                cs_mask = nst_mask & (cs_src_idx < state_len) & (cs_src_idx >= 0)
+                cs_off = bi * dim * state_len + nst_off_y0 * state_len + cs_src_idx
+                cs_val = tl.load(conv_state_ptr + cs_off, mask=cs_mask, other=0).to(conv_state_update_ptr.dtype.element_ty)
+                tl.store(conv_state_update_ptr + block_ptr_st, cs_val, mask=cs_mask)
+
+            src_col_off = new_state_start_off - t_start_off + nst_off_y1
+            src_valid = (src_col_off >= 0) & (src_col_off < T_CHK_SIZE + width - 1)
+            x_st_off = bi * dim * seq_len + nst_off_y0 * seq_len + (new_state_start_off + nst_off_y1)
+            x_st_mask = nst_mask & src_valid & ((new_state_start_off + nst_off_y1) < seq_len) & ((new_state_start_off + nst_off_y1) >= 0)
+            x_st = tl.load(x_ptr + x_st_off, mask=x_st_mask, other=0).to(conv_state_update_ptr.dtype.element_ty)
+            tl.store(conv_state_update_ptr + block_ptr_st, x_st, mask=x_st_mask)
 
         for owi in tl.range(0, width):
-            new_x = tl.extra.cann.extension.extract_slice(x_b, (owi, 0), (T_CHK_SIZE, D_CHK_SIZE), (1, 1))
-            w_chl_wi = tl.extra.cann.extension.extract_slice(w, (owi, 0), (1, D_CHK_SIZE), (1, 1))
-            x_mul_chl_wi = new_x * w_chl_wi
-            out_block += x_mul_chl_wi
-        out_block = tl.trans(out_block, (1, 0))
+            new_x = tl.extra.cann.extension.extract_slice(x_b, (0, owi), (D_CHK_SIZE, T_CHK_SIZE), (1, 1))
+            w_chl_wi = tl.extra.cann.extension.extract_slice(w, (0, owi), (D_CHK_SIZE, 1), (1, 1))
+            out_block += new_x * w_chl_wi
 
         if SILU_ACTIVATION:
-            out_block = (out_block * tl.sigmoid(out_block)).to(x_ptr.dtype.element_ty)
-        tl.store(
-            tl.make_block_ptr(
-                out_ptr,
-                shape=(batch, dim, out_len),
-                strides=(dim * out_len, out_len, 1),
-                offsets=(bi, di * D_CHK_SIZE, ti * T_CHK_SIZE),
-                block_shape=(1, D_CHK_SIZE, T_CHK_SIZE),
-                order=(2, 1, 0),
-            ),
-            out_block[None, :, :],
-            boundary_check=(0, 1, 2),
-        )
+            out_block = out_block / (1.0 + tl.exp(-out_block))
+        out_block = out_block.to(out_ptr.type.element_ty)
+        out_off_d = di * D_CHK_SIZE + tl.arange(0, D_CHK_SIZE)[:, None]
+        out_off_t = ti * T_CHK_SIZE + tl.arange(0, T_CHK_SIZE)[None, :]
+        out_mask = (out_off_d < dim) & (out_off_t < out_len)
+        out_off = bi * dim * out_len + out_off_d * out_len + out_off_t
+        tl.store(out_ptr + out_off, out_block, mask=out_mask)
 
 
 @input_guard(make_contiguous=True, auto_to_device=True)

--- a/mojo_opset/backends/ttx/kernels/npu/sdpa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/sdpa.py
@@ -616,8 +616,8 @@ def kernel_sdpa_bwd_q(
             block_mask = tl.load(ptr_mask, mask=mask_mask, other=False)
 
             block_s = tl.dot(block_q, block_k.T) * scale
-            block_s -= (1.0 - block_mask.to(HIGH_TYPE)) * 1e6
             block_p = tl.exp(block_s - block_lse[:, None])
+            block_p = tl.where(block_mask, block_p, 0.0)
             block_dp = tl.dot(block_do, block_v.T).to(HIGH_TYPE)
             block_ds = block_p * (block_dp - block_d[:, None]) * scale
             block_dq += tl.dot(block_ds.to(LOW_TYPE), block_k).to(HIGH_TYPE)
@@ -766,8 +766,8 @@ def kernel_sdpa_bwd_kv(
                 block_mask = tl.load(ptr_mask, mask=mask_mask, other=False)
 
                 block_s = tl.dot(block_q, block_k.T) * scale
-                block_s -= (1.0 - block_mask.to(HIGH_TYPE)) * 1e6
                 block_p = tl.exp(block_s - block_lse[:, None])
+                block_p = tl.where(block_mask, block_p, 0.0)
                 block_dv += tl.dot(block_p.to(LOW_TYPE).T, block_do).to(HIGH_TYPE)
                 block_dp = tl.dot(block_do, block_v.T).to(HIGH_TYPE)
                 block_ds = block_p * (block_dp - block_d[:, None]) * scale
@@ -948,6 +948,217 @@ def sdpa_fwd_impl(
     return o, lse
 
 
+
+@triton.autotune(
+    configs=[
+        triton.Config({"multibuffer": False, "BLOCK_R": 128, "BLOCK_C": 128}),
+    ],
+    key=["N", "S", "H"],
+    reset_to_zero=["dq", "dk", "dv"],
+)
+@triton.jit
+def kernel_sdpa_bwd_qkv(
+    q,
+    k,
+    v,
+    do,
+    d,
+    dq,
+    dk,
+    dv,
+    lse,
+    mask,
+    scale: tl.constexpr,
+    num_group: tl.constexpr,
+    B: tl.constexpr,
+    N: tl.constexpr,
+    S: tl.constexpr,
+    H: tl.constexpr,
+    STRIDE_Q_B: tl.constexpr,
+    STRIDE_Q_N: tl.constexpr,
+    STRIDE_Q_S: tl.constexpr,
+    STRIDE_Q_H: tl.constexpr,
+    STRIDE_K_B: tl.constexpr,
+    STRIDE_K_N: tl.constexpr,
+    STRIDE_K_S: tl.constexpr,
+    STRIDE_K_H: tl.constexpr,
+    STRIDE_V_B: tl.constexpr,
+    STRIDE_V_N: tl.constexpr,
+    STRIDE_V_S: tl.constexpr,
+    STRIDE_V_H: tl.constexpr,
+    STRIDE_D_B: tl.constexpr,
+    STRIDE_D_N: tl.constexpr,
+    STRIDE_D_S: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    n_programs = tl.num_programs(axis=0)
+    num_r = tl.cdiv(S, BLOCK_R)
+    group_size = N // num_group
+    group_num = N // group_size
+    idx_h = tl.arange(0, H)
+    start_id = pid % 2
+    for idx_br in range(pid // 2 , B * num_r * N, n_programs // 2):
+        idx_b = idx_br // num_r // N
+        idx_r = idx_br // N % num_r
+        idx_n = idx_br % N
+        tasks = num_r
+        ptr_dq = (
+                dq
+                + idx_b * STRIDE_Q_B
+                + idx_n * STRIDE_Q_N
+                + (idx_r * BLOCK_R + tl.arange(0, BLOCK_R))[:, None] * STRIDE_Q_S
+                + idx_h[None, :] * STRIDE_Q_H
+        )
+        dq_mask = (idx_r * BLOCK_R + tl.arange(0, BLOCK_R))[:, None] < S
+
+        q_block_ptr = tl.make_block_ptr(
+            base=q + idx_b * STRIDE_Q_B + idx_n * STRIDE_Q_N,
+            shape=(S, H),
+            strides=(STRIDE_Q_S, STRIDE_Q_H),
+            offsets=((idx_r * BLOCK_R).to(tl.int32), 0),
+            block_shape=(BLOCK_R, H),
+            order=(1, 0),
+        )
+        block_q = tl.load(q_block_ptr, boundary_check=(0, 1), padding_option="zero")
+
+        do_block_ptr = tl.make_block_ptr(
+            base=do + idx_b * STRIDE_Q_B + idx_n * STRIDE_Q_N,
+            shape=(S, H),
+            strides=(STRIDE_Q_S, STRIDE_Q_H),
+            offsets=((idx_r * BLOCK_R).to(tl.int32), 0),
+            block_shape=(BLOCK_R, H),
+            order=(1, 0),
+        )
+        block_do = tl.load(do_block_ptr, boundary_check=(0, 1), padding_option="zero")
+
+        block_dq = tl.zeros((BLOCK_R, H), dtype=tl.float32)
+        for idx_c in range(start_id, tasks, 2):
+            idx_group = idx_n // group_size
+
+            k_block_ptr = tl.make_block_ptr(
+                base=k + idx_b * STRIDE_K_B + idx_group * STRIDE_K_N,
+                shape=(S, H),
+                strides=(STRIDE_K_S, STRIDE_K_H),
+                offsets=((idx_c * BLOCK_C).to(tl.int32), 0),
+                block_shape=(BLOCK_C, H),
+                order=(1, 0),
+            )
+
+            v_block_ptr = tl.make_block_ptr(
+                base=v + idx_b * STRIDE_V_B + idx_group * STRIDE_V_N,
+                shape=(S, H),
+                strides=(STRIDE_V_S, STRIDE_V_H),
+                offsets=((idx_c * BLOCK_C).to(tl.int32), 0),
+                block_shape=(BLOCK_C, H),
+                order=(1, 0),
+            )
+
+            q_offs = idx_r * BLOCK_R + tl.arange(0, BLOCK_R)
+            mask_d = q_offs < S
+            ptr_d = d + idx_b * STRIDE_D_B + idx_n * STRIDE_D_N + q_offs * STRIDE_D_S
+            ptr_lse = lse + idx_b * STRIDE_D_B + idx_n * STRIDE_D_N + q_offs * STRIDE_D_S
+            block_d = tl.load(ptr_d, mask=mask_d, other=0.0)
+            block_lse = tl.load(ptr_lse, mask=mask_d, other=0.0)
+
+            ptr_mask = (
+                mask
+                + (idx_r * BLOCK_R + tl.arange(0, BLOCK_R))[:, None] * S
+                + (idx_c * BLOCK_C + tl.arange(0, BLOCK_C))[None, :]
+            )
+            mask_mask = ((idx_r * BLOCK_R + tl.arange(0, BLOCK_R))[:, None] < S) & (
+                (idx_c * BLOCK_C + tl.arange(0, BLOCK_C))[None, :] < S
+            )
+            block_mask = tl.load(ptr_mask, mask=mask_mask, other=False)
+
+
+            ptr_dk = (
+                dk
+                + pid // 2 * STRIDE_K_B * B
+                + idx_b * STRIDE_K_B
+                + idx_group * STRIDE_K_N
+                + (idx_c * BLOCK_C + tl.arange(0, BLOCK_C))[:, None] * STRIDE_K_S
+                + idx_h[None, :] * STRIDE_K_H
+            )
+            dk_mask = (idx_c * BLOCK_C + tl.arange(0, BLOCK_C))[:, None] < S
+
+            ptr_dv = (
+                dv
+                + pid // 2 * STRIDE_K_B * B
+                + idx_b * STRIDE_V_B
+                + idx_group * STRIDE_V_N
+                + (idx_c * BLOCK_C + tl.arange(0, BLOCK_C))[:, None] * STRIDE_V_S
+                + idx_h[None, :] * STRIDE_V_H
+            )
+
+            block_k = tl.load(k_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            k_T = tl.trans(block_k)
+            qk = tl.dot(block_q, k_T)
+            qk = qk * scale
+            p = tl.math.exp(qk - block_lse[:, None])
+
+            p = tl.where(block_mask, p, 0.0)
+            # dv
+            block_dv = tl.dot(tl.trans(p.to(block_k.dtype)), block_do)
+            tl.atomic_add(ptr_dv, block_dv, mask=dk_mask)
+            # dp
+            block_v = tl.load(v_block_ptr, boundary_check=(0, 1), padding_option="zero")
+            v_T = tl.trans(block_v)
+            dp = tl.dot(block_do, v_T)
+            # ds
+            ds = p * (dp - block_d[:, None]) * scale
+            ds_cast = ds.to(block_q.dtype)
+
+            # dk
+            block_dk = tl.dot(tl.trans(ds_cast), block_q)
+            tl.atomic_add(ptr_dk, block_dk, dk_mask)
+
+            # dq
+            block_dq = tl.dot(ds_cast, block_k, block_dq)
+            # tl.atomic_add(ptr_dq, block_dq.to(ptr_dq.dtype.element_ty), dq_mask)
+
+        tl.atomic_add(ptr_dq, block_dq, mask=dq_mask)
+        # tl.store(ptr_dq, block_dq.to(ptr_dq.dtype.element_ty), mask=dq_mask)
+
+
+_BWD_ATOMIC_PRESSURE_THRESHOLD = 256
+
+
+def _select_bwd_branch(seq_len, q_head_num, kv_head_num, block_r=128):
+    """
+    Return True for the fused (QKV) kernel, False for the split (Q + KV) kernels.
+    Two backward strategies exist:
+
+      "fused"  – kernel_sdpa_bwd_qkv computes dq, dk, dv in a single kernel.
+                 dq is accumulated locally and written once; dk/dv must use
+                 atomic_add into a per-core workspace (later reduced with sum).
+
+      "split"  – kernel_sdpa_bwd_q (dq) + kernel_sdpa_bwd_kv (dk, dv).
+                 Each kernel picks its own optimal parallelisation dimension,
+                 so NO atomics and NO workspace are needed, but the "front-end"
+                 work (Q@K^T, softmax, do@V^T) is computed twice.
+
+    The dominant cost driver of the fused path is the number of atomic_add
+    writes that land on each KV-block:
+
+        atomic_pressure = num_r * group_size
+                        = (seq_len / BLOCK_R) * (q_head_num / kv_head_num)
+
+    When atomic_pressure is small the fused kernel wins because it avoids the
+    redundant front-end computation.  When atomic_pressure is large the
+    atomic + workspace + reduction overhead explodes and the split kernels win.
+
+    The threshold below was calibrated on Ascend NPU.  Use force_branch in the
+    benchmark script to sweep shapes and refine it.
+
+    """
+    num_r = (seq_len + block_r - 1) // block_r
+    group_size = q_head_num // kv_head_num
+    atomic_pressure = num_r * group_size
+    return atomic_pressure < _BWD_ATOMIC_PRESSURE_THRESHOLD
+
+
 def sdpa_bwd_impl(
     o: torch.Tensor,
     do: torch.Tensor,
@@ -958,6 +1169,7 @@ def sdpa_bwd_impl(
     mask: torch.Tensor = None,
     scale: float = 1.0,
     gqa_enabled: bool = False,
+    force_branch: Optional[str] = None,
 ):
     """
     Backward computation interface:
@@ -989,9 +1201,7 @@ def sdpa_bwd_impl(
 
     num_cores, num_vec_cores = get_device_properties()
     d = torch.empty_like(lse)
-    dq = torch.empty_like(q)
-    dk = torch.empty_like(k)
-    dv = torch.empty_like(v)
+    dq = torch.zeros_like(q)
 
     kernel_sdpa_bwd_d[(num_vec_cores,)](
         o,
@@ -1009,79 +1219,140 @@ def sdpa_bwd_impl(
         d.stride(1),
         d.stride(2),
     )
-    kernel_sdpa_bwd_q[(num_cores,)](
-        q,
-        k,
-        v,
-        do,
-        d,
-        dq,
-        lse,
-        mask,
-        scale,
-        k.shape[1],
-        q.shape[0],
-        q.shape[1],
-        q.shape[2],
-        q.shape[3],
-        q.stride(0),
-        q.stride(1),
-        q.stride(2),
-        q.stride(3),
-        k.stride(0),
-        k.stride(1),
-        k.stride(2),
-        k.stride(3),
-        v.stride(0),
-        v.stride(1),
-        v.stride(2),
-        v.stride(3),
-        d.stride(0),
-        d.stride(1),
-        d.stride(2),
-        limit_auto_multi_buffer_buffer="no-limit",
-        hfusion_enable_multiple_consumer_fusion=True,
-        unit_flag=True,
-        limit_auto_multi_buffer_of_local_buffer="no-l0c",
-        intra_cache_num=1,
-    )
-    kernel_sdpa_bwd_kv[(num_cores,)](
-        q,
-        k,
-        v,
-        do,
-        d,
-        dk,
-        dv,
-        lse,
-        mask,
-        scale,
-        k.shape[1],
-        q.shape[0],
-        q.shape[1],
-        q.shape[2],
-        q.shape[3],
-        q.stride(0),
-        q.stride(1),
-        q.stride(2),
-        q.stride(3),
-        k.stride(0),
-        k.stride(1),
-        k.stride(2),
-        k.stride(3),
-        v.stride(0),
-        v.stride(1),
-        v.stride(2),
-        v.stride(3),
-        d.stride(0),
-        d.stride(1),
-        d.stride(2),
-        limit_auto_multi_buffer_buffer="no-limit",
-        hfusion_enable_multiple_consumer_fusion=True,
-        unit_flag=True,
-        limit_auto_multi_buffer_of_local_buffer="no-l0c",
-        intra_cache_num=3,
-        inter_cache_num=2,
-    )
 
-    return dq, dk, dv
+    # -- Select backward strategy -------------------------------------------
+    # force_branch: "fused" | "split" | None (auto-select via heuristic)
+    if force_branch is not None:
+        use_fused = force_branch == "fused"
+    else:
+        use_fused = _select_bwd_branch(q.shape[2], q.shape[1], k.shape[1])
+
+    if use_fused:
+        bsz, kv_head, seq_len, head_dim = k.shape
+        # Per-core workspace for dk/dv to reduce atomic_add conflicts.
+        # The fused kernel indexes this dimension with (pid // 2), so we
+        # need (num_cores + 1) // 2 slots.
+        num_workspace = (num_cores + 1) // 2
+        core_dk = torch.zeros((num_workspace, bsz, kv_head, seq_len, head_dim), dtype=torch.float32, device=k.device)
+        core_dv = torch.zeros((num_workspace, bsz, kv_head, seq_len, head_dim), dtype=torch.float32, device=v.device)
+        kernel_sdpa_bwd_qkv[(num_cores,)](
+            q,
+            k,
+            v,
+            do,
+            d,
+            dq,
+            core_dk,
+            core_dv,
+            lse,
+            mask,
+            scale,
+            k.shape[1],
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            q.shape[3],
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            d.stride(0),
+            d.stride(1),
+            d.stride(2),
+            limit_auto_multi_buffer_buffer="no-limit",
+            hfusion_enable_multiple_consumer_fusion=True,
+            unit_flag=True,
+            limit_auto_multi_buffer_of_local_buffer="no-l0c",
+            intra_cache_num=2,
+            inter_cache_num=2,
+            enable_vf_operand_substitution=True,
+        )
+        dk = torch.sum(core_dk, 0)
+        dv = torch.sum(core_dv, 0)
+    else:
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        kernel_sdpa_bwd_q[(num_cores,)](
+            q,
+            k,
+            v,
+            do,
+            d,
+            dq,
+            lse,
+            mask,
+            scale,
+            k.shape[1],
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            q.shape[3],
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            d.stride(0),
+            d.stride(1),
+            d.stride(2),
+            limit_auto_multi_buffer_buffer="no-limit",
+            hfusion_enable_multiple_consumer_fusion=True,
+            unit_flag=True,
+            limit_auto_multi_buffer_of_local_buffer="no-l0c",
+            intra_cache_num=1,
+        )
+
+        kernel_sdpa_bwd_kv[(num_cores,)](
+            q,
+            k,
+            v,
+            do,
+            d,
+            dk,
+            dv,
+            lse,
+            mask,
+            scale,
+            k.shape[1],
+            q.shape[0],
+            q.shape[1],
+            q.shape[2],
+            q.shape[3],
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),
+            d.stride(0),
+            d.stride(1),
+            d.stride(2),
+            limit_auto_multi_buffer_buffer="no-limit",
+            hfusion_enable_multiple_consumer_fusion=True,
+            unit_flag=True,
+            limit_auto_multi_buffer_of_local_buffer="no-l0c",
+            intra_cache_num=3,
+            inter_cache_num=2,
+        )
+    return dq, dk.to(k.dtype), dv.to(v.dtype)

--- a/mojo_opset/tests/perf/test_sdpa_impl.py
+++ b/mojo_opset/tests/perf/test_sdpa_impl.py
@@ -10,6 +10,25 @@ from mojo_opset.tests.utils import bypass_not_implemented
 from mojo_opset.backends.ttx.kernels import sdpa_fwd, sdpa_bwd
 
 
+def seed_all(seed=1234):
+    import random
+    import os
+    import numpy as np
+    random.seed(seed)
+    os.environ['PYTHONHASHSEED'] = str(seed)
+    os.environ['HCCL_DETERMINISTIC'] = str(True)
+    os.environ['LCCL_DETERMINISTIC'] = str(1)
+    os.environ['CLOSE_MATMUL_K_SHIFT'] = str(1)
+    os.environ['ATB_MATMUL_SHUFFLE_K_ENABLE'] = "0"
+    os.environ['ATB_LLM_LCOC_ENABLE'] = "0"
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.use_deterministic_algorithms(True)
+
+    torch_npu.npu.manual_seed_all(seed)
+    torch_npu.npu.manual_seed(seed)
+
+
 def generate_diffusion_attention_mask(seq_length, block_size):
     total_length = seq_length * 2
     i = torch.arange(total_length).unsqueeze(1)
@@ -132,6 +151,7 @@ def sdpa_npu_bwd_ref(q, k, v, do, mask, scale, enable_gqa):
 @auto_switch_platform(set_perf=True)
 @bypass_not_implemented
 def test_sdpa_impl(bsz, q_head_num, kv_head_num, head_dim, seq_length, block_size):
+    seed_all() # required for deterministic algorithms of torch_npu
     enable_gqa = q_head_num != kv_head_num
     scale = 1.0 / math.sqrt(head_dim)
 
@@ -215,9 +235,9 @@ def test_sdpa_impl(bsz, q_head_num, kv_head_num, head_dim, seq_length, block_siz
 
     dq_npu, dk_npu, dv_npu = sdpa_npu_bwd_ref(query, key, value, do, mask, scale, enable_gqa)
 
-    dq_diff_npu = (dq.cpu().to(torch.float32) - dq_npu.cpu().to(torch.float32)).abs()
-    dk_diff_npu = (dk.cpu().to(torch.float32) - dk_npu.cpu().to(torch.float32)).abs()
-    dv_diff_npu = (dv.cpu().to(torch.float32) - dv_npu.cpu().to(torch.float32)).abs()
+    dq_diff_npu = (dq_ref.cpu().to(torch.float32) - dq_npu.cpu().to(torch.float32)).abs()
+    dk_diff_npu = (dk_ref.cpu().to(torch.float32) - dk_npu.cpu().to(torch.float32)).abs()
+    dv_diff_npu = (dv_ref.cpu().to(torch.float32) - dv_npu.cpu().to(torch.float32)).abs()
     print(f"\n[Backward vs torch_npu]")
     print(f"  dq max_abs_diff={dq_diff_npu.max().item():.6f}  mean_abs_diff={dq_diff_npu.mean().item():.6f}")
     print(f"  dk max_abs_diff={dk_diff_npu.max().item():.6f}  mean_abs_diff={dk_diff_npu.mean().item():.6f}")


### PR DESCRIPTION
optimize sdpa_bwd and causal_conv1d_update_kernel_bdt_fwd

update sdpa bwd impl
1. calculate mask by 'where' instead multiply
2. Add fused bwd qkv kernel for small shape
3. Add deterministic initialization for torch npu

update causal_conv1d_update_kernel_bdt_fwd：
1. eliminate tile transposes with a consistent D-T layout
2. use FP32 accumulation for improved numerical precision
3. simplify memory access and handle short-sequence state updates