### PR TITLE
[NPU] flex_attention: enable preload + lazy-load for large tensors

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/flex_attention.py
+++ b/mojo_opset/backends/ttx/kernels/npu/flex_attention.py
@@ -1038,6 +1038,8 @@ def flex_attention_fwd_impl(
         enable_cross_if_fusion=True,
         enable_buffer_insert_optimization=True,
         enable_ub_refine_opt = True,
+        enable_preload=True,
+        enable_dynamic_cv_pipeline=False,
     )
 
     return output, lse
@@ -1115,6 +1117,8 @@ def flex_attention_bwd_impl(
         limit_auto_multi_buffer_of_local_buffer="no-l0c",
         intra_cache_num=3,
         inter_cache_num=2,
+        enable_preload=True,
+        enable_dynamic_cv_pipeline=False,
     )
 
     BLOCK_M_DKDV = TILE_BLOCK_SIZE
@@ -1162,6 +1166,8 @@ def flex_attention_bwd_impl(
         limit_auto_multi_buffer_of_local_buffer="no-l0c",
         intra_cache_num=2,
         inter_cache_num=1,
+        enable_preload=True,
+        enable_dynamic_cv_pipeline=False,
     )
 
     return dq.to(q.dtype), dk.to(k.dtype), dv.to(v.dtype)


### PR DESCRIPTION
Add enable_preload=True and enable_dynamic_cv_pipeline=False to the three kernel launch sites (fwd, bwd-dq, bwd-dkdv). Insert cv_pipeline_lazy_load compile_hint on large 2D data tensors (q, k, v, do) only — scalar index loads and small 1D tensors are excluded since their buffer expansion is negligible and extra DMA would be a net regression.