### PR TITLE
perf: set _sdpa_infer_kernel multi-buffer to only-cube

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/a5/sdpa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/a5/sdpa.py
@@ -868,7 +868,7 @@ def sdpa_infer_impl(
         set_workspace_multibuffer=4,
         tile_mix_vector_loop=8,
         tile_mix_cube_loop=4,
-        limit_auto_multi_buffer_buffer="no-limit",
+        limit_auto_multi_buffer_buffer="only-cube",
         enable_dynamic_cv_pipeline=True,
         enable_cube_block_merge=True,
         hfusion_enable_multiple_consumer_fusion=True,

--- a/mojo_opset/backends/ttx/kernels/npu/a5/swa.py
+++ b/mojo_opset/backends/ttx/kernels/npu/a5/swa.py
@@ -576,7 +576,7 @@ def swa_infer_impl(
         BLOCK_D,
         enable_ubuf_saving=True,
         limit_auto_multi_buffer_of_local_buffer="no-l0c",
-        limit_auto_multi_buffer_buffer="no-limit",
+        limit_auto_multi_buffer_buffer="only-cube",
         hfusion_enable_multiple_consumer_fusion=True,
         intra_cache_num=3,
         inter_cache_num=2,


### PR DESCRIPTION
## Summary
- Change A5 `_sdpa_infer_kernel` launches to `limit_auto_multi_buffer_buffer="only-cube"`.
- Vector-side UB multi-buffer regresses MixCV SDPA infer (~10%); keep cube ping-pong only.
- Covers `sdpa_infer_impl` (has `multibuffer=True`) and the same-named SWA infer launch.

## Test plan
- [ ] Run SDPA infer perf (`test_sdpa` / `mojo_sdpa`) and confirm no regression vs previous `no-limit`.
- [ ] Spot-check SDPA infer accuracy on HEAD_DIM 64/128, with and without mask.
- [ ] Confirm SWA infer still compiles and matches baseline numerically.
