### PR TITLE
perf: set _int8_gemm_dequant_kernel multi-buffer to only-cube

### DIFF
--- a/mojo_opset/backends/ttx/kernels/npu/a5/int8_gemm.py
+++ b/mojo_opset/backends/ttx/kernels/npu/a5/int8_gemm.py
@@ -246,6 +246,7 @@ def int8_gemm_dequant_impl(
         b_transposed.stride(0), b_transposed.stride(1),
         c.stride(0), c.stride(1),
         HAS_BIAS=has_bias,
+        limit_auto_multi_buffer_buffer="only-cube",
     )
 
     return c[:M_orig, :N_orig]


### PR DESCRIPTION
## Summary
- Set A5 `_int8_gemm_dequant_kernel` to `multibuffer=True` and `limit_auto_multi_buffer_buffer="only-cube"`.
- This MixCV INT8 GEMM (`tl.dot` + vector dequant epilogue) can take the cube-only multi-buffer limit; vector UB multi-buffer is left off.
- Matches the A2 launch (`multibuffer=True`) and the compiler default for `--limit-auto-multi-buffer-buffer`.

## Test plan
- [ ] Run `test_quant_gemm_perf` / `mojo_quant_gemm` and compare vs previous A5 launch.
- [ ] Spot-check INT8 GEMM dequant accuracy (with/without bias, bf16/fp16).
